### PR TITLE
refactor report tool

### DIFF
--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -50,9 +50,9 @@ func newReportCommand() *cobra.Command {
 						group = "uncategorized"
 					}
 
-					// ignore pull requests with only changes in the tools
-					// directory or this-week posts
-					return group == "tools" || group == "this-week"
+					// ignore pull requests with only changes in the
+					// hack, tools, or this-week directories
+					return group == "hack" || group == "tools" || group == "this-week"
 				},
 			}
 

--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -19,14 +19,93 @@ func newReportCommand() *cobra.Command {
 		Use:   "report",
 		Short: "Generate the weekly activity report",
 		RunE: func(cmd *cobra.Command, args []string) error {
+
 			query := util.NewPullRequestQuery(
 				daysBack, staleMonths, orgName, repoName, devMode,
 				util.NewGithubClient(configSettings.Github.Token))
 
-			theStats, err := stats.Generate(query)
+			all := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return true
+				},
+				Cascade: true,
+			}
+			merged := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return prd.State == "merged" && prd.Pull.ClosedAt.After(query.EarliestDate)
+				},
+			}
+			closed := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return prd.State == "closed" && prd.Pull.ClosedAt.After(query.EarliestDate)
+				},
+			}
+			revived := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					// Anything in either of these states from
+					// this period will fall into an earlier
+					// bucket with the rule that includes the date
+					// check.
+					return prd.State == "closed" || prd.State == "merged"
+				},
+			}
+			newPRs := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return prd.Pull.CreatedAt.After(query.EarliestDate)
+				},
+			}
+			oldPRs := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return prd.Pull.UpdatedAt.Before(query.StaleDate) && prd.RecentActivityCount > 0
+				},
+			}
+			stale := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return prd.Pull.UpdatedAt.Before(query.StaleDate)
+				},
+			}
+			active := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return prd.RecentActivityCount > 0
+				},
+			}
+			idle := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+					return true
+				},
+			}
+
+			reportBuckets := []*stats.Bucket{
+				&all,
+				&merged,
+				&closed,
+				&revived,
+				&newPRs,
+				&oldPRs,
+				&stale,
+				&active,
+				&idle,
+			}
+
+			theStats := &stats.Stats{
+				Query:   query,
+				Buckets: reportBuckets,
+			}
+
+			err := theStats.Populate()
 			if err != nil {
 				return errors.Wrap(err, "could not generate stats")
 			}
+
+			// FIXME: temporary hack to make the report printing work
+			theStats.All = all.Requests
+			theStats.Merged = merged.Requests
+			theStats.Revived = revived.Requests
+			theStats.New = newPRs.Requests
+			theStats.Old = oldPRs.Requests
+			theStats.Stale = stale.Requests
+			theStats.Active = active.Requests
+			theStats.Idle = idle.Requests
 
 			report.ShowReport(theStats, daysBack, staleMonths, full)
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -33,6 +33,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -55,19 +55,8 @@ type Bucket struct {
 
 // Stats holds the overall stats gathered from the repo
 type Stats struct {
-	Query *util.PullRequestQuery
-
+	Query   *util.PullRequestQuery
 	Buckets []*Bucket
-
-	All     []*PullRequestDetails
-	New     []*PullRequestDetails
-	Merged  []*PullRequestDetails
-	Closed  []*PullRequestDetails
-	Stale   []*PullRequestDetails
-	Idle    []*PullRequestDetails
-	Active  []*PullRequestDetails
-	Old     []*PullRequestDetails
-	Revived []*PullRequestDetails
 }
 
 // Populate runs the query and filters requests into the appropriate
@@ -151,6 +140,7 @@ func (s *Stats) process(pr *github.PullRequest) error {
 	return nil
 }
 
+// add records a given pr in the correct bucket(s)
 func (s *Stats) add(details *PullRequestDetails) {
 	for _, bucket := range s.Buckets {
 		match := bucket.Rule(details)

--- a/tools/stats/stats_test.go
+++ b/tools/stats/stats_test.go
@@ -1,0 +1,80 @@
+package stats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddWithCascade(t *testing.T) {
+	first := Bucket{
+		Rule: func(details *PullRequestDetails) bool {
+			return true
+		},
+		Cascade: true,
+	}
+	second := Bucket{
+		Rule: func(details *PullRequestDetails) bool {
+			return true
+		},
+	}
+
+	s := Stats{
+		Buckets: []*Bucket{
+			&first,
+			&second,
+		},
+	}
+	details := &PullRequestDetails{}
+	s.add(details)
+	assert.Equal(t, 1, len(first.Requests))
+	assert.Equal(t, 1, len(second.Requests))
+}
+
+func TestAddWithoutCascade(t *testing.T) {
+	first := Bucket{
+		Rule: func(details *PullRequestDetails) bool {
+			return true
+		},
+	}
+	second := Bucket{
+		Rule: func(details *PullRequestDetails) bool {
+			return true
+		},
+	}
+
+	s := Stats{
+		Buckets: []*Bucket{
+			&first,
+			&second,
+		},
+	}
+	details := &PullRequestDetails{}
+	s.add(details)
+	assert.Equal(t, 1, len(first.Requests))
+	assert.Equal(t, 0, len(second.Requests))
+}
+
+func TestAddWithoutMatch(t *testing.T) {
+	first := Bucket{
+		Rule: func(details *PullRequestDetails) bool {
+			return false
+		},
+	}
+	second := Bucket{
+		Rule: func(details *PullRequestDetails) bool {
+			return false
+		},
+	}
+
+	s := Stats{
+		Buckets: []*Bucket{
+			&first,
+			&second,
+		},
+	}
+	details := &PullRequestDetails{}
+	s.add(details)
+	assert.Equal(t, 0, len(first.Requests))
+	assert.Equal(t, 0, len(second.Requests))
+}


### PR DESCRIPTION
Make the stats package more general by defining a Bucket type with a
Rule to indicate which pull requests belong in the bucket. This opens
us up to moving the logic to organize the data and then print the report
to the same place, which makes it easier to change and extend.

/cc @russellb @markmc