### PR TITLE
Removes Status From Ingress Wildcard Admission Policy

### DIFF
--- a/enhancements/ingress/wildcard-admission-policy.md
+++ b/enhancements/ingress/wildcard-admission-policy.md
@@ -10,7 +10,7 @@ reviewers:
 approvers:
   - "@openshift/api-approvers"
 creation-date: 2020-03-19
-last-updated: 2020-03-19
+last-updated: 2020-03-27
 status: implementable
 see-also: [route-admission-policy](https://github.com/openshift/enhancements/blob/master/enhancements/ingress/openshift-route-admission-policy.md)
 replaces:
@@ -130,12 +130,6 @@ type IngressControllerSpec struct {
   //
   // +optional
   RouteAdmission *RouteAdmissionPolicy `json:"routeAdmission,omitempty"`
-}
-
-// (Existing type and field, included for completeness)
-type IngressControllerStatus struct {
-  // routeAdmission is the route admission policy that is in effect.
-  RouteAdmission *RouteAdmissionPolicy
 }
 ```
 


### PR DESCRIPTION
Previously, the wildcard admission policy enhancement proposal included route admission status. This is not being implemented, so the status field is removed by this PR.

/assign @ironcladlou @Miciah 
/cc @frobware 