### PR TITLE
Update standalone kube-proxy ports

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -70,7 +70,9 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9001  | machine-config-daemon oauth proxy | node || metrics |
 | 9100  | node-exporter | monitoring || metrics |
 | 9101  | openshift-sdn kube-rbac-proxy | sdn || metrics, openshift-sdn only |
+| 9101  | kube-proxy | sdn || metrics, third-party network plugins only, deprecated |
 | 9102  | ovn-kubernetes master kube-rbac-proxy | sdn || metrics, control plane only, ovn-kubernetes only |
+| 9102  | kube-proxy | sdn | 4.7 | metrics, third-party network plugins only |
 | 9103  | ovn-kubernetes node kube-rbac-proxy | sdn || metrics |
 | 9537  | crio      | node || metrics |
 | 9641  | ovn-kubernetes northd | sdn | 4.3 | control plane only, ovn-kubernetes only |
@@ -82,7 +84,9 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 10010 | crio | node || stream port|
 | 10250 | kubelet | node || kubelet api |
 | 10251 | kube-scheduler | apiserver || healthz, control plane only |
-| 10256 | openshift-sdn | sdn || healthz |
+| 10255 | kube-proxy | sdn | 4.7 | healthz, third-party network plugins only |
+| 10256 | openshift-sdn | sdn || healthz, openshift-sdn only |
+| 10256 | kube-proxy | sdn || healthz, third-party network plugins only, deprecated |
 | 10257 | kube-controller-manager | apiserver || metrics, healthz, control plane only |
 | 10259 | kube-scheduler | apiserver || metrics, control plane only |
 | 10357 | cluster-policy-controller | apiserver || healthz, control plane only |


### PR DESCRIPTION
https://github.com/openshift/cluster-network-operator/pull/820 changed the standalone kube-proxy metrics and healthz ports so as to allow running openshift-sdn with a standalone kube-proxy for testing purposes.

Previously, kube-proxy used the same metrics and healthz ports as openshift-sdn.
As of 4.7, it uses the same metrics port as ovn-kubernetes, and a new healthz port. (ovn-kube has no healthz port).

/assign @russellb 