### PR TITLE
tools: only look at markdown files in PRs

### DIFF
--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -63,6 +64,10 @@ func getModifiedFiles(pr int) (filenames []string, err error) {
 	for _, name := range strings.Split(string(out), "\n") {
 		trimmed := strings.TrimSpace(name)
 		if trimmed != "" {
+			// Ignore anything that doesn't look like a markdown file.
+			if filepath.Ext(trimmed) != ".md" {
+				continue
+			}
 			filenames = append(filenames, trimmed)
 		}
 	}


### PR DESCRIPTION
Update the code that looks for the summary of an enhancement to ignore
files that are obviously not going to include that summary.

/cc @russellb