### PR TITLE
enhancements: Standardize YAML vs. header title syntax

### DIFF
--- a/enhancements/automated-policy-based-disencryption.md
+++ b/enhancements/automated-policy-based-disencryption.md
@@ -1,6 +1,5 @@
-# Automated Policy-based DiskEncryption on Boot Images
 ---
-title: CoreOS Encrypted Disks By Default
+title: automated-policy-based-disk-encryption-on-boot-images
 
 authors:
   - "Ben Howard @behoward"
@@ -23,6 +22,7 @@ status: provisional
 
 ---
 
+# Automated Policy-based Disk Encryption on Boot Images
 
 ## Release Signoff Checklist
 

--- a/enhancements/automated-service-ca-rotation.md
+++ b/enhancements/automated-service-ca-rotation.md
@@ -1,5 +1,5 @@
 ---
-title: Automated Service CA Rotation
+title: automated-service-ca-rotation
 authors:
   - "@marun"
 reviewers:
@@ -19,7 +19,7 @@ replaces:
 superseded-by:
 ---
 
-# automated-service-ca-rotation
+# Automated Service CA Rotation
 
 ## Release Signoff Checklist
 

--- a/enhancements/compact-clusters.md
+++ b/enhancements/compact-clusters.md
@@ -1,5 +1,5 @@
 ---
-title: Compact Clusters
+title: compact-clusters
 authors:
   - "@smarterclayton"
 reviewers:

--- a/enhancements/compliance-operator.md
+++ b/enhancements/compliance-operator.md
@@ -1,5 +1,5 @@
 ---
-title: OpenShift Compliance operator
+title: openshift-complianc-operator
 authors:
   - "@jhrozek"
 reviewers:
@@ -13,7 +13,7 @@ last-updated: 2019-10-22
 status: provisional
 ---
 
-# OpenShift Compliance operator
+# OpenShift Compliance Operator
 
 ## Release Signoff Checklist
 

--- a/enhancements/installer/aws-customer-provided-subnets.md
+++ b/enhancements/installer/aws-customer-provided-subnets.md
@@ -1,5 +1,5 @@
 ---
-title: (AWS) Allow Customer-Provisioned Subnets
+title: allow-customer-provisioned-aws-subnets
 authors:
   - "@wking"
 reviewers:
@@ -15,7 +15,7 @@ superseded-by:
   - "https://docs.google.com/document/d/12Nu_OvcNnItD4vaH6G0ky0IeAxnvDSpzp5sVrZv7-8M/"
 ---
 
-# aws-allow-customer-provisioned-subnets
+# Allow Customer-Provisioned AWS Subnets
 
 ## Release Signoff Checklist
 

--- a/enhancements/installer/aws-internal-clusters.md
+++ b/enhancements/installer/aws-internal-clusters.md
@@ -1,5 +1,5 @@
 ---
-title: (AWS) Internal OpenShift clusters
+title: internal-aws-clusters
 authors:
   - "@abhinavdahiya"
 reviewers:
@@ -14,7 +14,7 @@ superseded-by:
   - "https://docs.google.com/document/d/1IUCqz6AhxNwYDyx9jPcqbsa1-EloWD13OIONK7YP3JE"
 ---
 
-# aws-internal-openshift-clusters
+# Internal AWS Clusters
 
 ## Release Signoff Checklist
 

--- a/enhancements/kube-apiserver/certificates.md
+++ b/enhancements/kube-apiserver/certificates.md
@@ -1,5 +1,5 @@
 ---
-title: kube-apiserver-Certificates
+title: kube-apiserver-certificates
 authors:
   - "@deads2k"
 reviewers:

--- a/enhancements/kube-apiserver/encrypting-data-at-datastore-layer.md
+++ b/enhancements/kube-apiserver/encrypting-data-at-datastore-layer.md
@@ -1,5 +1,5 @@
 ---
-title: Encrypting Data at Datastore Layer
+title: encrypting-data-at-datastore-layer
 authors:
   - "@enj"
 reviewers:

--- a/enhancements/kube-apiserver/tls-config.md
+++ b/enhancements/kube-apiserver/tls-config.md
@@ -1,5 +1,5 @@
 ---
-title: TLS-Config
+title: tls-config-for-externally-facing-services
 authors:
   - "@deads2k"
   - "@danehans"

--- a/enhancements/machine-api/machine-instance-lifecycle.md
+++ b/enhancements/machine-api/machine-instance-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-title: Machine/Instance lifecycle
+title: machine/instance-lifecycle
 authors:
   - @enxebre
 reviewers:

--- a/enhancements/mco-kargs-day1-support.md
+++ b/enhancements/mco-kargs-day1-support.md
@@ -1,5 +1,5 @@
 ---
-title: Kernel Arguments - Day 1 Support
+title: kernel-arguments-day-1-support
 authors:
   - "@ericavonb"
 reviewers:

--- a/enhancements/multi-arch/samples.md
+++ b/enhancements/multi-arch/samples.md
@@ -1,5 +1,5 @@
 ---
-title: Samples-Non-X86
+title: sample-imagestream-and-templates-on-non-x86-platforms
 authors:
   - "@gabemontero"
 reviewers:

--- a/enhancements/must-gather.md
+++ b/enhancements/must-gather.md
@@ -1,5 +1,5 @@
 ---
-title: Must-Gather
+title: must-gather
 authors:
 
 - "@deads2k"

--- a/enhancements/network/20190903-SRIOV-GA.md
+++ b/enhancements/network/20190903-SRIOV-GA.md
@@ -1,4 +1,4 @@
-title: SR-IOV GA
+title: sr-iov
 authors:
   - "@zshi-redhat"
   - "@pliurh"
