### PR TITLE
use 'share' instead of 'projectedResourceName' in csi driver yaml examples

### DIFF
--- a/enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
+++ b/enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
@@ -23,7 +23,7 @@ replaces:
   
 creation-date: 2020-03-17
 
-last-updated: 2020-08-03
+last-updated: 2020-09-01
 
 <!-- status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced -->
 status: implementable
@@ -243,7 +243,7 @@ spec:
         csi:
           driver: projectedresources.storage.openshift.io
           volumeAttributes:
-             projectedResourceName: the-projected-resource
+             share: the-projected-resource
 
 ```
 
@@ -319,7 +319,7 @@ spec:
         csi:
           driver: projectedresources.storage.openshift.io
           volumeAttributes:
-             projectedResourceName: the-projected-resource
+             share: the-projected-resource
 
 ```
  


### PR DESCRIPTION
the use of `share` as the `volumeAttributes` key was previously introduced but there were a couple of subsequent spots where the old `projectedResourceName` was still used

/assign @adambkaplan 