### PR TITLE
add alex crawford to owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - celebdor
   - chancez
   - cooktheryan
+  - crawford
   - danehans
   - deads2k
   - derekwaynecarr


### PR DESCRIPTION
Alex is a member of the architects team but was left out of the
approvers list in this repo.

/cc @russellb @crawford