### PR TITLE
Add CSI liveness probe port

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -108,6 +108,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 8797  | machine-config-daemon | node |4.0| metrics |
 | 9977  | etcd | etcd || ? |
 | 10248 | kubelet | node || healthz |
+| 10300 | various CSI drivers | storage | 4.6 | healthz |
 | 29102 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 | 29103 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 


### PR DESCRIPTION
AWS EBS and oVirt CSI drivers export liveness probe / healthz port on all nodes. Choosing 10300 randomly (unused by IANA). In the future, more CSI drivers will reuse the port on corresponding clouds.

See bug https://bugzilla.redhat.com/show_bug.cgi?id=1879406 for a bit of context. Optimistically expecting it's going to be fixed in 4.6, it's just a number in two yaml files.