### PR TITLE
enhancements/template: Fix maturity-levels link

### DIFF
--- a/enhancements/api-review/add-unqualified-search-registries.md
+++ b/enhancements/api-review/add-unqualified-search-registries.md
@@ -150,41 +150,7 @@ Update the tests that are currently in the MCO to verify that `unqualified-searc
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/autoscaling/cluster-resource-overrides.md
+++ b/enhancements/autoscaling/cluster-resource-overrides.md
@@ -102,46 +102,7 @@ TBD, see open questions.
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/installer/assisted-installer-bare-metal-validations.md
+++ b/enhancements/installer/assisted-installer-bare-metal-validations.md
@@ -202,41 +202,7 @@ verify that no extra validation rules are applied.
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
+None
 
 ## Implementation History
 

--- a/enhancements/installer/aws-custom-region-and-endpoints.md
+++ b/enhancements/installer/aws-custom-region-and-endpoints.md
@@ -361,41 +361,7 @@ TODO
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/installer/aws-permissions-check-bypass.md
+++ b/enhancements/installer/aws-permissions-check-bypass.md
@@ -284,46 +284,7 @@ state (assuming the credentials have sufficient permissions).
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/installer/azure-internal-with-user-defined-routing.md
+++ b/enhancements/installer/azure-internal-with-user-defined-routing.md
@@ -187,41 +187,7 @@ The easiest way to test the configuration would be to verify the [user story 2][
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/installer/azure-support-known-cloud-environments.md
+++ b/enhancements/installer/azure-support-known-cloud-environments.md
@@ -168,41 +168,7 @@ TODO
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/installer/connected-assisted-installer.md
+++ b/enhancements/installer/connected-assisted-installer.md
@@ -228,45 +228,7 @@ expectations).
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-N/A
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/installer/gcp-private-clusters.md
+++ b/enhancements/installer/gcp-private-clusters.md
@@ -138,32 +138,6 @@ This enhancement will follow standard graduation criteria.
 **For non-optional features moving to GA, the graduation criteria must include
 end to end tests.**
 
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
-
 ### Upgrade / Downgrade Strategy
 
 N/A

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -303,46 +303,7 @@ expectations).
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/kube-apiserver/stability-point-to-point-network-check.md
+++ b/enhancements/kube-apiserver/stability-point-to-point-network-check.md
@@ -288,24 +288,11 @@ expectations).
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
+None
 
-Define graduation milestones.
+### Examples
 
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-##### Example PodNetworkConnectivityCheck instance
+#### Example PodNetworkConnectivityCheck instance
 
 ```yaml
 kind: PodNetworkConnectivityCheck
@@ -345,7 +332,7 @@ status:
 
 ```
 
-##### Example PodNetworkConnectivityCheck instance with DNS
+#### Example PodNetworkConnectivityCheck instance with DNS
 ```yaml
 kind: PodNetworkConnectivityCheck
 version: network.openshift.io/v1alpha1
@@ -372,30 +359,6 @@ status:
         message: "etcd.openshift-etcd.sv resolved to 10.0.140.67"
         duration: "200ms"
 ```
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/monitoring/user-workload-monitoring.md
+++ b/enhancements/monitoring/user-workload-monitoring.md
@@ -419,18 +419,11 @@ TBD
 
 ### Graduation Criteria
 
-N/A
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
+#### Dev Preview -> Tech Preview
 
 There is no dev preview planned, just tech preview.
 
-##### Tech Preview -> GA
+#### Tech Preview -> GA
 
 - More testing (upgrade, downgrade, scale)
 - Sufficient time for feedback
@@ -442,11 +435,6 @@ The OperatorGroup is marked as deprecated,
 the removal is blocked by OLM's prometheus operator.
 - Analyze saturation of new prometheus servers
 and evaluate fitness for GA by analyzing telemetry.
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/oc/icsp-registry-scoped.md
+++ b/enhancements/oc/icsp-registry-scoped.md
@@ -159,46 +159,7 @@ expectations).
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
+None
 
 ### Upgrade / Downgrade Strategy
 

--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -165,15 +165,23 @@ determine graduation.
 
 Consider the following in developing the graduation criteria for this
 enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
 
-Clearly define what graduation means.
+- Maturity levels
+    - [`alpha`, `beta`, `stable` in upstream Kubernetes][maturity-levels]
+    - `Dev Preview`, `Tech Preview`, `GA` in OpenShift
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning),
+or by redefining what graduation means.
+
+In general, we try to use the same stages (alpha, beta, GA), regardless how the functionality is accessed.
+
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
 
 #### Examples
 
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
+These are generalized examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
 
 ##### Dev Preview -> Tech Preview
 


### PR DESCRIPTION
The broken link is from 881dbb7b94 (#2), with a sloppy copy from [the KEP template][1].  I'm fixing with a verbatim copy from the KEP template (and dropping template-only stuff from the user-workload-monitoring enhancement).  This is a bit of a semantic change from what we had previously.  The OpenShift vs. Kubernetes maturity levels are not clear to me.  OpenShift does have docs [on GA and later][2], and we do have docs on [using Technology Preview features][3], but I have not turned up docs for what Technology preview means in terms of maturity/support.

But even if there is a Kubernetes / OpenShift maturity distinction, OpenShift is going to expose Kubernetes features before they go stable.  And we use v1beta1 and whatnot for OpenShift configs.  So I don't think we can drop the Kubernetes maturity references altogether, although we can add OpenShift maturity references in addition (once we find out what to reference).

/assign @derekwaynecarr

[1]: https://github.com/kubernetes/enhancements/blame/f1a799d5f4658ed29797c1fb9ceb7a4d0f538e93/keps/YYYYMMDD-kep-template.md#L216-L221
[2]: https://access.redhat.com/support/policy/updates/openshift/
[3]: https://docs.openshift.com/container-platform/4.2/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-features-about_nodes-cluster-enabling