### PR TITLE
Fix the default issuer for bound sa tokens

### DIFF
--- a/enhancements/kube-apiserver/bound-sa-tokens.md
+++ b/enhancements/kube-apiserver/bound-sa-tokens.md
@@ -80,7 +80,7 @@ therefore risk of compromise) for a given service account token.
     - service-account-signing-key-file
       - Operator should set this to the path of the private key it manages
     - service-account-issuer
-      - Operator should default this to `auth.openshift.io` and it should be possible to
+      - Operator should default this to `https://kubernetes.default.svc` and it should be possible to
         override it. When it is overridden, tokens from the previous issuer will no longer
         validate and it may be necessary to restart affected pods.
     - api-audiences


### PR DESCRIPTION
The default for the issuer of bound sa tokens is updated to point to the internal dns name of the kube apiserver to ensure compatibility with the ServiceAccountIssuerDiscovery feature added in kube 1.18.