### PR TITLE
baremetal: clarify that optional provisioning network goals

### DIFF
--- a/enhancements/baremetal/baremetal-provisioning-optional.md
+++ b/enhancements/baremetal/baremetal-provisioning-optional.md
@@ -60,8 +60,11 @@ entirely.
 
 ### Non-Goals
 
-We do not intend to remove the static provisioning IP's at this time,
+- We do not intend to remove the static provisioning IP's at this time,
 but instead they will need to be IP's available in the external network.
+
+- As is the case for any other provisioning network decisions, this is a
+day 1 choice that we do not intend to support changing at a later time.
 
 ## Proposal
 


### PR DESCRIPTION
Explicitly state what was discussed in other forums: any decision
related to provisioning networks is not changeable later. We could
revisit it, but it would be an entirely separate set of stories.