### PR TITLE
tools: redefine stale in the report as having the lifecycle/stale label

### DIFF
--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -114,7 +114,7 @@ func newReportCommand() *cobra.Command {
 			}
 			stale := stats.Bucket{
 				Rule: func(prd *stats.PullRequestDetails) bool {
-					return prd.Pull.UpdatedAt.Before(query.StaleDate)
+					return prd.Stale
 				},
 			}
 			otherActive := stats.Bucket{
@@ -212,8 +212,7 @@ func newReportCommand() *cobra.Command {
 
 			report.SortByID(stale.Requests)
 			report.ShowPRs(
-				fmt.Sprintf("Stale (older than %d months, no discussion in last %d days)",
-					staleMonths, daysBack),
+				"Other lifecycle/stale",
 				stale.Requests,
 				false,
 			)

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -30,8 +30,9 @@ type PullRequestDetails struct {
 	AllActivityCount    int
 
 	State       string
-	LGTM        bool
-	Prioritized bool
+	LGTM        bool // lgtm
+	Prioritized bool // priority-important/soon or priority/critical-urgent
+	Stale       bool // lifecycle/stake
 }
 
 // RuleFilter refers to a function that selects pull requests. A
@@ -98,12 +99,16 @@ func (s *Stats) process(pr *github.PullRequest) error {
 
 	lgtm := false
 	prioritized := false
+	stale := false
 	for _, label := range pr.Labels {
 		if *label.Name == "lgtm" {
 			lgtm = true
 		}
 		if *label.Name == "priority/important-soon" || *label.Name == "priority/critical-urgent" {
 			prioritized = true
+		}
+		if *label.Name == "lifecycle/stale" {
+			stale = true
 		}
 	}
 
@@ -115,6 +120,7 @@ func (s *Stats) process(pr *github.PullRequest) error {
 		Reviews:             reviews,
 		LGTM:                lgtm,
 		Prioritized:         prioritized,
+		Stale:               stale,
 	}
 	if isMerged {
 		details.State = "merged"


### PR DESCRIPTION
Instead of doing the calculation ourselves and potentially having
different results, use the existing label applied by the bot.

Related to #620

/cc @russellb