### PR TITLE
Update OWNERS to include baremetal IPI architects and team leads

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - ashcrow
   - bparees
   - brancz
+  - celebdor
   - chancez
   - cooktheryan
   - deads2k
@@ -15,20 +16,24 @@ approvers:
   - enxebre
   - eparis
   - ericavonb
+  - hardys
   - imcleod
   - ironcladlou
   - jcantrill
   - joelanford
   - josephschorr
   - jsafrane
+  - juliakreger
   - jwforres
   - jwmatthews
   - kbsingh
   - knobunc
+  - markmc
   - mfojtik
   - mrunalp
   - pmorie
   - runcom
+  - russellb
   - sdodson
   - shawn-hurley
   - sjenning
@@ -36,6 +41,7 @@ approvers:
   - soltysh
   - spadgett
   - squeed
+  - stbenjam
   - stevekuznetsov
   - sttts
   - sudhaponnaganti


### PR DESCRIPTION
This updates the OWNERS to include architects and team leads from the
baremetal IPI effort.

CC: @celebdor, @hardys, @juliakreger, @markmc, @russellb 