### PR TITLE
tools: ignore this-week newsletter posts in report

### DIFF
--- a/tools/report/main.go
+++ b/tools/report/main.go
@@ -84,8 +84,8 @@ func showPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 		}
 
 		// ignore pull requests with only changes in the tools
-		// directory
-		if group == "tools" {
+		// directory or this-week posts
+		if group == "tools" || group == "this-week" {
 			continue
 		}
 


### PR DESCRIPTION
It's not interesting to report in the newsletter that we have saved a
copy of an old newsletter to git.

/cc @russellb