### PR TITLE
Update CSI installation KEP with current state

### DIFF
--- a/enhancements/storage/csi-driver-install.md
+++ b/enhancements/storage/csi-driver-install.md
@@ -191,8 +191,8 @@ Since operators managed by OLM are not managed ART pipeline, there are some cons
      What / when is going to mirror the operator & driver images?
      The installation will time out when cluster-storage operator can't install a CSI driver via OLM.
 
-2. When / how often are index images updated after operator release?
-   Even when we synchronize operator & OCP errata release as suggested above, clusters may not be installable until OLM sees the operator in the index image.
+     A: currently not possible.
+
 
 3. When a CSI driver operator becomes installed by default and installed by cluster-storage-operator, all CI jobs must have the current version of the operator available in OLM in the cluster.
    Currently, all 4.5 CI clusters show only 4.4 operators.
@@ -215,6 +215,12 @@ Answered questions:
 4. Since most CSI operators has to be singletons, we need to stop users from installing the operator multiple times in different namespaces. Currently this is not possible.
 
   A. We use `AllNamespaces` install mode - an operator with this mode can be installed only once in a cluster. Still, user has possiblity to override the namespace where the operator actually runs, which complicates update from "optional" operator to "installed by default" (see Upgrade from optional operator to a driver installed by default)
+
+6. When / how often are index images updated after operator release?
+   Even when we synchronize operator & OCP errata release as suggested above, clusters may not be installable until OLM sees the operator in the index image.
+
+   Answered on "Operator Framework (Eng + PM) sync call with Operator Teams" - index images are synced almost immediatelly after Errata is shipped (in under 1 hour).
+   Similarly, staging index for QA is regenerated after new builds are added to an errata.
 
 
 ## Timeline

--- a/enhancements/storage/csi-driver-install.md
+++ b/enhancements/storage/csi-driver-install.md
@@ -55,7 +55,7 @@ We would like to approach various goals of this KEP in different phases, because
 
 ### Phase-1 Goals
 
-* Provide a way for AWS and GCE CSI driver installation . Users could either optionally install it or CSI driver could be installed
+* Provide a way for AWS and GCE CSI driver installation. Users could either optionally install it or CSI driver could be installed
 along with in-tree driver and users could use both.
 * Install CSI provided storageclass along with in-tree StorageClass.
 
@@ -87,38 +87,41 @@ We propose that - we provide each driver mentioned above as a separate operator 
 is responsible for its installation and release. The operator is responsible for creating storageclass that the driver provides.
 
 The configuration of CSI driver can be done via OLM UI if required and CSI driver can access cloudprovider credentials
-from Openshift provided sources.The CR that is responsible for driver configuration can be installed by the operator
-itself optionally or by the user. We expect operator configuration CR to be *cluster-scoped* rather than namespace scoped.
+from Openshift provided sources. Initially, when the CSI driver is an optional component, user must create the CR for the operator.
+We expect operator configuration CR to be *cluster-scoped* rather than namespace scoped.
 
 The reason for choosing cluster-scoped CRs are two fold:
 1. CSI drivers logically span the entire cluster, so control of them in a single namespace doesn't make sense in a cluster and could lead to unnecessary conflicts. In addition, only a cluster-admin should be manipulating the set of CSI drivers, so cluster-scoped is a good choice in this case.
 2. Having CRs cluster-scoped avoids unnecessary deletion and re-creation of CRs when cluster-storage-operator could potentially adopt an operator subscription.
 
