### PR TITLE
tools:  improve formatting of weekly report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swo
 *.swp
 .idea/*
+tools/bin

--- a/tools/.golangci.yml
+++ b/tools/.golangci.yml
@@ -1,0 +1,32 @@
+run:
+  timeout: "5m"
+
+linters:
+  disable-all: true
+  enable: [
+    "govet",
+    "goimports",
+    "gofmt",
+    "staticcheck",
+    "deadcode",
+    "dupl",
+    "errcheck",
+    "structcheck",
+    "unparam",
+    "unused",
+    "varcheck",
+  ]
+
+linters-settings:
+  goimports:
+    local-prefixes: "github.com/openshift/enhancements/tools"
+  govet:
+    check-shadowing: false
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-rules:
+   - linters:
+     - staticcheck
+     text: "SA1019:"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,13 @@
+ifeq (/,${HOME})
+GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache/
+else
+GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint
+endif
+
+# Run go lint against code
+.PHONY: lint
+lint: bin/golangci-lint
+	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) ./bin/golangci-lint run --exclude=G101
+
+bin/golangci-lint:
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.31.0

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -123,6 +123,8 @@ func GetGroup(pr int) (filename string, err error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not determine the list of modified files")
 	}
+	// First look for an actual enhancement document...
+	// FIXME: What if we find more than one?
 	for _, name := range filenames {
 		if strings.HasPrefix(name, "enhancements/") {
 			parts := strings.Split(name, "/")
@@ -132,7 +134,17 @@ func GetGroup(pr int) (filename string, err error) {
 			return "general", nil
 		}
 	}
-	return "", fmt.Errorf("could not find an enhancement file for PR %d", pr)
+	// If there was no enhancement, take the root directory of the
+	// first file that has a directory.
+	for _, name := range filenames {
+		if strings.Contains(name, "/") {
+			parts := strings.Split(name, "/")
+			return parts[0], nil
+		}
+	}
+	// If there was no directory, assume a "general" change like
+	// OWNERS file.
+	return "general", nil
 }
 
 // GetSummary reads the files being changed in the pull request to

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -100,21 +100,6 @@ func extractSummary(body string) string {
 	return b.String()
 }
 
-// getEnhancementFilename returns the filename of the enhancement
-// document modified by the pull request
-func getEnhancementFilename(pr int) (filename string, err error) {
-	filenames, err := getModifiedFiles(pr)
-	if err != nil {
-		return "", errors.Wrap(err, "could not determine the list of modified files")
-	}
-	for _, name := range filenames {
-		if strings.HasPrefix(name, "enhancements/") {
-			return name, nil
-		}
-	}
-	return "", fmt.Errorf("could not find an enhancement file for PR %d", pr)
-}
-
 // GetGroup returns the grouping of the enhancement, based
 // on the filename. Documents are normally named
 // "enhancements/group/title.md" or "enhancements/title.md"

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -100,6 +100,41 @@ func extractSummary(body string) string {
 	return b.String()
 }
 
+// getEnhancementFilename returns the filename of the enhancement
+// document modified by the pull request
+func getEnhancementFilename(pr int) (filename string, err error) {
+	filenames, err := getModifiedFiles(pr)
+	if err != nil {
+		return "", errors.Wrap(err, "could not determine the list of modified files")
+	}
+	for _, name := range filenames {
+		if strings.HasPrefix(name, "enhancements/") {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("could not find an enhancement file for PR %d", pr)
+}
+
+// GetGroup returns the grouping of the enhancement, based
+// on the filename. Documents are normally named
+// "enhancements/group/title.md" or "enhancements/title.md"
+func GetGroup(pr int) (filename string, err error) {
+	filenames, err := getModifiedFiles(pr)
+	if err != nil {
+		return "", errors.Wrap(err, "could not determine the list of modified files")
+	}
+	for _, name := range filenames {
+		if strings.HasPrefix(name, "enhancements/") {
+			parts := strings.Split(name, "/")
+			if len(parts) == 3 {
+				return parts[1], nil
+			}
+			return "general", nil
+		}
+	}
+	return "", fmt.Errorf("could not find an enhancement file for PR %d", pr)
+}
+
 // GetSummary reads the files being changed in the pull request to
 // find the summary block.
 func GetSummary(pr int) (summary string, err error) {

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -118,10 +118,10 @@ func getEnhancementFilename(pr int) (filename string, err error) {
 // GetGroup returns the grouping of the enhancement, based
 // on the filename. Documents are normally named
 // "enhancements/group/title.md" or "enhancements/title.md"
-func GetGroup(pr int) (filename string, err error) {
+func GetGroup(pr int) (filename string, isEnhancement bool, err error) {
 	filenames, err := getModifiedFiles(pr)
 	if err != nil {
-		return "", errors.Wrap(err, "could not determine the list of modified files")
+		return "", false, errors.Wrap(err, "could not determine the list of modified files")
 	}
 	// First look for an actual enhancement document...
 	// FIXME: What if we find more than one?
@@ -129,9 +129,9 @@ func GetGroup(pr int) (filename string, err error) {
 		if strings.HasPrefix(name, "enhancements/") {
 			parts := strings.Split(name, "/")
 			if len(parts) == 3 {
-				return parts[1], nil
+				return parts[1], true, nil
 			}
-			return "general", nil
+			return "general", true, nil
 		}
 	}
 	// If there was no enhancement, take the root directory of the
@@ -139,12 +139,12 @@ func GetGroup(pr int) (filename string, err error) {
 	for _, name := range filenames {
 		if strings.Contains(name, "/") {
 			parts := strings.Split(name, "/")
-			return parts[0], nil
+			return parts[0], false, nil
 		}
 	}
 	// If there was no directory, assume a "general" change like
 	// OWNERS file.
-	return "general", nil
+	return "general", false, nil
 }
 
 // GetSummary reads the files being changed in the pull request to

--- a/tools/report/main.go
+++ b/tools/report/main.go
@@ -75,11 +75,25 @@ func showPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 				}
 			}
 		}
-		fmt.Printf("- [%d](%s): (%d/%d) %s (%s)\n",
+
+		group, err := enhancements.GetGroup(*prd.Pull.Number)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: failed to get group of PR %d: %s\n",
+				*prd.Pull.Number, err)
+			group = "uncategorized"
+		}
+		groupPrefix := fmt.Sprintf("%s: ", group)
+		if strings.HasPrefix(*prd.Pull.Title, groupPrefix) {
+			// avoid redundant group prefix
+			groupPrefix = ""
+		}
+
+		fmt.Printf("- [%d](%s): (%d/%d) %s%s (%s)\n",
 			*prd.Pull.Number,
 			*prd.Pull.HTMLURL,
 			prd.RecentActivityCount,
 			prd.AllActivityCount,
+			groupPrefix,
 			*prd.Pull.Title,
 			author,
 		)

--- a/tools/report/main.go
+++ b/tools/report/main.go
@@ -29,7 +29,7 @@ func fileExists(filename string) bool {
 }
 
 func handleError(msg string) {
-	fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\n", msg))
+	fmt.Fprintf(os.Stderr, "%s\n", msg)
 	os.Exit(1)
 }
 

--- a/tools/report/main.go
+++ b/tools/report/main.go
@@ -88,13 +88,20 @@ func showPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 			groupPrefix = ""
 		}
 
+		// Sometimes we have a superfluous "enhancement:" prefix in
+		// the PR title
+		title := *prd.Pull.Title
+		if strings.HasPrefix(strings.ToLower(title), "enhancement:") {
+			title = strings.TrimLeft(title[12:], " ")
+		}
+
 		fmt.Printf("- [%d](%s): (%d/%d) %s%s (%s)\n",
 			*prd.Pull.Number,
 			*prd.Pull.HTMLURL,
 			prd.RecentActivityCount,
 			prd.AllActivityCount,
 			groupPrefix,
-			*prd.Pull.Title,
+			title,
 			author,
 		)
 		if withDescription {

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -45,7 +45,6 @@ func New(daysBack int, staleMonths int, orgName, repoName string, devMode bool, 
 type Stats struct {
 	org          string
 	repo         string
-	minAge       int
 	earliestDate time.Time
 	staleDate    time.Time
 	devMode      bool


### PR DESCRIPTION
- Use the filename of the enhancement document being changed in each PR to add grouping information to the summary line.
- Remove "enhancement:" prefix from titles.
- Use the PR description as the summary if the PR doesn't contain an enhancement document.

[sample output](https://hackmd.io/RdANRydbT3SKUQQCiH8O4g)