### PR TITLE
Add weekly newsletters to the repository

### DIFF
--- a/this-week/2020-08-28.md
+++ b/this-week/2020-08-28.md
@@ -1,0 +1,107 @@
+# This Week in Enhancements - 2020-08-28
+
+Hello, everyone!
+
+This is the first weekly edition of a new experiment. We want to highlight the
+great work happening in the OpenShift enhancements repository in a newsletter
+format.  We hope to encourage participation in enhancement discussions, but
+also to help more people get a feel for new things happening in areas you may
+not normally pay attention to.
+
+And now, to the first edition …
+
+## Merged Enhancements
+
+<PR ID>: (reviews this week / total reviews) summary
+
+3 Enhancements have merged in the last week.
+
+[104](https://github.com/openshift/enhancements/pull/104): (1/11) add tech preview guidelines 
+
+This is an older pull request from Ben Parees that starts to capture things
+engineers need to know when implementing a feature that is Tech Preview.  It
+was resurrected and merged this week.  Ongoing feedback is encouraged via
+follow-up pull requests.
+
+[405](https://github.com/openshift/enhancements/pull/405): (0/41) Add an enhancement for adding a VRF CNI 
+
+“To allow isolation, and make it possible to have overlaps between the CIDRs of
+secondary networks (and between them and the pod's address space), we want to
+introduce a VRF meta cni plugin. Taking advantage of the chaining mechanism, it
+can be used to assign a secondary interface to a custom VRF.”
+
+[451](https://github.com/openshift/enhancements/pull/451): (1/1) default-ingress-cert-configmap: implemented 
+
+This was more of a housekeeping update.  Take this as a reminder to think about
+enhancements written over the last year.  Do any need to be updated to reflect
+the current state?  Should the enhancement status be updated to “implemented”?
+Did the design details change throughout implementation and code review?
+
+## New Enhancements
+
+10 new enhancements were posted this week.
+
+[449](https://github.com/openshift/enhancements/pull/449): (0/0) Add Tunable Router Buffer Sizes EP 
+
+[450](https://github.com/openshift/enhancements/pull/450): (3/3) Adds Contour Operator Enhancement Proposal 
+
+[452](https://github.com/openshift/enhancements/pull/452): (3/3) Add egress router EP 
+
+[453](https://github.com/openshift/enhancements/pull/453): (22/22) WIP: network: Add a high level BGP use cases overview 
+
+[454](https://github.com/openshift/enhancements/pull/454): (44/44) Enhancement for User Space Pod Interface and API Library 
+
+This enhancement received the highest number of reviews in the last week!
+
+[455](https://github.com/openshift/enhancements/pull/455): (7/7) network: add port registry 
+
+[456](https://github.com/openshift/enhancements/pull/456): (1/1) Adds ExternalDNS Operator Enhancement Proposal 
+
+[457](https://github.com/openshift/enhancements/pull/457): (2/2) Enhancement: Select logs By pod label 
+
+[458](https://github.com/openshift/enhancements/pull/458): (0/0) Whereabouts IPAM CNI Sticky IP Addresses Enhancement 
+
+[459](https://github.com/openshift/enhancements/pull/459): (22/22) installer: early write up for SLB managed API lbs 
+
+## Other Highlights
+
+In addition to listing merged and newly posted pull requests, we would like to
+highlight a few enhancements with a bit more commentary.
+
+
+[436](https://github.com/openshift/enhancements/pull/436): enhancement proposal for Packet IPI
+
+OpenShift has grown to include IPI support for multiple platforms.  What’s
+really interesting about this proposal is that it comes from the Packet.net
+team directly.  They wrote this enhancement proposal as well as the first PR
+against the installer and intend to do all of the work necessary to complete
+IPI support for their platform.  It is exciting to see this level of engagement
+from a provider!
+
+[450](https://github.com/openshift/enhancements/pull/450): Adds Contour Operator Enhancement Proposal
+
+A proposal to add an operator for the Contour Project is interesting on its
+own.  It also includes a really good open question: should the team focus on
+building a community operator first that is then used as the basis for the
+OpenShift specific operator?  This practice is not nearly as common as you
+might hope.  The Network Edge team has struggled to find any examples beyond
+the monitoring operator.  Do you have ideas for how best to approach this?
+Weigh in on the enhancement with your thoughts!
+
+[423](https://github.com/openshift/enhancements/pull/423): Implement OpenStack Cloud Controller Manager support
+
+We need to move from the in-tree OpenStack cloud provider to an external
+implementation of the OpenStack cloud controller manager.  This is the first
+platform where we’re moving to an out-of-tree cloud provider, so in addition to
+the OpenStack support, it raises questions about how we handle out-of-tree
+providers in general.  This enhancement includes a proposal to implement that
+general support.  It’s great that the OpenStack team is stepping up to
+implement this, but an open question on the enhancement asks who should own
+this longer term.
+
+
+That’s all for this week.  Feedback welcome!
+
+-- 
+Russell Bryant
+Doug Hellmann

--- a/this-week/2020-09-04.md
+++ b/this-week/2020-09-04.md
@@ -1,0 +1,128 @@
+# This Week in Enhancements - 2020-09-04
+
+This is the second weekly edition of this experiment to provide a weekly digest
+newsletter of activity in the OpenShift enhancements repository.
+
+As a request to enhancement authors, please try to capture the area of your
+enhancement in the summary line.  That will make it easier to determine what
+the enhancement is related to when seeing it in a list of 1-liner summaries
+either in this list, via email subjects, or when looking at the list of open PRs.
+
+## Merged Enhancements
+
+*<PR ID>: (comments this week / total comments) summary*
+
+There were 8 Merged pull requests:
+	      
+[259](https://github.com/openshift/enhancements/pull/259): (3/5) Add Machine Config Support in NTO proposal.
+
+	      This enhancement proposes adding the ability for admins to target 
+          MachineConfigPools and create MachineConfigs through the Node Tuning 
+          Operator.  With this enhancement we can take another step towards 
+          full support for tuned profiles that need `[bootloader]`
+          support on RHCOS.
+
+This feature was actually implemented several months ago, but the enhancement
+was never merged.  It was updated to reflect that it was already implemented
+and then merged this week.
+
+[356](https://github.com/openshift/enhancements/pull/356): (0/59) network: on premise Service load balancers
+
+	      OpenShift does not currently support Services of type=LoadBalancer on
+	      bare metal or other on premise infrastructure environments. This
+	      enhancement proposes a way forward, which is to adopt MetalLB.
+	      
+	      The document explores some high level requirements, discusses some
+	      alternatives considered, and maps out how we would get to work on
+	      this through technical due diligence, upstream community engagement,
+	      and careful planning of OpenShift integration with a new operator.
+	      
+	      There is not currently a target for when this would be fully
+	      supported, as this is a proposed enhancement on a direction to take.
+	      More extensive technical due diligence, development, and testing will
+	      help define the roadmap over time.
+
+[394](https://github.com/openshift/enhancements/pull/394): (0/44) Discuss host network configuration interfaces
+
+	      This change introduces a new enhancement that discusses host network
+	      configuration. It is different from the typical enhancement in that
+	      its goal is informational and to discuss what is already present in
+	      this area. It also provides references to other related works in
+	      progress.
+	      
+	      I wrote this first for myself and propose it here in hopes that it
+	      may help others. I find that this context is important and helpful to
+	      understand when discussing or reviewing enhancements for a specific
+	      feature related to host network configuration.
+	      
+	      I imagine this as a living document that should get updated as key
+	      improvements are made to how we manage host network configuration for
+	      OpenShift.
+          
+[455](https://github.com/openshift/enhancements/pull/455): (3/10) network: add port registry
+
+	      This document isn't exactly an enhancement. Rather it captures host
+	      ports, so developers know which ones they can use.
+	               
+[457](https://github.com/openshift/enhancements/pull/457): (1/3) Enhancment: Select logs By pod label
+
+	      Add an input selector to the ClusterLogForwarder (CLF) to forward
+	      application logs from pods identified by labels.
+	      
+	      Kubernetes has two ways to identify pods: namespaces and labels. The
+	      CLF already has an input selector for namespaces, this enhancement will
+	      add a selector for labels.
+          
+### Minor Updates that Merged
+
+[393](https://github.com/openshift/enhancements/pull/393): (2/2) cleanup assisted installer bare metal validations enhancement
+[294](https://github.com/openshift/enhancements/pull/294): (0/0) ingress/logging-api: Update status to "implemented"
+[285](https://github.com/openshift/enhancements/pull/285): (1/1) host-level-openvswitch: tweaks, enhancements
+
+## New Enhancements
+
+There were 10 New pull requests:
+
+[460](https://github.com/openshift/enhancements/pull/460): (0/0) Add empty-requests-policy enhancement
+[461](https://github.com/openshift/enhancements/pull/461): (0/0) Add aws-elb-idle-timeout enhancement
+[462](https://github.com/openshift/enhancements/pull/462): (3/3) Add client-tls enhancement
+[463](https://github.com/openshift/enhancements/pull/463): (2/2) [WIP] Describing steps to support out-of-tree providers
+[464](https://github.com/openshift/enhancements/pull/464): (1/1) use 'share' instead of 'projectedResourceName' in csi driver yaml examples
+[465](https://github.com/openshift/enhancements/pull/465): (12/12) Insights operator up to date gathering
+
+This one generated the most comments on a new enhancement this week.  The
+enhancement proposes a specific method to decouple the Insights Operator from
+OpenShift releases, using examples of a drawn out backport process as an
+example for why this is desirable.  The discussion has highlighted that
+becoming an OLM operator that could be installed by default could be a more
+general solution to the problem raised, though this would take significant
+effort to accomplish.  Ongoing improvements to the backport process and
+timeline could also reduce the pressure that led to the proposal.
+
+[466](https://github.com/openshift/enhancements/pull/466): (3/3) [WIP] Enhancement: Internationalization for console
+[467](https://github.com/openshift/enhancements/pull/467): (3/3) [WIP] Add MCO Flattened Ignition proposal
+[468](https://github.com/openshift/enhancements/pull/468): (5/5) Add dedicated instances proposal
+[469](https://github.com/openshift/enhancements/pull/469): (3/3) enhancement: console user settings
+
+## Closed Enhancements
+
+There was 1 Closed pull request:
+
+[287](https://github.com/openshift/enhancements/pull/287): (0/9) Ingress proposal: path rewriting
+
+## Top 5 Most Active Pull Requests
+
+The following PRs received the highest number of comments in the last week:
+
+[429](https://github.com/openshift/enhancements/pull/429): (29/29) Enforce label scheme
+[448](https://github.com/openshift/enhancements/pull/448): (19/41) Proposal to enable JSON data processing
+[363](https://github.com/openshift/enhancements/pull/363): (17/73) Enhancement for adding upgrade preflight checks for operators
+[399](https://github.com/openshift/enhancements/pull/399): (17/55) [machine-config-operator/baremetal] MCO declarative network configuration
+[423](https://github.com/openshift/enhancements/pull/423): (17/24) Implement OpenStack Cloud Controller Manager support
+
+That's it for this week.
+
+Thanks for reading,
+
+Russell Bryant
+Doug Hellmann

--- a/this-week/2020-09-11.md
+++ b/this-week/2020-09-11.md
@@ -1,0 +1,83 @@
+# This Week in Enhancements - 2020-09-11
+
+This is the third weekly edition of this experiment to provide a weekly digest
+newsletter of activity in the OpenShift enhancements repository.
+
+## Merged Enhancements
+
+*<PR ID>: (reviews this week / total reviews) summary*
+
+There were 4 Merged pull requests:
+
+[297](https://github.com/openshift/enhancements/pull/297): (4/14) Template: add specific guidance in upgrade/downgrade section
+
+	      Capture some more specific guidance on upgrade/downgrade expectations
+	      to help authors think through their scrnarios.
+	      
+	      In https://bugzilla.redhat.com/1794360 we see an example of debate
+	      around our expectations for handling downgrades and rollbacks. The
+	      conclusions there are good examples of the kind of information that
+	      is useful to add to the template.
+
+[399](https://github.com/openshift/enhancements/pull/399): (2/57) [machine-config-operator/baremetal] MCO declarative network configuration
+
+	      Enhancement proposal to extend MCO for declaritive network
+	      configuration.
+
+This is a very interesting enhancement that has had a long discussion.
+[399](https://github.com/openshift/enhancements/pull/399) is a continuation of
+[161](https://github.com/openshift/enhancements/pull/161), which was originally
+filed in December of 2019.
+
+The enhancement addresses how we can provide a declarative configuration
+interface for the network configuration of RHCOS hosts in a way that is
+compatible with our existing OpenShift architecture.  Configuring network
+interfaces on Linux is far from new, but how we model and expose it in
+OpenShift is not trivial.  See the [host network
+configuration](https://github.com/openshift/enhancements/blob/master/enhancements/host-network-configuration.md)
+document for a higher level discussion of this problem space in OpenShift.
+
+The original proposal was to adopt
+[kubernetes-nmstate](https://github.com/nmstate/kubernetes-nmstate) and
+[nmstate](https://github.com/nmstate/nmstate) to present host network
+configuration through the Kubernetes API and apply changes as needed.  This
+model seemed to be working well as a generally useful add-on for Kubernetes
+cluster.
+
+The design review process helped highlight an important architectural conflict.
+We desire to have host configuration owned by the Machine Config Operator
+(MCO).  Introducing `kubernetes-nmstate` would leave us with another component
+managing a subset of host configuration completely outside the view of the MCO,
+resulting in potential conflicts that we have no way to resolve.
+
+Over several months, engineers collaborated to explore different alternative
+approaches before settling on one that still provides the API features we
+desire, but also fits well with the MCO.  While different approaches of deep
+integration were considered, the final approach has the components peacefully
+co-exist with known and defined interactions between them.
+
+### Minor Merged Updates
+
+[464](https://github.com/openshift/enhancements/pull/464): (0/1) use 'share' instead of 'projectedResourceName' in csi driver yaml examples
+[474](https://github.com/openshift/enhancements/pull/474): (0/0) Update OWNERS
+
+
+## Closed Enhancements
+
+There were 0 Closed pull requests.
+
+
+## New Enhancements
+
+*<PR ID>: (reviews this week / total reviews) summary*
+
+There were 4 New pull requests:
+
+[470](https://github.com/openshift/enhancements/pull/470): (1/1) register the metrics port for the baremetal-operator
+[471](https://github.com/openshift/enhancements/pull/471): (2/2) Downstream Operator SDK
+[472](https://github.com/openshift/enhancements/pull/472): (0/0) host-port-registry: Use "control plane" term
+[473](https://github.com/openshift/enhancements/pull/473): (1/1) Enhancement: Enable IPsec support in OVNKubernetes
+
+-- 
+Russell Bryant
+Doug Hellmann

--- a/this-week/2020-09-18.md
+++ b/this-week/2020-09-18.md
@@ -1,0 +1,91 @@
+# This Week in Enhancements - 2020-09-18
+
+This is the 4th edition of this experimental newsletter.  Feedback is welcome.  Have you found this useful?  Do you have suggestions for how to make it more useful?  Should we ensure it continues?  Let us know.
+
+To find past editions, you can check out [PR #476](https://github.com/openshift/enhancements/pull/476) which proposes putting them into the enhancements repository.
+
+## Merged Enhancements
+
+*<PR ID>: (activity this week / total activity) summary*
+
+There were 4 Merged pull requests:
+
+[360](https://github.com/openshift/enhancements/pull/360): (1/96) Quick Starts for Console
+
+	      Introducing the Workflow Guides enhancement for the OpenShift
+	      Console. The approach is different then the suggested Guided Tours.
+	      Main difference is that the Guides are not hosted by the OpenShift
+	      platform, but just linked to a GitHub repository. By utilising GitHubs
+	      markdown, guide creators will have a proper tool for creating a step
+	      by step guide for different area of interests (operators, workloads,
+	      ...).
+	      
+	      Stories:
+	      - https://issues.redhat.com/browse/CONSOLE-2255
+	      - https://issues.redhat.com/browse/CONSOLE-2232
+	      - https://issues.redhat.com/browse/SRVLS-262
+	      
+	      @openshift/team-ux-review @spadgett @alimobrem
+
+	      
+### Minor Merged Updates
+
+[470](https://github.com/openshift/enhancements/pull/470): (1/3) register the metrics port for the baremetal-operator
+[472](https://github.com/openshift/enhancements/pull/472): (0/0) host-port-registry: Use "control plane" term
+[481](https://github.com/openshift/enhancements/pull/481): (1/1) Update rebase doc to reflect relevance only for 4.5 and below
+
+
+## Closed Enhancements
+
+There were 0 Closed pull requests.
+
+
+## New Enhancements
+
+*<PR ID>: (activity this week / total activity) summary*
+
+There were 7 New pull requests:
+
+[475](https://github.com/openshift/enhancements/pull/475): (0/0) enhancements/update/update-blocker-lifecycle: Propose a new enhancement
+[476](https://github.com/openshift/enhancements/pull/476): (0/0) Add weekly newsletters to the repository
+[477](https://github.com/openshift/enhancements/pull/477): (0/0) enhancements/update/manifest-install-levels: Propose a new enhancement
+[478](https://github.com/openshift/enhancements/pull/478): (2/2) add a tool to report on activity in this repository
+[479](https://github.com/openshift/enhancements/pull/479): (1/1) Add CSI liveness probe port
+[480](https://github.com/openshift/enhancements/pull/480): (32/32) [wip] enhancements/etcd: support assisted install
+[482](https://github.com/openshift/enhancements/pull/482): (0/0) Add single-node-developer Cluster Profile
+
+## Active Enhancements
+
+*<PR ID>: (activity this week / total activity) summary*
+
+There were 19 Active pull requests:
+
+[473](https://github.com/openshift/enhancements/pull/473): (124/125) Enhancement: Enable IPsec support in OVNKubernetes
+[463](https://github.com/openshift/enhancements/pull/463): (55/83) Describing steps to support out-of-tree providers
+
+The migration of cloud provider implementations to separate repositories managed individually has been a long-standing issue. This enhancement explains the support plan for the OpenShift versions of those providers, to align with the upstream approach.
+
+[471](https://github.com/openshift/enhancements/pull/471): (37/44) enhancement: Downstream Operator SDK
+[452](https://github.com/openshift/enhancements/pull/452): (26/34) Add egress router EP
+[441](https://github.com/openshift/enhancements/pull/441): (22/61) enhancement: dynamic plugins for console
+[466](https://github.com/openshift/enhancements/pull/466): (18/31) [WIP] Enhancement: Internationalization for console
+[454](https://github.com/openshift/enhancements/pull/454): (12/126) Enhancement for User Space Pod Interface and API Library
+[429](https://github.com/openshift/enhancements/pull/429): (8/66) Enforce label scheme
+[458](https://github.com/openshift/enhancements/pull/458): (7/8) Whereabouts IPAM CNI Sticky IP Addresses Enhancement
+[146](https://github.com/openshift/enhancements/pull/146): (7/65) openstack: Add Baremetal Compute Nodes RFE
+[389](https://github.com/openshift/enhancements/pull/389): (6/131) Subscription Injection Operator
+[465](https://github.com/openshift/enhancements/pull/465): (6/35) Insights operator up to date gathering
+[417](https://github.com/openshift/enhancements/pull/417): (6/70) Add enhancement: IPI kubevirt provider
+[419](https://github.com/openshift/enhancements/pull/419): (4/85) Enhancement for adding a manifest annotation for object removal
+[430](https://github.com/openshift/enhancements/pull/430): (4/61) Proposal for networkpolicy for multus interface (i.e. net-attach-def)
+[369](https://github.com/openshift/enhancements/pull/369): (4/21) scheduling: Add new pod pod priority class
+[411](https://github.com/openshift/enhancements/pull/411): (2/17) run the Assisted Installer on-premise as opposed to utilizing a cloud service
+
+This enhancement builds on the work done previously for the [connected-assisted-installer](https://github.com/openshift/enhancements/blob/master/enhancements/installer/connected-assisted-installer.md) to support running the workflow assistant in a user's data center, to avoid relying on cloud.redhat.com. This is the next step towards a completely disconnected version of the service and is part of the process of unifying the approach for bare metal deployments of OCP.
+
+[448](https://github.com/openshift/enhancements/pull/448): (2/44) Proposal to enable JSON data processing
+[438](https://github.com/openshift/enhancements/pull/438): (2/13) Add ingress fault detection proposal
+
+-- 
+Doug Hellmann
+Russell Bryant

--- a/this-week/README.md
+++ b/this-week/README.md
@@ -1,0 +1,9 @@
+# This Week in Enhancements
+
+An experiment to produce a weekly newsletter highlighting the activity that has
+occurred in the OpenShift enhancements repository.
+
+Goals:
+* Make it easy to keep up with activity
+* Encourage participation
+* Encourage people to read about new things they may not have otherwise read


### PR DESCRIPTION
Doug Hellmann (@dhellmann) and I have started experimenting with a
weekly newsletter digest of activity in the OpenShift enhancements
repository.  This commit includes the editions from the first few weeks
we've tried it.

The bulk of the structure of the newsletter is generated by a report
tool that pulls data from the Github API.  We're still iterating on the
details of the data collected and its output, but the tool will come in
a future PR to this repository.

Adding these directly to github will make them easier to discover and
refer back to than only having them in a mailing list archive or
something similar.