### PR TITLE
reformat summaries in newsletter

### DIFF
--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -112,7 +112,6 @@ func GetSummary(pr int) (summary string, err error) {
 	}
 	summary = fmt.Sprintf("(no '## Summary' section found in %s)", filenames[0])
 	fileRef := fmt.Sprintf("%s:%s", prRef(pr), filenames[0])
-	fmt.Fprintf(os.Stderr, "looking for summary in %s\n", fileRef)
 	content, err := getFileContents(fileRef)
 	if err != nil {
 		return summary, errors.Wrap(err, fmt.Sprintf("could not get content of %s", fileRef))

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,6 @@ module github.com/openshift/enhancements/tools
 go 1.14
 
 require (
-	github.com/eidolon/wordwrap v0.0.0-20161011182207-e0f54129b8bb
 	github.com/google/go-github/v32 v32.1.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,6 +1,4 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/eidolon/wordwrap v0.0.0-20161011182207-e0f54129b8bb h1:ioQwBmKdOCpMVS/bDaESqNWXIE/aw4+gsVtysCGMWZ4=
-github.com/eidolon/wordwrap v0.0.0-20161011182207-e0f54129b8bb/go.mod h1:ZAPs+OyRzeVJFGvXVDVffgCzQfjg3qU9Ig8G/MU3zZ4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/tools/report/main.go
+++ b/tools/report/main.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eidolon/wordwrap"
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 
@@ -18,8 +17,6 @@ import (
 	"github.com/openshift/enhancements/tools/enhancements"
 	"github.com/openshift/enhancements/tools/stats"
 )
-
-var wrapper = wordwrap.Wrapper(70, false)
 
 // fileExists checks if a file exists and is not a directory before we
 // try using it to prevent further errors.
@@ -37,16 +34,22 @@ func handleError(msg string) {
 }
 
 func formatDescription(text string, indent string) string {
-	paras := strings.SplitN(text, "\n", -1)
-	wrappedParas := []string{}
+	paras := strings.SplitN(text, "\n\n", -1)
+
+	unwrappedParas := []string{}
+
 	for _, p := range paras {
-		wrappedParas = append(wrappedParas, wrapper(p))
+		unwrapped := strings.ReplaceAll(p, "\n", " ")
+		quoted := fmt.Sprintf("%s> %s", indent, unwrapped)
+		unwrappedParas = append(unwrappedParas, quoted)
 	}
-	wrappedText := strings.Join(wrappedParas, "\n")
-	return wordwrap.Indent(wrappedText, indent, true)
+
+	joinOn := fmt.Sprintf("\n%s>\n", indent)
+
+	return strings.Join(unwrappedParas, joinOn)
 }
 
-const descriptionIndent = "\t      "
+const descriptionIndent = "  "
 
 func showPRs(name string, prds []*stats.PullRequestDetails, withDescription bool) {
 	fmt.Printf("\n## %s Enhancements\n", name)


### PR DESCRIPTION
Use block quote formatting instead of literal text so that the markdown we
extract from the summaries of enhancements render correctly to HTML with
automatic paragraph wrapping.

/cc @russellb

https://hackmd.io/csI8DILoSWG2dY43dhWyjQ shows an example of the new output.