### PR TITLE
tools: include standard comments in PR activity count

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -10,3 +10,11 @@ go run ./report/main.go
 
 There are command line options to control the range of time
 scanned. Use the `-h` option to see the help.
+
+You need to create a `~/.config/ocp-enhancements/config.yml`
+containing a [personal access token](https://github.com/settings/tokens):
+
+```yaml
+github:
+  token: "deadbeefdeadbeefdeadbeefdeadbeef"
+```


### PR DESCRIPTION
Since every PR is also an issue, the standard comments in PR are available via the issue comments API. We were only counting "review comments", which are comments associated with a particular diff.

(And "review comments" are different from the comments that are associate with PR reviews. Not confusing.)

openshift/enhancements#205 is an example of PR with lots of standard comments
