### PR TITLE
user-workload-monitoring: reflect changes in role naming

### DIFF
--- a/enhancements/monitoring/user-workload-monitoring.md
+++ b/enhancements/monitoring/user-workload-monitoring.md
@@ -341,7 +341,7 @@ $ oc -n <namespace> create/patch/delete prometheusrule <foo>.
 
 2. Silence firing alerts from the Alertmanager `/alerts?namespace=<foo>` endpoint matching the permitted namespace.
 
-#### `monitoring-targets-edit`
+#### `monitoring-edit`
 This is a cluster role which can be bound against a concrete namespace by the cluster admin.
 Embeds the `get/create/edit/delete` permissions for the following custom resources:
 


### PR DESCRIPTION
Following https://github.com/openshift/cluster-monitoring-operator/pull/754

cc @brancz @s-urbaniak 