-User should be able to edit the CR and change log level, managementState and update credentials(if operator configuration CR is mechanism by which credentials are delivered to the CSI driver) required for talking to storage backend.
+User should be able to edit the CR and change log level, managementState and update credentials (if operator configuration CR is mechanism by which credentials are delivered to the CSI driver) required for talking to storage backend.
 
 Installation via OLM however means that, when we want to enable these CSI drivers as default drivers,
 they must be installed by default in Openshift installs. We further propose that -
 Cluster Storage Operator(https://github.com/openshift/cluster-storage-operator)
-could create subscriptions for these driver operators when drivers have to be installed by default.
+could create subscriptions for these driver operators when drivers have to be installed by default
+and create CR for the driver with default parameters.
 
 Expected workflow as optional driver (using EBS as an example):
 1. User finds EBS CSI driver operator in OLM and installs it.
-2. The operator automatically creates a cluster-scoped CR for itself and install AWS EBS CSI driver with default settings. User can configure basic operator features as log level or ManagementState in the CR. We expect only few (if any) configuration options for the CSI drivers themselves - they don't have any options in-tree. User cannot create any other CR for the operator (ensured via webhooks).
+2. User creates creates a cluster-scoped CR for the operator, typically using console.
+   We expect only few  configuration options for the CSI drivers themselves (`ManagementState`, `LogLevel`) - they don't have any options in-tree.
+   User cannot create any other CR for the operator (ensured via CR name validation).
+3. The operator install AWS EBS CSI driver.
 4. While the operator is installed in a user provider namespace, the CSI driver should be installed in a namespace pre-defined(for example - `openshift-csi-ebs-driver`) in the operator.
-3. EBS CSI driver is installed and it creates relevant storageclass that user can use to provision CSI EBS volumes.
+5. EBS CSI driver is installed and it creates relevant storageclass that user can use to provision CSI EBS volumes.
 
-When a CSI driver operator is in technical preview, we expect that the operator will be available from a `beta` channel. Moving to a `stable` channel once a driver reaches GA will require Openshift admin to manually change subscribed channel from beta to stable. At this point we expect that, operator in GA state will simply **adopt** the resources(CRs) created by beta version of the operator.
-
+When a CSI driver operator is in technical preview, we expect that the operator will be available from a `preview` channel. Moving to a `stable` channel once a driver reaches GA will require Openshift admin to manually change subscribed channel from beta to stable. At this point we expect that, operator in GA state will simply **adopt** the resources(CRs) created by beta version of the operator.
 
 #### Uninstallation of optional CSI driver operator.
 
-Removing a CSI driver should be a safe operation and only possible if no workload is using the driver and hence we propose that - driver configuration CR
+Removing a CSI driver should be only possible if no workload is using the driver and hence we propose that - driver configuration CR
 should have a finalizer which will be removed by the operator when csi-driver operator detects that no volume provisioned by this driver is in-use. Typically we expect following steps to happen in order for removal of the driver:
 
 1. User should remove any pods that are using the CSI volumes.
 2. User should delete all PV/PVCs provisioned by the CSI driver.
 3. User should remove all snapshots provisioned by the CSI driver.
-4. User deletes the CSI driver CR which in turn will cause operator to delete all resources created by the driver (daemonsets, storageclasses, deployments)
+4. User deletes the CSI driver CR which in turn will cause operator to delete all resources created by the driver (daemonsets, storageclasses, deployments).
 5. Finalizer is removed from CR and CSI driver CR is removed from api-server.
 6. User can now safely uninstall the CSI driver operator by deleting the subscription from UI or from command line.
 
@@ -127,12 +130,11 @@ should have a finalizer which will be removed by the operator when csi-driver op
 When these drivers become mandatory part of Openshift cluster, we need to install them by default. This section in general only applies to drivers which want to be enabled by default in Openshift installation.
 
 1. CVO installs cluster-storage-operator.
-2. cluster-storage-operator detects cloudprovider on which cluster is running(lets say EBS).
+2. cluster-storage-operator detects cloudprovider on which cluster is running (lets say EBS).
 3. cluster-storage-operator creates a subscription for EBS CSI driver using redhat operator source.
-4. cluster-storage-operator monitors progress of subscription and sets its own status as available when subscription is installed.
+4. cluster-storage-operator monitors progress of subscription and CR and sets its own status as available when the operator reports the driver is running via the CR.
 
 cluster-storage-operator ensures that there is always an subscription for CSI driver in given cloudprovider environment. cluster-storage-operator will also update subscribed channel for the operator when creating the subscription.
-
 
 There are pros and cons to this approach:
 
@@ -147,44 +149,80 @@ Cons:
 
 #### Upgrade from optional operator to a driver installed by default
 
-When a CSI driver is moved from optional to a mandatory one, existing installation of CSI driver operator must be **adopted** by the CVO managed operator (in above case cluster-storage-operator).
+When a CSI driver is moved from optional to installed by default, existing installation of CSI driver operator must be **adopted** by the CVO managed operator (in above case cluster-storage-operator).
 
 1. CVO installs cluster-storage-operator.
 2. cluster-storage-operator detects cloudprovider on which cluster is running(lets say EBS).
-3. cluster-storage-operator searches for existing subscription to an operator with same name in all namespaces and if found it deletes and re-creates the subscription in pre-defined namespace.
-4. At this point if there are any changes in configuration CR between previously installed versions vs version shipped with new operator, it must be reconciled.
+3. cluster-storage-operator searches for existing subscription to an operator with same name in all namespaces and if found it deletes it and re-creates the subscription in pre-defined namespace.
+4. At this point if there are any changes in configuration CR between previously installed versions vs version shipped with new operator, they are reconciled.
 
+### Release
 
-### Open questions for OLM team:
+Since operators managed by OLM are not managed ART pipeline, there are some consequences.
+
+1. CSI sidecar images, used by the operator, are part of OCP extras errata.
+   Therefore at OCP 4.x release (or shortly after), we must rebuild the operator bundle image with sidecar SHAs that were just released by OCP and respin the operator errata.
+
+   The operator will **not** be available at OCP GA date, it will be released later (few days?).
+      * When the operator is optional, it's not an issue, cusomers can use in-tree volume plugins and experiment with CSI few days later.
+      * When the operator is installed by default and an older version of the operator is available, it's not an issue.
+        OCP installation will use the old version of the operator until the new version is available.
+      * When the operator is installed by default and an older version of the operator is not available, **OCP cluster cannot be installed** until the operator errata is released.
+          * The operator and OCP erratas should be synchronized and released at the same time.
+            The operator bugs blocks OCP from release.
+            This applies only to the first release of the operator, when there is no older version to use.
+            It may not be an issue if we follow the timeline outlined below, but it's a very tight timeline!
+
+2. There is no automation to rebuild operator bundle images when operand or sidecar image change.
+   In addition we must sync dist-gits manually and create / respin erratas manually too:
+   * During development & testing, we will update the operator / operand / sidecar SHAs only few times (say once per sprint).
+   * After release, we won't release any z-streams of the operators, CSI drivers and/or SHAs of new sidecars unless absolutelly necessary (CVEs, urgent bugs).
+
+3. Since there is no CI for images that we build ourselves (without ART), all our downstream images are tested only by QA.
+
+### Open questions:
 1. How will disconnected installs work?
 
   A: This was partly answered by shawn. It is possible to use disconnected installs today via
      https://docs.openshift.com/container-platform/4.3/operators/olm-restricted-networks.html but index images should make it easier.
+     This only covers manual installation of the operator *after* cluster installation.
 
+     What about a driver being installed by default, during cluster installation?
+     What / when is going to mirror the operator & driver images?
+     The installation will time out when cluster-storage operator can't install a CSI driver via OLM.
 
-2. We need a way for a CSI driver operator to say version range of Openshift against which it is supported.
+2. When / how often are index images updated after operator release?
+   Even when we synchronize operator & OCP errata release as suggested above, clusters may not be installable until OLM sees the operator in the index image.
+
+3. When a CSI driver operator becomes installed by default and installed by cluster-storage-operator, all CI jobs must have the current version of the operator available in OLM in the cluster.
+   Currently, all 4.5 CI clusters show only 4.4 operators.
+
+Answered questions:
+
+1. We need a way for a CSI driver operator to say version range of Openshift against which it is supported.
 
   A: This is less of a problem with index images because all versions of operator is not available from same source.
 
-3. Are channel to which user is subscribed to automatically upgraded when Openshift version is bumped? For example: If we install an operator from 4.2 channel on OCP-4.2 and then upgrade to OCP-4.3, is subscription updated to use channel 4.3? Or this should be handled via `skipRange`?
+2. Are channel to which user is subscribed to automatically upgraded when Openshift version is bumped? For example: If we install an operator from 4.2 channel on OCP-4.2 and then upgrade to OCP-4.3, is subscription updated to use channel 4.3? Or this should be handled via `skipRange`?
 
-  A: Channels aren't automatically upgraded on OCP upgrade but we will be using stable and beta channel names rather than version specific channels.As
+  A: Channels aren't automatically upgraded on OCP upgrade but we will be using stable and beta channel names rather than version specific channels. As
      proposed above we expect that an operator installed from stable channel will adopt resources created by beta channel.
 
-4. Currently CVO operators can directly access cloudprovider configuration via configmap placed in `openshift-config` namespace, are we going to allow OLM operators to do the same? Do we need to do something to support CSI driver configuration?
+3. Currently CVO operators can directly access cloudprovider configuration via configmap placed in `openshift-config` namespace, are we going to allow OLM operators to do the same? Do we need to do something to support CSI driver configuration?
 
-  A: This is still an open question. Currently in 4.6 we will have cluster-storage-operator create the subscription but this is being tracked via RFE - https://issues.redhat.com/browse/RFE-664.
+  A: CSI drivers should get cloud credentials using [CredentialsRequest](https://github.com/openshift/cloud-credential-operator).
 
-5. Since most CSI operators has to be singletons,we need to stop users from installing the operator multiple times in different namespaces. Currently this is not possible.
+4. Since most CSI operators has to be singletons, we need to stop users from installing the operator multiple times in different namespaces. Currently this is not possible.
 
-  A. This is still an open question and work to address this is being tracked via https://issues.redhat.com/browse/RFE-660.
+  A. We use `AllNamespaces` install mode - an operator with this mode can be installed only once in a cluster. Still, user has possiblity to override the namespace where the operator actually runs, which complicates update from "optional" operator to "installed by default" (see Upgrade from optional operator to a driver installed by default)
 
 
 ## Timeline
 Bases on current upstream plans & assumptions.
 
 ### OCP-4.5 (Kubernetes 1.18)
-* We support installation of AWS CSI driver alongside with in-tree drivers. User can use both drivers at the same time. The default storage class is for in-treee volume plugin (unless cluster admin changes it).
+* We support installation of AWS EBS CSI driver alongside with in-tree drivers. User can use both drivers at the same time. The default storage class is for in-tree volume plugin (unless cluster admin changes it).
+  * The driver is optional, not installed by default.
 * The CR required for operator configuration will be created by the user.
 * We do not support enabling or disabling CSI migration feature gate at this point.
 
@@ -193,7 +231,10 @@ Bases on current upstream plans & assumptions.
 * All sidecars and openshift/origin should run tests with forked OCP sidecars and forked OCP driver.
 
 ### OCP-4.6 (Kubernetes 1.19)
-* Add support for Azure and Cinder CSI drivers.
+* AWS EBS driver becomes installed by default in all clusters. User can use both drivers at the same time. The default storage class is for in-tree volume plugin (unless cluster admin changes it).
+* Add support for GCE, Azure and Cinder CSI drivers.
+  * They're optional, not installed by default.
+  * Three new drivers per release are pretty ambitious.
 * We will allow users to enable or disable CSI migration. Disabling the migration should not remove the driver.
 
 #### Testing
@@ -209,12 +250,12 @@ Bases on current upstream plans & assumptions.
   * To make sure the CSI driver can sustain more than 1 hour of regular e2e tests.
 
 ### OCP-4.7 (Kubernetes 1.20)
-
-* vSphere CSI driver installation.
+* GCE, Azure and Cinder CSI drivers become installed by default (with non-default storage class).
+* vSphere CSI driver installation (as optional).
   * Current vSphere driver is not backward compatible. We expect some changes and stabilization upstream. Our gut feeling is +/- Kubernetes 1.20 timeframe.
 
 ### OCP-4.8 (Kubernetes 1.21)
 Kubernetes 1.21 is current upstream target for removal of in-tree cloud providers and their volume plugins!
 
-* CSI drivers for their in-tree counterpart will become GA and CSI volumes will become default.
+* CSI drivers for their in-tree counterparts will become GA and CSI volumes will become default.
 * CSI migration is enabled and cannot be disabled (code for corresponding in-tree volume plugins and in-tree cloud providers doesn't event exist).


### PR DESCRIPTION
Updated according to the current plan.

@jupierce @shawn-hurley @eparis @jwforres, I'd like to have your explicit approval - there are still some open items that need to be answered before!

Needles to say that while it's possible to install a CSI driver via OLM (OCS is a good example), installing OLM operators during OCP installation is complicated and I am not really convinced it's worth the effort.
