### PR TITLE
Update snapshot enhancement for Kubernetes 1.17

### DIFF
--- a/enhancements/storage/csi-snapshot.md
+++ b/enhancements/storage/csi-snapshot.md
@@ -59,20 +59,20 @@ Upstream has chosen [addon](https://github.com/kubernetes/kubernetes/tree/master
 1. OCP ships a new operator for csi-snapshot-controller, say csi-snapshot-controller-operator.
   * This operator will be installed by CVO in all clusters.
     * We do not know in advance what CSI drivers will a cluster admin install and we want the cluster ready for snapshots.
-  * This operator will create Deployment with csi-snapshot-controller and report its status via standard `ClusterOperator` object.
-    * Using Deployment with leader election instead of upstream StatefulSet - leader election is significantly faster to run a new leader when a node with the current leader gets unavailable.
-    * TBD: Use DaemonSet on masters? The controller can read / write any VolumeSnapshot, VolumeSnapshotContent and PV objects in the cluster and read any PVC. Running it on masters may be more secure.
-  * Everything runs in namespace `openshift-csi-snapshot-controller`.
+  * This operator will create / update VolumeSnapshot, VolumeSnapshotContent and VolumeSnapshotClass CRDs.
+    * Vanilla copy of [upstream CRDs](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/volumesnapshots/crd) is used.
+  * This operator will create Deployment with csi-snapshot-controller
+    * Using Deployment with 3 replicas + leader election instead of upstream StatefulSet - leader election is significantly faster to run a new leader when a node with the current leader gets unavailable.
+    * Optionally, run the Deployment on masters using proper node selector + tolerations.
+  * This operator will report its status and status of the operand (Deployment) via standard `ClusterOperator` object.
+    * With RelatedObjects = the Deployment with the controller + `openshift-csi-snapshot-controller` namespace.
+  * Everything (the operator + the operand) runs in namespace `openshift-csi-snapshot-controller`.
   * Requires new github repo, openshift/csi-snapshot-controller-operator.
   * Requires new image.
   * No new CRD / CR is needed for the operator itself, the operator does the same on all clusters / clouds and does not need any configuration.
 
 2. OCP ships new image csi-snapshot-controller. Its source code is already available in github.com/openshift/csi-external-snapshotter, we only need an image.
-  * The component / image is called kubernetes-csi/snapshot-controller upstream, we add csi- prefix to repository and image names, who knows what other kinds of snapshotters there will be.
-
-3. OCP creates upstream snapshot CRDs via CVO.
-  * Created during (or before) csi-snapshot-controller-operator installation.
-  * We just copy [upstream CRDs](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/volumesnapshots/crd).
+  * The component / image is called kubernetes-csi/snapshot-controller upstream, we add csi- prefix to repository and image names, as we do with other repos / images from github.com/kubernetes-csi
 
 ### User Stories [optional]
 

--- a/enhancements/storage/csi-snapshot.md
+++ b/enhancements/storage/csi-snapshot.md
@@ -2,13 +2,14 @@
 title: csi-snapshots
 authors:
   - "@chuffman"
+  - "@jsafrane"
 reviewers:
   - "@gnufied”
-  - “@jsafrane”
+  - "@bertinatto"
 approvers:
   - "@..."
 creation-date: 2019-09-05
-last-updated: 2019-09-25
+last-updated: 2019-12-09
 status: provisional
 see-also:
 replaces:
@@ -37,25 +38,55 @@ We want to include the upstream CSI Snapshot feature in OpenShift.
 
 ### Goals
 
-* Rebase the downstream csi-external-snapshotter and csi-external-provisioner images off of the upstream images based on Kubernetes 1.16.
+* Enable snapshot feature by default and provide the same support as upstream 1.17 release.
 
-* Package and ship a downstream image of the this sidecar.
+* Release and maintain downstream csi-external-snapshotter, csi-external-provisioner sidecars images off of the upstream images based on Kubernetes 1.17 to allow Red Hat CSI drivers (such as OCS) to consume them.
 
 ### Non-Goals
 
+## Upstream status
+This feature has reached v1beta status upstream and is described in https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190709-csi-snapshot.md and https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-snapshot.md.
+
+This feature poses new requirements on Kubernetes distributions such as OpenShift:
+* Ship and install snapshot CRDs.
+* Ship and run snapshot-controller in a cluster.
+  * snapshot-controller is very similar to in-tree PV controller in its function, it watches VolumeSnapshots and provisions VolumeSnapshotContents for them. The snapshot controller is independent on storage backend and only one runs for all CSI drivers installed in a cluster.
+
+Upstream has chosen [addon](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/volumesnapshots) for both. Upstream uses [StatefulSet for the snapshot-controller with single replica](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml) for the snapshot-controller.
+
 ## Proposal
 
-This feature has already been implemented upstream, and is described in https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190709-csi-snapshot.md . It is currently documented upstream at https://kubernetes.io/docs/concepts/storage/volume-snapshots/ .
+1. OCP ships a new operator for csi-snapshot-controller, say csi-snapshot-controller-operator.
+  * This operator will be installed by CVO in all clusters.
+    * We do not know in advance what CSI drivers will a cluster admin install and we want the cluster ready for snapshots.
+  * This operator will create Deployment with csi-snapshot-controller and report its status via standard `ClusterOperator` object.
+    * Using Deployment with leader election instead of upstream StatefulSet - leader election is significantly faster to run a new leader when a node with the current leader gets unavailable.
+    * TBD: Use DaemonSet on masters? The controller can read / write any VolumeSnapshot, VolumeSnapshotContent and PV objects in the cluster and read any PVC. Running it on masters may be more secure.
+  * Everything runs in namespace `openshift-csi-snapshot-controller`.
+  * Requires new github repo, openshift/csi-snapshot-controller-operator.
+  * Requires new image.
+  * No new CRD / CR is needed for the operator itself, the operator does the same on all clusters / clouds and does not need any configuration.
 
-We will be releasing the `external-snapshotter` sidecar image to enable CSI Snapshot support in OCP as Developer Preview only. This sidecar can be used by internal teams, such as CNV or OCS, for their drivers.
+2. OCP ships new image csi-snapshot-controller. Its source code is already available in github.com/openshift/csi-external-snapshotter, we only need an image.
+  * The component / image is called kubernetes-csi/snapshot-controller upstream, we add csi- prefix to repository and image names, who knows what other kinds of snapshotters there will be.
+
+3. OCP creates upstream snapshot CRDs via CVO.
+  * Created during (or before) csi-snapshot-controller-operator installation.
+  * We just copy [upstream CRDs](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/volumesnapshots/crd).
 
 ### User Stories [optional]
 
 #### Story 1
 
-As an OCS developer, I want to release the `csi-external-snapshotter` sidecar image so that users can utilize volume snapshots.
+As OCP cluster admin, I want to deploy a 3rd party CSI driver that supports snapshots and use it right away, without any OCP (re)configuration.
+
+This is possible since csi-snapshot-controller and all snapshot CRDs are created during installation of the cluster.
 
 #### Story 2
+
+As OCS developer, I want to user CSI external-snapshotter sidecar shipped and supported by Red Hat to run my CSI driver.
+
+We (OpenShift storage team) are going to ship the external-snapshotter sidecar in the same way as other CSI sidecars (provisioner, attacher, node-driver-registrar, ...)
 
 ### Implementation Details/Notes/Constraints [optional]
 
@@ -63,15 +94,26 @@ This feature has already been implemented upstream. Therefore, this feature requ
 
 ### Risks and Mitigations
 
-* Kubernetes 1.15+ rebase
+* Kubernetes 1.17 rebase.
+* Release of upstream external-snapshotter and snapshot-controller for Kubernetes 1.17. This has been done usually within 1 month after appropriate Kubernetes release.
 
 ## Design Details
 
-No design is needed, as this feature has already been implemented upstream. The upstream design was discussed under https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190709-csi-snapshot.md.
+This feature has already been implemented upstream. The upstream design was discussed under https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190709-csi-snapshot.md.
+
+### csi-snapshot-controller-operator
+The operator is fairly straightforward, it manages just one Deployment that runs csi-snapshot-controller and requires no API changes / new CRDs.
+
+* Upstream RBAC from [upstream](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml)
+* Upstream [StatefulSet](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml)
+  * We will use Deployment with leader election, it recovers faster from leader being on an unavailable node 
+  * We may consider DaemonSet on masters, as the controller can read all PVs / PVCs / VolumeSnapshot / VolumeSnapshotContent objects in the cluster and write to most of them (everything except PVC).
 
 ### Test Plan
 
-We’ll want the e2e tests to run using CSI sidecars shipped as part of OCP. There is ongoing progress in the following links regarding testing OCP CSI sidecars:
+The csi-snapshot-controller-operator will have e2e test to ensure it does not break openshift/origin installation.
+
+We want the e2e tests to run using CSI sidecars shipped as part of OCP. There is ongoing progress in the following links regarding testing OCP CSI sidecars:
 
 * https://github.com/openshift/origin/pull/23560
 * https://jira.coreos.com/browse/STOR-223
@@ -79,10 +121,15 @@ Tests for this sidecar are currently defined upstream at https://github.com/kube
 
 ### Graduation Criteria
 
-##### Dev Preview -> Tech Preview
+There is no dev-preview phase.
+
+##### Tech Preview
 
 * Unit and e2e tests implemented.
 * Update snapshot CRDs to v1beta1 and enable VolumeSnapshotDataSource feature gate by default. The feature must also be at least v1beta1 upstream, and have a strong indication that it will be made GA in a reasonable time frame with a compatible API.
+* csi-snapshot-controller-operator is installed in all clusters.
+* csi-snapshot-controller-operator has e2e test(s).
+* csi-external-snapshotter is available to CSI drivers shipped by Red Hat (OCS, Ember, ...).
 
 ##### Tech Preview -> GA
 
@@ -103,4 +150,7 @@ Tests for this sidecar are currently defined upstream at https://github.com/kube
 
 ## Infrastructure Needed [optional]
 
-None. The csi-external-snapshotter repository will be updated to include this feature.
+Nothing special, just:
+
+* csi-snapshot-controller-operator github repository.
+* New csi-snapshot-controller-operator and csi-snapshot-controller images, as described above.


### PR DESCRIPTION
In order to support volume snapshots, OCP needs to run a new cluster-wide snapshot-controller. It manages lifecycle of volume snapshots and is very similar to in-tree PV controller.

OCP needs a new operator to install the snapshot-controller and monitor its health. No new API is required on OCP side, the snapshot-controller will be the same on all clusters and does not require any configuration.

@openshift/storage 
@openshift/openshift-architects 