### PR TITLE
formalize what a must-gather image includes

### DIFF
--- a/must-gather.md
+++ b/must-gather.md
@@ -105,6 +105,14 @@ There are several special cases today.
     3. take a best guess to find a healthz endpoint and all sub-healthz endpoints 
     
 
+### must-gather Images
+To provide your own must-gather image, it must....
+
+1. Must have a zero-arg, executable file at `/usr/bin/gather` that does your default gathering
+2. Must produce data to be copied back at `/must-gather`.  The data must not contain any sensitive data.  We don't string PII information, only secret information.
+3. Must produce a text `/must-gather/version` that indicates the product (first line) and the version (second line, `major.minor.micro.qualifier`),
+ so that programmatic analysis can be developed.
+
 ### User Stories [optional]
 
 #### Story 1


### PR DESCRIPTION
This formalizes what our client-side must-gather command expects.  I think we'll build on this.

Note that this requires a new version file.  @sanchezl can you fix that up for us?