### PR TITLE
Allocate 10301 for CSI too

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -109,6 +109,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9977  | etcd | etcd || ? |
 | 10248 | kubelet | node || healthz |
 | 10300 | various CSI drivers | storage | 4.6 | healthz |
+| 10301 | various CSI drivers | storage | 4.6 | healthz |
 | 29102 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 | 29103 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 


### PR DESCRIPTION
Some CSI drivers (AWS EBS, oVirt) actually need two ports for their liveness probes, as both control-plane and node-level pods run with `hostNetwork: true`.