### PR TITLE
network: add port registry

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -1,0 +1,126 @@
+---
+title: Host Port Registry
+authors:
+  - "@squeed"
+reviewers:
+  - "@danw"
+  - "@jsafrane"
+  - "@wking"
+approvers:
+  - "@russelb"
+creation-date: 2020-08-26 
+last-updated: 2020-08-26
+status: informational
+---
+
+# Host Port Registry
+
+OpenShift has a number of host-level services that listen on a socket. Since they
+are not isolated by network namespace, they can conflict if both listen on the same
+port.
+
+This document serves as the authoritative list of port assignments.
+
+## Background
+
+Ports 9000-9999 are available for general use by system services. We require that
+customers open this range [and several others](https://github.com/openshift/openshift-docs/blob/master/modules/installation-network-user-infra.adoc)
+between nodes.
+
+The user-facing documentation, informed by the installer's
+terraform templates, is the authoritative source for usable port ranges.
+
+These ports are used by certain services that, for whatever reason, must run
+in the host network (or use host-port forwarding).
+
+The Kubernetes scheduler is aware of host ports, and will fail to schedule pods
+on a node where there would be a port conflict.
+
+### Localhost
+
+Separately, it is a common pattern for a pod to have one or more processes only
+listening on localhost. Since all HostNetwork pods share a network namespace,
+coordination is also required in this case.
+
+## Requirements
+
+All processes that wish to listen on a host port MUST
+
+- Have an entry in the table below
+- be in a [documented range](https://github.com/openshift/openshift-docs/blob/master/modules/installation-network-user-infra.adoc), 
+  if they are intended to be reachable 
+- declare that port in their `Pod.Spec`
+
+Localhost-only ports SHOULD be outside of this range, to leave room.
+
+# Port Registry
+
+## External
+
+Ports are assumed to be used on all nodes in all clusters unless otherwise specified.
+
+
+### TCP
+
+| Port  | Process   | Owning Team | Since | Notes |
+|-------|-----------|-------------|-------|-------|
+| 2379  | etcd      | etcd || masters only |
+| 2380  | etcd      | etcd || masters only |
+| 6443  | kube-apiserver | apiserver || masters only |
+| 9001  | machine-config-daemon oauth proxy | node || metrics |
+| 9100  | node-exporter | monitoring || metrics |
+| 9101  | openshift-sdn kube-rbac-proxy | sdn || metrics, openshift-sdn only |
+| 9102  | ovn-kubernetes master kube-rbac-proxy | sdn || metrics, masters only, ovn-kubernetes only |
+| 9103  | ovn-kubernetes node kube-rbac-proxy | sdn || metrics |
+| 9537  | crio      | node || metrics |
+| 9641  | ovn-kubernetes northd | sdn | 4.3 | masters only, ovn-kubernetes only |
+| 9642  | ovn-kubernetes southd | sdn | 4.3 | masters only, ovn-kubernetes only |
+| 9643  | ovn-kubernetes northd | sdn | 4.3 | masters only, ovn-kubernetes only |
+| 9644  | ovn-kubernetes southd | sdn | 4.3 | masters only, ovn-kubernetes only |
+| 9978  | etcd      | etcd || metrics, masters only |
+| 9979  | etcd      | etcd || ?, masters only |
+| 10010 | crio | node || stream port|
+| 10250 | kubelet | node || kubelet api |
+| 10251 | kube-scheduler | apiserver || healthz, masters only |
+| 10256 | openshift-sdn | sdn || healthz |
+| 10257 | kube-controller-manager | apiserver || metrics, healthz, masters only |
+| 10259 | kube-scheduler | apiserver || metrics, masters only |
+| 10357 | cluster-policy-controller | apiserver || healthz, masters only |
+| 17697 | kube-apiserver | apiserver || ?, masters only |
+| 22623 | machine-config-server | node || masters only |
+| 22624 | machine-config-server | node || masters only |
+| 29101 | openshift-sdn | sdn || metrics |
+
+
+### UDP
+
+| Port  | Process   | Owning Team | Since | Notes |
+|-------|-----------|-------|-------|-------|
+| 4789  | openshift-sdn vxlan | sdn | 3.0 | openshift-sdn only |
+| 6081  | ovn-kubernetes geneve | sdn | 4.3 | ovn-kubernetes only |
+
+
+## Localhost-only
+| Port  | Process   | Owning Team | Since | Notes |
+|-------|-----------|-------------|-------|-------|
+| 4180  | machine-config-daemon oauth-proxy | node ||
+| 8797  | machine-config-daemon | node |4.0| metrics |
+| 9977  | etcd | etcd || ? |
+| 10248 | kubelet | node || healthz |
+| 29102 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
+| 29103 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
+
+
+## Previously allocated
+
+If a feature is completely removed, (not just deprecated), then any now-free
+ports should be noted here, along with the version in which they were removed.
+
+
+## Future 
+
+We can enforce this in an automated fashion in the future. We should write tests
+that ensure
+
+- pods opening host ports declare those ports in their Pod.Spec (host-level processes excluded)
+- pods that declare host ports are in the port registry. The registry will need to be machine-readable


### PR DESCRIPTION
This document isn't exactly an enhancement. Rather it captures host ports, so developers know which ones they can use.

I'm not sure if there's a better place for it to live. An equivalent PR on the origin repository never got traction.