### PR TITLE
enhancements/template: Fix openshift-docs links

### DIFF
--- a/enhancements/automated-policy-based-disencryption.md
+++ b/enhancements/automated-policy-based-disencryption.md
@@ -33,7 +33,7 @@ status: provisional
 - [ ] Test plan is defined
 - [ ] Test plan implemented 
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 - [ ] Transition Plan to Ignition controlled policy application
 
 ## Summary

--- a/enhancements/automated-service-ca-rotation.md
+++ b/enhancements/automated-service-ca-rotation.md
@@ -27,7 +27,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/cluster-logging/cluster-logging-elasticsearch-proxy.md
+++ b/enhancements/cluster-logging/cluster-logging-elasticsearch-proxy.md
@@ -29,7 +29,7 @@ superseded-by: []
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/cluster-logging/cluster-logging-log-forwarding.md
+++ b/enhancements/cluster-logging/cluster-logging-log-forwarding.md
@@ -27,7 +27,7 @@ superseded-by:[]
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/compact-clusters.md
+++ b/enhancements/compact-clusters.md
@@ -25,7 +25,7 @@ superseded-by:
 - [x] Design details are appropriately documented from clear requirements
 - [x] Test plan is defined
 - [x] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/compliance-operator.md
+++ b/enhancements/compliance-operator.md
@@ -21,7 +21,7 @@ status: provisional
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/dns/plugins.md
+++ b/enhancements/dns/plugins.md
@@ -28,7 +28,7 @@ includes [forward](https://coredns.io/plugins/forward/) as the first plugin impl
 - [x] Design details are appropriately documented from clear requirements
 - [x] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Open Questions [optional]
 

--- a/enhancements/etcd/storage-migration-for-etcd-encryption.md
+++ b/enhancements/etcd/storage-migration-for-etcd-encryption.md
@@ -23,7 +23,7 @@ see-also:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/installer/aws-customer-provided-subnets.md
+++ b/enhancements/installer/aws-customer-provided-subnets.md
@@ -23,7 +23,7 @@ superseded-by:
 - [ x ] Design details are appropriately documented from clear requirements
 - [ x ] Test plan is defined
 - [ x ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/installer/aws-internal-clusters.md
+++ b/enhancements/installer/aws-internal-clusters.md
@@ -22,7 +22,7 @@ superseded-by:
 - [ x ] Design details are appropriately documented from clear requirements
 - [ x ] Test plan is defined
 - [ x ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/kube-apiserver/auto-cert-recovery.md
+++ b/enhancements/kube-apiserver/auto-cert-recovery.md
@@ -23,7 +23,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/kube-apiserver/certificates.md
+++ b/enhancements/kube-apiserver/certificates.md
@@ -25,7 +25,7 @@ for the kube-apiserver in particular are managed.
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/kube-apiserver/encrypting-data-at-datastore-layer.md
+++ b/enhancements/kube-apiserver/encrypting-data-at-datastore-layer.md
@@ -25,7 +25,7 @@ see-also:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/kube-apiserver/tls-config.md
+++ b/enhancements/kube-apiserver/tls-config.md
@@ -32,7 +32,7 @@ level of TLS config restrictions than the infrastructure.
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/mco-kargs-day1-support.md
+++ b/enhancements/mco-kargs-day1-support.md
@@ -26,7 +26,7 @@ status: **provisional**|implementable|implemented|deferred|rejected|withdrawn|re
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/monitoring/user-workload-monitoring.md
+++ b/enhancements/monitoring/user-workload-monitoring.md
@@ -23,7 +23,7 @@ status: implementable
 - [x] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/multi-arch/samples.md
+++ b/enhancements/multi-arch/samples.md
@@ -43,7 +43,7 @@ any non-x86 images for these existing samples.
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/must-gather.md
+++ b/enhancements/must-gather.md
@@ -24,7 +24,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/network/20190903-SRIOV-GA.md
+++ b/enhancements/network/20190903-SRIOV-GA.md
@@ -24,7 +24,7 @@ status: implementable
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/network/20190919-OVN-Kubernetes.md
+++ b/enhancements/network/20190919-OVN-Kubernetes.md
@@ -24,7 +24,7 @@ Superseded-by: []
 - [X] Design details are appropriately documented from clear requirements
 - [X] Test plan is defined
 - [X] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 Makes OVN-Kubernetes production-ready for OpenShift’s use-cases.

--- a/enhancements/network/allow-external-ip-overrides.md
+++ b/enhancements/network/allow-external-ip-overrides.md
@@ -25,7 +25,7 @@ superseded-by:
 - [x] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/oc/inspect.md
+++ b/enhancements/oc/inspect.md
@@ -26,7 +26,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/oc/olm-mirroring.md
+++ b/enhancements/oc/olm-mirroring.md
@@ -25,7 +25,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/olm/operator-bundle.md
+++ b/enhancements/olm/operator-bundle.md
@@ -6,7 +6,7 @@
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 This enhancement proposes standards and conventions for storing kubernetes manifests and `metadata` associated with an operator as container images in OCI-compliant container registries, and to associate metadata-only images with standard, runnable images.

--- a/enhancements/olm/operator-registry.md
+++ b/enhancements/olm/operator-registry.md
@@ -19,7 +19,7 @@ status: provisional
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/olm/phone-home-support.md
+++ b/enhancements/olm/phone-home-support.md
@@ -6,7 +6,7 @@
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ]  -facing documentation is created in [openshift/docs]
+- [ ]  -facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/olm/simplify-apis.md
+++ b/enhancements/olm/simplify-apis.md
@@ -22,7 +22,7 @@ see-also:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/proxy/global-cluster-egress-proxy.md
+++ b/enhancements/proxy/global-cluster-egress-proxy.md
@@ -27,7 +27,7 @@ see-also:
 - [ x ] Design details are appropriately documented from clear requirements
 - [ x ] Test plan is defined
 - [ x ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Open Questions [optional]
 

--- a/enhancements/ptp-time-integration.md
+++ b/enhancements/ptp-time-integration.md
@@ -21,7 +21,7 @@ status: implementable
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/security/file-integrity-operator.md
+++ b/enhancements/security/file-integrity-operator.md
@@ -21,7 +21,7 @@ status: provisional
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Open Questions [optional]
 

--- a/enhancements/service-catalog/prepare-service-catalog-and-brokers-for-removal.md
+++ b/enhancements/service-catalog/prepare-service-catalog-and-brokers-for-removal.md
@@ -23,7 +23,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/storage/csi-cloning.md
+++ b/enhancements/storage/csi-cloning.md
@@ -24,7 +24,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs] 
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/storage/csi-resize.md
+++ b/enhancements/storage/csi-resize.md
@@ -25,7 +25,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/storage/csi-snapshot.md
+++ b/enhancements/storage/csi-snapshot.md
@@ -23,7 +23,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/template.md
+++ b/enhancements/template.md
@@ -57,7 +57,7 @@ around the enhancement process.
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Open Questions [optional]
 

--- a/enhancements/user-defined-default-ingress-controller.md
+++ b/enhancements/user-defined-default-ingress-controller.md
@@ -26,7 +26,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/windows-containers/cluster-logging-windows-worker-nodes.md
+++ b/enhancements/windows-containers/cluster-logging-windows-worker-nodes.md
@@ -26,7 +26,7 @@ status: implementable
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/enhancements/windows-containers/productization.md
+++ b/enhancements/windows-containers/productization.md
@@ -22,7 +22,7 @@ status: implementable
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/image-registry/automate-pruning.md
+++ b/image-registry/automate-pruning.md
@@ -29,7 +29,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 

--- a/image-registry/remove-registry-baremetal.md
+++ b/image-registry/remove-registry-baremetal.md
@@ -28,7 +28,7 @@ superseded-by:
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
-- [ ] User-facing documentation is created in [openshift/docs]
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 


### PR DESCRIPTION
The bracketed `openshift/docs` is from 881dbb7b94 (#2).  But a link makes it easy for folks to see where changes should go, and is something that can be updated by enhancements to link specific PRs as they check off this box.