### PR TITLE
move open questions section lower in the template

### DIFF
--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -59,13 +59,6 @@ around the enhancement process.
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-## Open Questions [optional]
-
-This is where to call out areas of the design that require closure before deciding
-to implement the design.  For instance, 
- > 1. This requires exposing previously private resources which contain sensitive
-  information.  Can we do this? 
-
 ## Summary
 
 The `Summary` section is incredibly important for producing high quality
@@ -122,6 +115,13 @@ How will security be reviewed and by whom? How will UX be reviewed and by whom?
 Consider including folks that also work outside your immediate sub-project.
 
 ## Design Details
+
+### Open Questions [optional]
+
+This is where to call out areas of the design that require closure before deciding
+to implement the design.  For instance, 
+ > 1. This requires exposing previously private resources which contain sensitive
+  information.  Can we do this? 
 
 ### Test Plan
 


### PR DESCRIPTION
The list of open questions are likely to refer to information that
won't make sense without the context found deeper in the enhancement
proposal. Let's move the open questions list into the design details
section, so a reader will encounter them after that required context.