### PR TITLE
register the metrics port for the baremetal-operator

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -90,6 +90,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 22623 | machine-config-server | node || masters only |
 | 22624 | machine-config-server | node || masters only |
 | 29101 | openshift-sdn | sdn || metrics |
+| 60000 | baremetal-operator | kni || metrics, 4.6+, control plane only |
 
 
 ### UDP


### PR DESCRIPTION
This is the port number the MAO uses when configuring the baremetal-operator in 4.6.

The pod uses host networking, and only runs on the control plane. Maybe that means this value needs to be part of a different list?