### PR TITLE
enhancements/update: Consolidate update-related enhancements

### DIFF
--- a/enhancements/update/available-update-metadata.md
+++ b/enhancements/update/available-update-metadata.md
@@ -11,8 +11,8 @@ approvers:
   - "@sdodson"
   - "@smarterclayton"
 creation-date: 2019-11-19
-last-updated: 2020-07-21
-status: implementable
+last-updated: 2020-08-05
+status: implemented
 ---
 
 # Available-update Metadata
@@ -180,6 +180,8 @@ The YAML rendering of the old and updated type are compatible, with the only dif
 ## Implementation History
 
 * [API pull request][api-pull-request].
+* [CVO implementation][cluster-version-operator-pull-request], landed 2020-07-31.
+* Will GA with 4.6.
 
 ## Drawbacks
 
@@ -275,6 +277,7 @@ Leave the current `ClusterVersionStatus` alone and just continue to fill the now
 [cluster-version-operator-available-updates-handler]: https://github.com/openshift/cluster-version-operator/blob/751c6d0c872e05f218f01d2a9f20293b4dfcca88/pkg/cvo/cvo_test.go#L2284
 [cluster-versoin-operator-desired-copy]: https://github.com/openshift/cluster-version-operator/blob/8240a9b3711fa6938129d06ee8c6957a8f3b6464/pkg/cvo/cvo.go#L393-L421
 [cluster-version-operator-findUpdateFromConfig]: https://github.com/openshift/cluster-version-operator/blob/8240a9b3711fa6938129d06ee8c6957a8f3b6464/pkg/cvo/updatepayload.go#L294
+[cluster-version-operator-pull-request]: https://github.com/openshift/cluster-version-operator/pull/419
 [cluster-version-operator-update-lookup]: https://github.com/openshift/cluster-version-operator/blob/01adf75393b6e11d3d8c98ecfeeebd3feb998a6c/pkg/cvo/updatepayload.go#L297-L309
 [cluster-version-operator-update-translation]: https://github.com/openshift/cluster-version-operator/blob/8240a9b3711fa6938129d06ee8c6957a8f3b6464/pkg/cvo/availableupdates.go#L192-L198
 [console-channels]: https://github.com/openshift/console/pull/2935

--- a/enhancements/update/cluster-profiles.md
+++ b/enhancements/update/cluster-profiles.md
@@ -12,9 +12,10 @@ approvers:
   - "@derekwaynecarr"
   - "@smarterclayton"
 creation-date: 2020-02-04
-last-updated: 2019-02-04
+last-updated: 2020-08-05
 status: implementable
 see-also:
+  - "/enhancements/update/ibm-public-cloud-support.md"
 replaces:
 superseded-by:
 ---
@@ -100,6 +101,10 @@ will need to be created to support each variation in the node selector. This fea
 not support including/excluding sections of a manifest. In order to avoid drift and 
 maintenance burden, components may use a templating solution such as kustomize to generate
 the required manifests while keeping a single master source.
+
+## Implementation History
+
+* Teach cluster-version operator about profiles, [cvo#404](https://github.com/openshift/cluster-version-operator/pull/404), in flight.
 
 ## Alternatives
 

--- a/enhancements/update/clusteroperator-resource-handling.md
+++ b/enhancements/update/clusteroperator-resource-handling.md
@@ -9,8 +9,8 @@ approvers:
   - "@abhinavdahiya"
   - "@derekwaynecarr"
 creation-date: 2019-12-11
-last-updated: 2019-12-11
-status: implementable
+last-updated: 2020-08-05
+status: implemented
 see-also:
 replaces:
 superseded-by:
@@ -20,10 +20,10 @@ superseded-by:
 
 ## Release Signoff Checklist
 
-- [ ] Enhancement is `implementable`
-- [ ] Design details are appropriately documented from clear requirements
-- [ ] Test plan is defined
-- [ ] Graduation criteria for dev preview, tech preview, GA
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [x] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
@@ -102,8 +102,10 @@ No special consideration.
 
 ## Implementation History
 
-Major milestones in the life cycle of a proposal should be tracked in `Implementation
-History`.
+* Teach the cluster-version operator to fast-fill ClusterOperators, [cvo#318](https://github.com/openshift/cluster-version-operator/pull/318), merged 2020-04-14.
+* Bugfix for [excluded manifests](ibm-public-cloud-support.md), [cvo#370](https://github.com/openshift/cluster-version-operator/pull/370).
+* GA with 4.5 in 4.5.1.
+* Backport to 4.4 still in flight, [cvo#376](https://github.com/openshift/cluster-version-operator/pull/376).
 
 ## Drawbacks
 

--- a/enhancements/update/distribute-secondary-metadata-as-container-image.md
+++ b/enhancements/update/distribute-secondary-metadata-as-container-image.md
@@ -12,7 +12,7 @@ approvers:
   - @sdodson
 creation-date: 2020-05-07
 last-updated: 2020-05-07
-status: provision
+status: provisional
 see-also:
 -
 replaces: []

--- a/enhancements/update/ibm-public-cloud-support.md
+++ b/enhancements/update/ibm-public-cloud-support.md
@@ -15,9 +15,10 @@ reviewers:
 approvers:
   - "@derekwaynecarr"
 creation-date: 2020-02-04
-last-updated: 2020-02-04
-status: implementable
+last-updated: 2020-08-05
+status: implemented
 see-also:
+  - "/enhancements/update/cluster-profiles.md"
 replaces:
 superseded-by:
 ---
@@ -27,9 +28,9 @@ superseded-by:
 ## Release Signoff Checklist
 
 - [x] Enhancement is `implementable`
-- [ ] Design details are appropriately documented from clear requirements
+- [x] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
-- [ ] Graduation criteria for dev preview, tech preview, GA
+- [x] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
@@ -249,3 +250,10 @@ of RHCOS nodes using the same mechanisms as in self-hosted OpenShift.
 
 ### Version Skew Strategy
 
+## Implementation History
+
+* Teach cluster-version operator about the new annotation, [cvo#252](https://github.com/openshift/cluster-version-operator/pull/252), merged 2019-11-13.
+* Add the exclude annotation to the cluster-version operator manifests, [cvo#269](https://github.com/openshift/cluster-version-operator/pull/269), merged 2019-11-14.
+* Add the exclude annotation to the machine-API operator manifests, [mao#437](https://github.com/openshift/machine-api-operator/pull/437), merged 2019-11-15.
+* Many more pull requests adding exclusion annotations.
+* Feature went live in 4.3 with 51 excluded manifests in 4.3.0.


### PR DESCRIPTION
These are all related to the cluster-version operator, which is the update team.  Collect them all together in a single directory to make them easier to find.  I didn't bother leaving "there used to be an enhancement here, but it has moved to..." markers in the old locations, because I expect traffic is low, but we could do that if it turns out folks had linked the old locations and can't find the new ones.

Source for "51 excluded manifests in 4.3.0":

```console
$ oc adm release extract --to manifests quay.io/openshift-release-dev/ocp-release:4.3.0-x86_64
Extracted release payload from digest sha256:3a516480dfd68e0f87f702b4d7bdd6f6a0acfdac5cd2e9767b838ceede34d70d created at 2020-01-22T02:05:15Z
$ grep -hr exclude.release.openshift.io manifests | sort | uniq -c
     51     exclude.release.openshift.io/internal-openshift-hosted: "true"
```

/assign @sdodson