### PR TITLE
Bug 1908145: Add workloads localhost ports for recovery-controllers

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -121,10 +121,12 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 |-------|-----------|-------------|-------|-------|
 | 4180  | machine-config-daemon oauth-proxy | node ||
 | 8797  | machine-config-daemon | node |4.0| metrics |
+| 9443 | kube-controller-manager | workloads || recovery-controller|
 | 9977  | etcd | etcd || ? |
 | 10248 | kubelet | node || healthz |
 | 10300 | various CSI drivers | storage | 4.6 | healthz |
 | 10301 | various CSI drivers | storage | 4.6 | healthz |
+| 11443 | kube-scheduler | workloads || recovery-controller|
 | 29102 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 | 29103 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 


### PR DESCRIPTION
This adds the updated port, as recommended in https://bugzilla.redhat.com/show_bug.cgi?id=1908145#c1 and changed in https://github.com/openshift/cluster-kube-scheduler-operator/pull/311