### PR TITLE
must-gather|oc/inspect: Fix YAML front-matter formatting

### DIFF
--- a/enhancements/must-gather.md
+++ b/enhancements/must-gather.md
@@ -1,21 +1,19 @@
 ---
 title: must-gather
 authors:
-
 - "@deads2k"
-  reviewers:
+reviewers:
 - "@derekwaynecarr"
 - "@soltysh"
 - "@mfojtik"
-  approvers:
+approvers:
 - "@derekwaynecarr"
-  creation-date: 2019-09-09
-  last-updated: 2019-09-09
-  status: implemented
-  see-also:
-  replaces:
-  superseded-by:
-
+creation-date: 2019-09-09
+last-updated: 2019-09-09
+status: implemented
+see-also:
+replaces:
+superseded-by:
 ---
 
 # Must-Gather

--- a/enhancements/oc/inspect.md
+++ b/enhancements/oc/inspect.md
@@ -1,23 +1,21 @@
 ---
 title: inspect
 authors:
-
 - "@sanchezl"
 - "@deads2k"
-  reviewers:
+reviewers:
 - "@deads2k"
 - "@derekwaynecarr"
 - "@soltysh"
 - "@mfojtik"
-  approvers:
+approvers:
 - "@deads2k"
-  creation-date: 2019-09-21
-  last-updated: 2019-09-25
-  status: provisional
-  see-also:
-  replaces:
-  superseded-by:
-
+creation-date: 2019-09-21
+last-updated: 2019-09-25
+status: provisional
+see-also:
+replaces:
+superseded-by:
 ---
 
 # inspect


### PR DESCRIPTION
Unwind the indent and empty-line breakage introduced by 6ac1e0b7e8 (#40).