@@ -16,7 +16,7 @@ last-updated: 2019-09-03
 status: implementable
 ---
 
-# Graduate SR-IOV to GA
+# SR-IOV
 
 ## Release Signoff Checklist
 

--- a/enhancements/network/allow-external-ip-overrides.md
+++ b/enhancements/network/allow-external-ip-overrides.md
@@ -1,5 +1,5 @@
 ---
-title: Allow over-ride of allowable External IP addresses for a service
+title: allow-external-ip-overrides-for-services
 authors:
   - "@abhat"
 reviewers:
@@ -17,7 +17,7 @@ replaces:
 superseded-by:
 ---
 
-# Allow external IP overrides
+# Allow External IP Overrides for Services
 
 ## Release Signoff Checklist
 

--- a/enhancements/oc/olm-mirroring.md
+++ b/enhancements/oc/olm-mirroring.md
@@ -1,5 +1,5 @@
 ---
-title: Compact Clusters
+title: oc-tooling-for-disconnected-olm
 authors:
   - "@ecordell"
 reviewers:

--- a/enhancements/oc/upgrade_kubernetes.md
+++ b/enhancements/oc/upgrade_kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrading oc to latest version of Kubernetes with gomod
+title: upgrading-oc-to-latest-version-of-kubernetes-with-gomod
 authors:
   - "@soltysh"
 reviewers:

--- a/enhancements/ptp-time-integration.md
+++ b/enhancements/ptp-time-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Precision Time Protocol
+title: precision-time-protocol
 authors:
   - "@zshi-redhat"
 reviewers:
@@ -13,7 +13,7 @@ last-updated: 2019-09-03
 status: implementable
 ---
 
-# Add-Precision-Time-Protocol-Support
+# Precision Time Protocol
 
 ## Release Signoff Checklist
 

--- a/enhancements/security/file-integrity-operator.md
+++ b/enhancements/security/file-integrity-operator.md
@@ -1,5 +1,5 @@
 ---
-title: OpenShift node file integrity monitoring
+title: cluster-node-file-integrity-operator
 authors:
   - "@mrogers950"
 reviewers:

--- a/enhancements/service-catalog/prepare-service-catalog-and-brokers-for-removal.md
+++ b/enhancements/service-catalog/prepare-service-catalog-and-brokers-for-removal.md
@@ -15,7 +15,7 @@ replaces:
 superseded-by:
 ---
 
-# prepare-service-catalog-and-brokers-for-removal
+# Prepare Service Catalog and Brokers for Removal
 
 ## Release Signoff Checklist
 

--- a/enhancements/storage/csi-cloning.md
+++ b/enhancements/storage/csi-cloning.md
@@ -1,5 +1,5 @@
 ---
-title: CSI Cloning
+title: csi-cloning
 authors:
   - "@chuffman"
 reviewers:
@@ -16,7 +16,7 @@ replaces:
 superseded-by:
 ---
 
-# csi-cloning
+# CSI Cloning
 
 ## Release Signoff Checklist
 

--- a/enhancements/storage/csi-resize.md
+++ b/enhancements/storage/csi-resize.md
@@ -1,5 +1,5 @@
 ---
-title: CSI Volume Expansion
+title: csi-volume-expansion
 authors:
   - "@bertinatto"
   - "@gnufied"
@@ -17,7 +17,7 @@ superseded-by:
 
 ---
 
-# csi-volume-expansion
+# CSI Volume Expansion
 
 ## Release Signoff Checklist
 

--- a/enhancements/storage/csi-snapshot.md
+++ b/enhancements/storage/csi-snapshot.md
@@ -1,5 +1,5 @@
 ---
-title: CSI Snapshots
+title: csi-snapshots
 authors:
   - "@chuffman"
 reviewers:
@@ -15,7 +15,7 @@ replaces:
 superseded-by:
 ---
 
-# csi-snapshots
+# CSI Snapshots
 
 ## Release Signoff Checklist
 

--- a/enhancements/template.md
+++ b/enhancements/template.md
@@ -1,5 +1,5 @@
 ---
-title: Neat-Enhancement-Idea
+title: neat-enhancement-idea
 authors:
   - "@janedoe"
 reviewers:
@@ -19,14 +19,14 @@ superseded-by:
   - "/enhancements/our-past-effort.md"
 ---
 
-# Title
+# Neat Enhancement Idea
 
 This is the title of the enhancement. Keep it simple and descriptive. A good
 title can help communicate what the enhancement is and should be considered as
 part of any review.
 
-The title should be lowercased and spaces/punctuation should be replaced with
-`-`.
+The YAML `title` should be lowercased and spaces/punctuation should be
+replaced with `-`.
 
 To get started with this template:
 1. **Pick a domain.** Find the appropriate domain to discuss your enhancement.

--- a/enhancements/windows-containers/cluster-logging-windows-worker-nodes.md
+++ b/enhancements/windows-containers/cluster-logging-windows-worker-nodes.md
@@ -1,5 +1,5 @@
 ---
-title: OpenShift Windows Worker Node and Container Logging
+title: openshift-windows-worker-node-and-container-logging
 authors:
   - "@ravisantoshgudimetla"
   - "@aravindhp"
@@ -18,7 +18,7 @@ last-updated: 2019-09-17
 status: implementable
 ---
 
-# logging-for-windows-worker-nodes
+# OpenShift Windows Worker Node and Container Logging
 
 ## Release Signoff Checklist
 


### PR DESCRIPTION
The previous docs were ambiguous, which lead to divergent implementations and confusion about what was supposed to be lowercased and dashed.  This PR makes the template more specific and tries to standardize the existing enhancements.  But if there is a clear rule about how to process the Markdown header, I'm not clear on why we need a YAML `title` property at all.