### PR TITLE
host-port-registry: add 6080 port

### DIFF
--- a/enhancements/network/host-port-registry.md
+++ b/enhancements/network/host-port-registry.md
@@ -71,6 +71,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 2380  | etcd      | etcd || control plane only |
 | 3306  | mariadb   | kni | 4.4 | baremetal ironic DB, control plane only |
 | 5050  | ironic-inspector | kni | 4.4 | baremetal provisioning, control plane only |
+| 6080  | cluster-kube-apiserver-operator | apiserver || control plane only |
 | 6180  | httpd     | kni | 4.4 | baremetal provisioning server, control plane only |
 | 6181  | httpd     | kni | 4.7 | baremetal image cache, control plane only |
 | 6385  | ironic-api   | kni | 4.4 | baremetal provisioning, control plane only |


### PR DESCRIPTION
This is used by the insecure /readyz endpoint proxy to be used by cloud provider that do not support https probes.