### PR TITLE
tools: ignore pull requests with changes only in the tools directory

### DIFF
--- a/tools/report/main.go
+++ b/tools/report/main.go
@@ -82,6 +82,13 @@ func showPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 				*prd.Pull.Number, err)
 			group = "uncategorized"
 		}
+
+		// ignore pull requests with only changes in the tools
+		// directory
+		if group == "tools" {
+			continue
+		}
+
 		groupPrefix := fmt.Sprintf("%s: ", group)
 		if strings.HasPrefix(*prd.Pull.Title, groupPrefix) {
 			// avoid redundant group prefix


### PR DESCRIPTION
There is no point in including tool changes in the summary report.

Fixes #516

/cc @russellb