### PR TITLE
enhancements: Remove "[optional]" from headers

### DIFF
--- a/enhancements/authentication/configuring-webhook-token-authenticators.md
+++ b/enhancements/authentication/configuring-webhook-token-authenticators.md
@@ -30,7 +30,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 

--- a/enhancements/authentication/oauth-resource-storage.md
+++ b/enhancements/authentication/oauth-resource-storage.md
@@ -30,7 +30,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 1. Do we really need token read access for users. This enhancement allows us to add that with reasonable effort,
    but we should consider also either some imperative logout subresource, or an endpoint for the oauth server. This
@@ -100,7 +100,7 @@ Note: the tilde is a valid character in oauth tokens used as bearer tokens (acco
 [RFC6750](https://tools.ietf.org/html/rfc6750#section-2.1)), and it works as character in URL paths. Colon,
 which we used in an earlier iteration of this enhancement is not valid for the former. 
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -208,7 +208,7 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Use this section if you need things from the project. Examples include a new
 subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/authentication/separate-oauth-resources.md
+++ b/enhancements/authentication/separate-oauth-resources.md
@@ -24,7 +24,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift/docs]
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 
@@ -62,7 +62,7 @@ backported to 4.n-1.
 
 If we stop at any any intermediate step, we are still safe to ship.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -112,7 +112,7 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Use this section if you need things from the project. Examples include a new
 subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/autoscaling/cluster-resource-overrides.md
+++ b/enhancements/autoscaling/cluster-resource-overrides.md
@@ -76,13 +76,13 @@ the kube-apiserver.
  that we re-bootstrap.
 4. Expose the new operator via OLM and integrate our docs that way.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
 #### Story 2
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 We *must* be able to re-bootstrap the cluster.  This means that a cluster with this admission plugin created must be able
 to be completely shut down and subsequently restarted.
@@ -176,7 +176,7 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Use this section if you need things from the project. Examples include a new
 subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/baremetal/baremetal-provisioning-config.md
+++ b/enhancements/baremetal/baremetal-provisioning-config.md
@@ -153,7 +153,7 @@ with 2 members:
 	range. If unset, then the default IP address range (.10 to .100) would be
 	used. The value of the DHCP range can be changed even after insallation.
 
-### User Stories [optional]
+### User Stories
 
 1. As a Deployment Operator, I want Barametal IPI deployments to be customizable to
 hardware and network requirements.

--- a/enhancements/builds/node-cache-for-builds.md
+++ b/enhancements/builds/node-cache-for-builds.md
@@ -62,7 +62,7 @@ that need to be pulled when the build commences.
 As a developer using OpenShift to build container images I want builds to use image layers cached on
 the node So that builds don't have to pull all layers in their base images and builds run faster.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 1. The build controller will mount the node image cache located at `/var/lib/containers/storage`
    into the build pod as `readOnly`. The host path mount will use the `DirectoryOrCreate` type

--- a/enhancements/cluster-logging/forwarder-tagging.md
+++ b/enhancements/cluster-logging/forwarder-tagging.md
@@ -202,6 +202,6 @@ Complicates the forwarder.
 
 None.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Nothing new.

--- a/enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
+++ b/enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
@@ -43,7 +43,7 @@ status: implementable
 - [/] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 > 1. If data on the CSI volume represents data the Pod's SA no longer has access to that data because of ACL/RBAC changes,
 >from a storage/CSI volume perspective are there any best practices on how to deal with the data?  The CSI driver can
@@ -100,7 +100,7 @@ impossible to avoid that.
 
 ## Proposal
 
-### User Stories [optional]
+### User Stories
 
 1. As a cluster admin with an OpenShift subscription, I want to share the entitlement keys and configuration with my 
 users' workload Pods so that containers in those Pods can install RHEL subscription content.
@@ -114,7 +114,7 @@ facilitate those scenarios across multiple namespaces.
 4. As a cluster admin who has to rotate credentials shared via this proposal, and I remove access to new versions of
 the credentials, I want to stop updating content within the existing pods consuming the content. 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 #### Install
 
@@ -544,6 +544,6 @@ persistent volume styled approach with CSI:
   - there is an analogous method `deleteHostpathVolume` for deleting the directory.
 
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 N/A

--- a/enhancements/dns/plugins.md
+++ b/enhancements/dns/plugins.md
@@ -30,7 +30,7 @@ includes [forward](https://coredns.io/plugins/forward/) as the first plugin impl
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 1. How are API changes handled for cluster downgrades?
 2. Should the number of `Servers` be restricted due to Gap 4?
@@ -336,6 +336,6 @@ Major milestones in the life cycle of a proposal should be tracked in `Implement
 
 Possible alternatives are listed [here](https://docs.google.com/document/d/17OEwYs9HuCeGtFKfJLwtk809C6MIjZmguce5-LQYxIM/edit?usp=sharing).
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 TODO

--- a/enhancements/etcd/cluster-etcd-operator.md
+++ b/enhancements/etcd/cluster-etcd-operator.md
@@ -32,7 +32,7 @@ cluster-etcd-operator (CEO) is an operator that handles the scaling of etcd duri
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift/docs]
 
-## Open Questions [optional]
+## Open Questions
 
 TODO
 
@@ -341,6 +341,6 @@ TODO
 
 TODO
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 TODO

--- a/enhancements/etcd/disaster-recovery-with-ceo.md
+++ b/enhancements/etcd/disaster-recovery-with-ceo.md
@@ -238,7 +238,7 @@ The series of actions performed on the recovery node by `cluster-restore.sh` can
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 ### New github projects:
 

--- a/enhancements/etcd/etcd-encryption-for-separate-oauth-apis.md
+++ b/enhancements/etcd/etcd-encryption-for-separate-oauth-apis.md
@@ -25,7 +25,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift/docs]
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 
@@ -82,7 +82,7 @@ On the next release `n+1` we will copy over the keys to avoid creating new ones.
    - it will report whether all instances of `oauth-apiserver` converged to the same revision
    - make sure that `oauth-apiserver` deployer won't synchronize the secrets
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -150,4 +150,4 @@ History`.
 
 1. Turn off encryption before upgrading to new version and turn it on right after. It would be simple but not desirable by the end users. 
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed

--- a/enhancements/etcd/storage-migration-for-etcd-encryption.md
+++ b/enhancements/etcd/storage-migration-for-etcd-encryption.md
@@ -75,7 +75,7 @@ We will use the upstream `kube-storage-version-migrator` (the controller-based s
   * Enable CI on `openshift/kube-storage-version-migrator` repo.
 * Utilize `StorageVersionMigration` API when etcd storage encryption keys are updated.
 
-## User Stories [optional]
+## User Stories
 
 * kube-apiserver-operator can request a resource migration and confirm when the migration has completed. 
 
@@ -175,7 +175,7 @@ This component should not be invoked during an upgrade.
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 ### New github projects:
 

--- a/enhancements/ingress/openshift-route-admission-policy.md
+++ b/enhancements/ingress/openshift-route-admission-policy.md
@@ -57,7 +57,7 @@ Add a new _RouteAdmissionPolicy_ field to the [IngressController API resource][h
 
 ### User Stories
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 The [Ingress Operator](https://github.com/openshift/cluster-ingress-operator) will use `RouteAdmissionPolicy` to configure the environment variable `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK` in the [OpenShift Router](https://github.com/openshift/router).
 
@@ -158,6 +158,6 @@ This only implements one existing feature in the OpenShift Router that existed i
 - There are many environment variables exposed by the OpenShift Router which are not included in this proposal. An alternative proposal would be to allow setting environment variables directly through the ingress-controller CRD, but this would expose more feature in an uncontrolled manner.
 - This proposal implements an enum based [comment](https://github.com/openshift/api/pull/416#issuecomment-523658482), but there are only two values. This could be implemented as a boolean. There is an [existing PR](https://github.com/openshift/api/pull/416) with this implementation.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 [ingress-controller-api]: https://github.com/openshift/api/blob/release-4.2/operator/v1/types_ingress.go

--- a/enhancements/ingress/user-defined-default-ingress-controller.md
+++ b/enhancements/ingress/user-defined-default-ingress-controller.md
@@ -268,6 +268,6 @@ Some broad reasons this proposal might _not_ be acceptable are:
   documented here; this is an overview of the properties common to the general
   approach.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 TODO

--- a/enhancements/ingress/wildcard-admission-policy.md
+++ b/enhancements/ingress/wildcard-admission-policy.md
@@ -67,7 +67,7 @@ resource that allows administrators to manage route admission based on the route
 
 As a cluster administrator, I need the ability to admit routes based on the route's wildcard policy configuration.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 The [Ingress Operator](https://github.com/openshift/cluster-ingress-operator) will use `WildcardPolicy` to configure
 the environment variable `ROUTER_ALLOW_WILDCARD_ROUTES` in the [OpenShift Router](https://github.com/openshift/router).

--- a/enhancements/installer/assisted-installer-bare-metal-validations.md
+++ b/enhancements/installer/assisted-installer-bare-metal-validations.md
@@ -100,7 +100,7 @@ to allow the latter 2 capabilities to be configured for
 user-provisioned infrastructure, without requiring configuration that
 is only relevant to the first capability.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -118,7 +118,7 @@ the cluster is being built using the installer-provisioned
 infrastructure workflow or the user-provisioned workflow so I can
 apply only the rules necessary for each case.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 All of the validation is currently performed during early phases of
 the installer for the `InstallConfig` target. The user-provisioned

--- a/enhancements/installer/aws-custom-region-and-endpoints.md
+++ b/enhancements/installer/aws-custom-region-and-endpoints.md
@@ -418,7 +418,7 @@ None
 
 Already covered inline.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 1. Access to US Gov Cloud region to test the changes.
 

--- a/enhancements/installer/aws-customer-provided-subnets.md
+++ b/enhancements/installer/aws-customer-provided-subnets.md
@@ -203,7 +203,7 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Use this section if you need things from the project. Examples include a new
 subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/installer/aws-permissions-check-bypass.md
+++ b/enhancements/installer/aws-permissions-check-bypass.md
@@ -29,7 +29,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 
@@ -203,7 +203,7 @@ will use the contents of the install-config ConfigMap to build the runtime
 configuration to ensure CCO runs in the desired mode.
 ```
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -231,7 +231,7 @@ spec:
   forceCredentialsMode: "mint"
 ```
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 Bypassing these checks means that errors will be encountered at the moment the
 API calls are attempted. For example a user with enough permissions to create
@@ -361,7 +361,7 @@ to put the `forceCredentialsMode` field into a platform-specific section, and
 the CloudCredentialOperatorConfig CRD could be modified to have
 platform-specific overides as well.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 (For testing and for any ongoing e2e) A pair of AWS accounts where the root
 account has the ability to set/modify SCP polcies, and a second child account to

--- a/enhancements/installer/azure-support-known-cloud-environments.md
+++ b/enhancements/installer/azure-support-known-cloud-environments.md
@@ -225,6 +225,6 @@ We could treat all the non-public Azure cloud environments as Custom Azure cloud
 - The installer can control the known cloud names easily.
 - The installer users the azurerm terraform provider that doesn't have support of custom resource endpoint URLs and would require use of the azurestack terraform provider. A change like that would be a lot more involved and therefore supporting known cloud names is a lot more easier to satisfy the goals.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 1. Access to MAG environment to test the changes.

--- a/enhancements/installer/connected-assisted-installer.md
+++ b/enhancements/installer/connected-assisted-installer.md
@@ -315,7 +315,7 @@ each host has an IP provided by an outside DHCP server. Hardware
 support for automating virtual media is not consistent between
 vendors.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 The existing code (see "Proof of Concept" above) will need to be moved
 into an official GitHub organization.

--- a/enhancements/installer/crc.md
+++ b/enhancements/installer/crc.md
@@ -22,7 +22,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 This is where to call out areas of the design that require closure before deciding
 to implement the design.  For instance, 

--- a/enhancements/installer/gcp-customer-provided-subnets.md
+++ b/enhancements/installer/gcp-customer-provided-subnets.md
@@ -57,7 +57,7 @@ Resources owned by the cluster and resources must be clearly identifiable.
 
 Destroy cluster must make sure that no resources are deleted that didn't belong to the cluster. leaking resources is preferred than any possibility of deleting non-cluster resource.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 #### Resources provided to the installer
 

--- a/enhancements/installer/gcp-private-clusters.md
+++ b/enhancements/installer/gcp-private-clusters.md
@@ -184,7 +184,7 @@ A limitation of this design is that no health check for the machine config serve
 
 Other alternatives were considered but this is the only known feasible design. As mentioned above, using external network load balancers and limiting public access with firewalls is not possible, because tagged VM instances can not be granted access through source tags. 
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 * Network deployment in GCP CI account which includes VPC, subnets, NAT gateways, Internet gateway that provide egress to the Internet for instance in private subnet.
 * VPN accessibility to the network deployment created above.

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -28,7 +28,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 
@@ -172,7 +172,7 @@ Any kind of further, deeper policy configuration, e.g. that filters by API group
 is explicitly not part of this proposal and requires work on the [upstream dynamic audit](https://github.com/kubernetes/enhancements/blob/f1a799d5f4658ed29797c1fb9ceb7a4d0f538e93/keps/sig-auth/0014-dynamic-audit-configuration.md)
 mechanism and its promotion to beta eventually, or a post-processing mechanism of the audit logs.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -194,7 +194,7 @@ change up to request payload level detail, but accept increased resource usage.
 As an even more security and regulatory demanding customer, I want to log **every** non-sensitive request
 both for read **and** for write operations, but also accept even more increased resource usage. 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 The proposed API looks like this: 
 

--- a/enhancements/kube-apiserver/bound-sa-tokens.md
+++ b/enhancements/kube-apiserver/bound-sa-tokens.md
@@ -118,7 +118,7 @@ therefore risk of compromise) for a given service account token.
     tokens signed by the previous private key will continue to validate since the
     corresponding public key will still be used to validate bound tokens.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 Bound tokens are not currently required until bootstrap is complete, so it should be
 reasonable to delay support of bound tokens until the post-bootstrap phase.

--- a/enhancements/kube-apiserver/certificates.md
+++ b/enhancements/kube-apiserver/certificates.md
@@ -122,7 +122,7 @@ They can change at any time, for any reason, without any notice.
 | secret/etcd-client | `kube-controller-manager --etcd-certfile` | installer | kube-apiserver, openshift-apiserver |
 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 ### Risks and Mitigations
 

--- a/enhancements/kube-apiserver/stability-point-to-point-network-check.md
+++ b/enhancements/kube-apiserver/stability-point-to-point-network-check.md
@@ -23,7 +23,7 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 This is where to call out areas of the design that require closure before deciding
 to implement the design.  For instance, 
@@ -139,7 +139,7 @@ The binary will:
 
 7. Repeat evey minute.
 
-### User Stories [optional]
+### User Stories
 
 Detail the things that people will be able to do if this is implemented.
 Include as much detail as possible so that people can understand the "how" of
@@ -150,7 +150,7 @@ bogged down.
 
 #### Story 2
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 What are the caveats to the implementation? What are some important details that
 didn't come across above. Go in to as much detail as necessary here. This might
@@ -438,7 +438,7 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Use this section if you need things from the project. Examples include a new
 subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/kube-apiserver/tls-config.md
+++ b/enhancements/kube-apiserver/tls-config.md
@@ -357,7 +357,7 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Use this section if you need things from the project. Examples include a new
 subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/machine-config/ignition-spec-dual-support.md
+++ b/enhancements/machine-config/ignition-spec-dual-support.md
@@ -443,6 +443,6 @@ and potentially will be not feasible. Existing user workflow will be
 disrupted, so communication of these changes will also be very important.
 
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 None extra

--- a/enhancements/machine-config/mco-kargs-day1-support.md
+++ b/enhancements/machine-config/mco-kargs-day1-support.md
@@ -267,7 +267,7 @@ Acceptance Criteria
 - Kernel arg configuration by the MCD works the same on all supported platforms
 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 What are the caveats to the implementation? What are some important details that
 didn't come across above. Go in to as much detail as necessary here. This might

--- a/enhancements/machine-config/user-data-secret-managed.md
+++ b/enhancements/machine-config/user-data-secret-managed.md
@@ -71,7 +71,7 @@ The proposal is pretty simple today:
 - The MCO has a way to manage the lifecycle of the Secret containing the stub ignition
 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 The implementation has already started and there are two PRs that provide a working POC:
 

--- a/enhancements/mcd-reboot-exceptions.md
+++ b/enhancements/mcd-reboot-exceptions.md
@@ -37,7 +37,7 @@ superseded-by:
 - [x] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 - Should the parts of the configuration that do and don't require reboot be
   part of user facing documentation?
@@ -101,7 +101,7 @@ The full list of post-write actions required for this feature to be useful are:
 If the action results in an error, or takes too long, a reboot will be
 performed as in prior 4.x versions.
 
-### User Stories [optional]
+### User Stories
 
 The user stories below are intended to be illustrative of the different types of 
 services we need to build capabilities for.
@@ -137,7 +137,7 @@ updates and changes to kernel flags, so that they are applied in a timely
 manner.
 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 How the function determines what constitutes a unit of configuration or "domain" 
 for the purposes of comparision and output is left for later discussion.
@@ -251,6 +251,6 @@ The risks primarily fall into 4 categories:
   much larger body of work that would not be possible to complete in the short 
   term.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 None

--- a/enhancements/multi-arch/samples.md
+++ b/enhancements/multi-arch/samples.md
@@ -101,13 +101,13 @@ architecture.
 There are some interesting details and caveats that will be discussed in the 
 implementation details section.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
 #### Story 2
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 In a somewhat related note, there have been a lot of side conversations regarding the Jenkins imagestream
 in particular, as the openshift/jenkins images are included in the 4.1/4.2 payloads.
@@ -173,7 +173,7 @@ Another alternative is to bootstrap the samples operator as "Removed" on non-x86
 over installing it as Managed w/ no imagestreams/templates to install.  And if the cluster admin were to subsequently
 change to "Managed", the issue of invalid content arises.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 New PR e2e jobs running on non-x86, or hybrid topologies, where clear means for the tests to determine the 
 architectures employed such that common tests can be run across multiple architectures.

--- a/enhancements/network/allow-external-ip-overrides.md
+++ b/enhancements/network/allow-external-ip-overrides.md
@@ -140,6 +140,6 @@ user has [sufficient privileges](#admin-user).
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 OpenShift 4.x cluster

--- a/enhancements/network/baremetal-networking.md
+++ b/enhancements/network/baremetal-networking.md
@@ -255,7 +255,7 @@ The next capabilities are supported by the `baremetal-runtimecfg`:
   - https://github.com/openshift/baremetal-runtimecfg/blob/master/pkg/monitor/corednsmonitor.go
 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 This has already been implemented for baremetal, Ovirt, vSphere and OpenStack.
 

--- a/enhancements/network/host-level-openvswitch.md
+++ b/enhancements/network/host-level-openvswitch.md
@@ -73,7 +73,7 @@ There is a pod that acts as a “sidecar” or “babysitter” for the openvswi
 Configuration for OVS is always presented as a set of key-value pairs that are inserted in to a configuration database. If needed, we should allow custom configuration to be expressed as a ConfigMap, which is reconciled to the database.
 
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 As a prototype, this can be implemented with just a few shell scripts. Ideally, it should be ultimately implemented as a go program that talks to the SystemD DBus API directly.
 

--- a/enhancements/oc/icsp-registry-scoped.md
+++ b/enhancements/oc/icsp-registry-scoped.md
@@ -27,7 +27,7 @@ status: implementable
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 
 ## Summary
@@ -101,7 +101,7 @@ As a user with a cluster in a disconnected network, I can mirror updates to
 optional operators that I already have installed without causing my cluster to
 reboot.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 This is an example of a registry-scoped ICSP:
 
@@ -240,6 +240,6 @@ could likely be delivered to users sooner. This enhancement also has the
 advantage of simplifying the contents of `registries.conf` and the sum of all
 ICSPs, which itself is a good thing for manageability.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 None.

--- a/enhancements/oc/inspect.md
+++ b/enhancements/oc/inspect.md
@@ -128,7 +128,7 @@ If we have extra space, keep more of the available logs.
 When trimming logs, prefer to trim logs for healthy pods more than unhealthy pods.  
 *Happy pods are all alike, but every unhappy pod is unhappy in its own way.*
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -270,6 +270,6 @@ The `inspect` command must skew +/- one like normal commands.
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 [1]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#container-v1-core

--- a/enhancements/oc/must-gather.md
+++ b/enhancements/oc/must-gather.md
@@ -92,13 +92,13 @@ To provide your own must-gather image, it must....
 
 If the `oc adm must-gather` tool's pod cannot be scheduled or run on the cluster, the `oc adm must-gather` tool will, after a timeout, fall-back to running `oc adm inspect clusteroperators` locally. 
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
 #### Story 2
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 What are the caveats to the implementation? What are some important details that
 didn't come across above. Go in to as much detail as necessary here. This might
@@ -159,4 +159,4 @@ The `oc` command must skew +/- one like normal commands.
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed

--- a/enhancements/proxy/global-cluster-egress-proxy.md
+++ b/enhancements/proxy/global-cluster-egress-proxy.md
@@ -29,7 +29,7 @@ see-also:
 - [ x ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 
@@ -123,7 +123,7 @@ is performing traffic decryption/re-encryption, I want to provide a
 valid CA that can trust my proxy's certificate to openshift components
 so they will trust my proxy.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 This enhancement introduces a cluster scoped proxy configuration resource.
 The resource includes fields to:
@@ -287,6 +287,6 @@ as the design/implementation evolves.
 Make every component define its own configuration mechanism for proxy support and require
 admins to modify all of them and keep them in sync.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 * CI environments with configured proxies that we can direct the clusters under test to use.

--- a/enhancements/samples/removed-bootstrapping.md
+++ b/enhancements/samples/removed-bootstrapping.md
@@ -183,6 +183,6 @@ they should as well for s390x or ppc64le.
 
 See the `Non-Goals` section for items that could also be classified as `Alternatives`.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 IPV6 and Disconnected environments for launching e2e's either from PRs out periodic tests.

--- a/enhancements/security/file-integrity-operator.md
+++ b/enhancements/security/file-integrity-operator.md
@@ -23,7 +23,7 @@ status: provisional
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 ## Summary
 

--- a/enhancements/service-catalog/prepare-service-catalog-and-brokers-for-removal.md
+++ b/enhancements/service-catalog/prepare-service-catalog-and-brokers-for-removal.md
@@ -97,7 +97,7 @@ each of the operators add alerting code.
 The operators will need a new dependency.
 [alerting client](https://github.com/prometheus/alertmanager/blob/master/client/client.go)
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 The 4 operators, Service Catalog Controller Manager operator (svcat-cm-op),
 Service Catalog APIServer operator (svcat-apiserver-op), the Ansible Service
@@ -235,6 +235,6 @@ Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed
 by an enhancement.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 N/A

--- a/enhancements/service-catalog/service-catalog-and-broker-removal.md
+++ b/enhancements/service-catalog/service-catalog-and-broker-removal.md
@@ -27,7 +27,7 @@ superseded-by:
 - [x] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
+## Open Questions
 
 N/A
 
@@ -186,7 +186,7 @@ upgradeable condition to allow z-level upgrades" [PR #291](https://github.com/op
 Create a bugzilla for docs include detailed directions on how to remove the
 Service Catalog and it's associated objects to allow upgrading to OpenShift 4.4.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 N/A
 
@@ -256,6 +256,6 @@ These Custom Brokers will be orphaned and remain running.
 
 N/A
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 N/A

--- a/enhancements/storage/csi-certification.md
+++ b/enhancements/storage/csi-certification.md
@@ -52,7 +52,7 @@ We propose that in order to be certified, a CSI driver should meet the following
   * The driver must be installed via the operator that will be available in our marketplace.
 * Once all tests pass, the CSI driver vendor should provide our certification team with the output of the tests in order to prove they passed.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -62,7 +62,7 @@ As a storage vendor, I want to make my CSI driver available to OCP users so that
 
 As an OCP user, I want to store my application data to a given storage backend using a certified CSI driver.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 No technical work needs to be done in the `openshift-tests` utility, as it already contains the `openshift/csi` test suite.
 
@@ -123,4 +123,4 @@ In order to run all tests of the `openshift/csi` test suite, CSI driver vendors 
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed

--- a/enhancements/storage/csi-cloning.md
+++ b/enhancements/storage/csi-cloning.md
@@ -48,12 +48,12 @@ This feature has already been implemented upstream, and is described in https://
 
 We will be releasing the `csi-external-provisioner` sidecar image with cloning support (already enabled by default) as Technology Preview. This sidecar will be provided to internal teams, such as CNV and OCS, for their drivers. No other consumer is supported, although it is eligible for use by any CSI driver.
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 As an OCS developer, I want to release the CSI Driver with cloning support so that drivers which include this feature, such as OCS, can use the API to easily Clone a volume.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 This feature has already been implemented upstream. Therefore, this feature requires the Kubernetes 1.16 rebase, and the `csi-external-provisioner` to be released with cloning support.
 We must also include e2e tests for this feature.
@@ -99,7 +99,7 @@ Additional references:
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 None. The csi-external-provisioner repository will be updated to include this feature.
 

--- a/enhancements/storage/csi-ebs-operator.md
+++ b/enhancements/storage/csi-ebs-operator.md
@@ -102,11 +102,11 @@ type EBSCSIDriverList struct {
 The CRD and its `cluster` instance is created by OLM from the operator manifest.
 
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 ### Risks and Mitigations
 
@@ -144,7 +144,7 @@ There is no dev-preview phase.
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 * aws-ebs-csi-driver GitHub repository (forked from upstream).
 * aws-ebs-csi-driver-operator GitHub repository.

--- a/enhancements/storage/csi-resize.md
+++ b/enhancements/storage/csi-resize.md
@@ -93,4 +93,4 @@ strategy of their drivers along with the sidecars those drivers use.
 
 Users could use the upstream sidecar instead of the one proposed here.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed

--- a/enhancements/storage/csi-snapshot.md
+++ b/enhancements/storage/csi-snapshot.md
@@ -114,7 +114,7 @@ type CSISnapshotStatus struct {
 The CRD and its `cluster` instance is created by CVO from the csi-snapshot-controller-operator manifest.
 
 
-### User Stories [optional]
+### User Stories
 
 #### Story 1
 
@@ -128,7 +128,7 @@ As OCS developer, I want to user CSI external-snapshotter sidecar shipped and su
 
 We (OpenShift storage team) are going to ship the external-snapshotter sidecar in the same way as other CSI sidecars (provisioner, attacher, node-driver-registrar, ...)
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 This feature has already been implemented upstream. Therefore, this feature requires a Kubernetes rebase of 1.15 or later.
 
@@ -188,7 +188,7 @@ There is no dev-preview phase.
 
 ## Alternatives
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 Nothing special, just:
 

--- a/enhancements/subscription-content/subscription-content-access.md
+++ b/enhancements/subscription-content/subscription-content-access.md
@@ -96,7 +96,7 @@ As a multi-cluster administrator, I want to enable my cluster for entitlements v
 that works well with GitOps (or similar patterns) so that granting access to subscription content is
 not a burden as I scale the number of clusters under management.
 
-### Implementation Details/Notes/Constraints [optional]
+### Implementation Details/Notes/Constraints
 
 To consume RHEL content in OpenShift, the running container must have access to the following:
 
@@ -303,13 +303,13 @@ This proposal has been rejected out of the desire to make OpenShift nodes as eph
 Kubernetes Pods. For OpenShift, the subscription belongs to the cluster, and concerns regaring use
 and billing are addressed via monitoring and telemetry.
 
-## Infrastructure Needed [optional]
+## Infrastructure Needed
 
 - New Github repos will be needed for each component above.
 - New CI templates needed to install the respective components for e2e testing.
 - Ultimately this will be introduced as an OLM operator, with attendant images produced by CPaaS
 
 
-## Open Questions [optional]
+## Open Questions
 
 - How can the cluster subscription manager be informed of key rotation/revocation events?


### PR DESCRIPTION
These mark optional sections in the template, but are no longer
required in actual enhancements where the decision has been made to
use the given section.  Generated with:

```console
$ sed -i 's/ \[optional]$//' $(git grep -l '\[optional]')
$ git checkout HEAD enhancements/template.md
```