### PR TITLE
[wip] create a CSI driver for global configmaps and secrets

### DIFF
--- a/enhancements/storage/csi-driver-global-configmap-secret-mounter.md
+++ b/enhancements/storage/csi-driver-global-configmap-secret-mounter.md
@@ -1,0 +1,201 @@
+---
+title: global-configmap-secret-mounter
+authors:
+  - "@janedoe"
+reviewers:
+  - TBD
+  - "@alicedoe"
+approvers:
+  - TBD
+  - "@oscardoe"
+creation-date: yyyy-mm-dd
+last-updated: yyyy-mm-dd
+status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
+see-also:
+  - "/enhancements/this-other-neat-thing.md"  
+replaces:
+  - "/enhancements/that-less-than-great-idea.md"
+superseded-by:
+  - "/enhancements/our-past-effort.md"
+---
+
+# Global ConfigMap and Secret Mounter
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
+
+## Open Questions [optional]
+
+ 1.  It is possible to build some sorts of per-namespace ACL boundaries if we really wanted to, but I think it makes more sense
+ to have the idea of global or namespaced and no in-between since nothing else is in between today.  They can write a controller
+ if they really want to create resources shared across some namespaces and not others.
+
+## Summary
+
+A CSI driver that can mount a configmap or secret from a specified namespace into any pod.
+This would allow a single copy of a configmap to exist in openshift-config-managed (say the trusted-ca) and mount that configmap into any pod.
+There is no ACL check on the pod attempting to mount it.  Any configmap or secret that can be mounted, can be mounted anywhere.
+The CSI driver must keep the content on disk up to date, similar to how the kubelet keeps configmap and secret data consistent today.
+This allows the creation of a webhook admission plugin to allow annotation based injection of well-known configmaps and secrets, like the trusted-ca today.
+
+To have reasonable security boundaries, the cluster-admin must explicitly enumerate all namespace/name tuples for the configmaps and secrets that he wants to expose. 
+This will allow the CSI driver to use individual list/watches to drive the watch behavior to have scoped RBAC for the CSI driver.
+
+## Motivation
+
+This CSI driver would generically solve the problem of "inject this custom CA bundle into every requesting pod".
+A clever admission webhook could even do this unconditionally across namespaces or even have a bash wrapping ability for system certs if so desired. 
+
+### Goals
+
+List the specific goals of the proposal. How will we know that this has succeeded?
+
+### Non-Goals
+
+What is out of scope for this proposal? Listing non-goals helps to focus discussion
+and make progress.
+
+## Proposal
+
+This is where we get down to the nitty gritty of what the proposal actually is.
+
+### User Stories [optional]
+
+Detail the things that people will be able to do if this is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+
+#### Story 1
+
+#### Story 2
+
+### Implementation Details/Notes/Constraints [optional]
+
+What are the caveats to the implementation? What are some important details that
+didn't come across above. Go in to as much detail as necessary here. This might
+be a good place to talk about core concepts and how they releate.
+
+### Risks and Mitigations
+
+What are the risks of this proposal and how do we mitigate. Think broadly. For
+example, consider both security and how this will impact the larger OKD
+ecosystem.
+
+How will security be reviewed and by whom? How will UX be reviewed and by whom?
+
+Consider including folks that also work outside your immediate sub-project.
+
+## Design Details
+
+### Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+### Graduation Criteria
+
+**Note:** *Section not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, or as something else. Initial proposal
+should keep this high-level with a focus on what signals will be looked at to
+determine graduation.
+
+Consider the following in developing the graduation criteria for this
+enhancement:
+- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
+- Deprecation
+
+Clearly define what graduation means.
+
+#### Examples
+
+These are generalized examples to consider, in addition to the aforementioned
+[maturity levels][maturity-levels].
+
+##### Dev Preview -> Tech Preview
+
+- Ability to utilize the enhancement end to end
+- End user documentation, relative API stability
+- Sufficient test coverage
+- Gather feedback from users rather than just developers
+
+##### Tech Preview -> GA 
+
+- More testing (upgrade, downgrade, scale)
+- Sufficient time for feedback
+- Available by default
+
+**For non-optional features moving to GA, the graduation criteria must include
+end to end tests.**
+
+##### Removing a deprecated feature
+
+- Announce deprecation and support policy of the existing feature
+- Deprecate the feature
+
+### Upgrade / Downgrade Strategy
+
+If applicable, how will the component be upgraded and downgraded? Make sure this
+is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to keep previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to make use of the enhancement?
+
+### Version Skew Strategy
+
+How will the component handle version skew with other components?
+What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- During an upgrade, we will always have skew among components, how will this impact your work?
+- Does this enhancement involve coordinating behavior in the control plane and
+  in the kubelet? How does an n-2 kubelet without this feature available behave
+  when this feature is used?
+- Will any other components on the node change? For example, changes to CSI, CRI
+  or CNI may require updating that component before the kubelet.
+
+## Implementation History
+
+Major milestones in the life cycle of a proposal should be tracked in `Implementation
+History`.
+
+## Drawbacks
+
+The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
+
+## Alternatives
+
+Similar to the `Drawbacks` section the `Alternatives` section is used to
+highlight and record other possible approaches to delivering the value proposed
+by an enhancement.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project. Examples include a new
+subproject, repos requested, github details, and/or testing infrastructure.
+
+Listing these here allows the community to get the process for these resources
+started right away.


### PR DESCRIPTION
Mainly so I don't lose the idea.

A CSI driver that can mount a configmap or secret from a specified namespace into any pod. This would allow a single copy of a configmap to exist in openshift-config-managed (say the trusted-ca) and mount that configmap into any pod. There is no ACL check on the pod attempting to mount it.  Any configmap or secret that can be mounted, can be mounted anywhere. The CSI driver must keep the content on disk up to date, similar to how the kubelet keeps configmap and secret data consistent today. This allows the creation of a webhook admission plugin to allow annotation based injection of well-known configmaps and secrets, like the trusted-ca today.

 To have reasonable security boundaries, the cluster-admin must explicitly enumerate all namespace/name tuples for the configmaps and secrets that he wants to expose.  This will allow the CSI driver to use individual list/watches to drive the watch behavior to have scoped RBAC for the CSI driver.

This would solve the problem of cluster-admins wanting to distribute global config and secrets.  You can imagine it well-paired  with things like service-serving-cert-signer and distinct signers for the multiple CSR signers coming in 1.18.

@openshift/storage 

reminder for self.  Examples for how to write csi drivers are 
1. https://github.com/kubernetes-csi/csi-test/tree/master/mock
2. https://github.com/openshift/origin/tree/master/vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/mock