### PR TITLE
tools: fix summary formatting

### DIFF
--- a/tools/report/report.go
+++ b/tools/report/report.go
@@ -10,20 +10,21 @@ import (
 	"github.com/openshift/enhancements/tools/stats"
 )
 
+// Indent the summary and prefix it each line to make it format as a
+// block quote.
 func formatDescription(text string, indent string) string {
-	paras := strings.SplitN(strings.ReplaceAll(text, "\r", ""), "\n\n", -1)
+	withoutCarriageReturns := strings.ReplaceAll(text, "\r", "")
+	withoutWhitespace := strings.TrimSpace(withoutCarriageReturns)
+	lines := strings.SplitN(withoutWhitespace, "\n", -1)
 
-	unwrappedParas := []string{}
+	indentedLines := []string{}
+	prefix := fmt.Sprintf("%s> ", indent)
 
-	for _, p := range paras {
-		unwrapped := strings.ReplaceAll(p, "\n", " ")
-		quoted := fmt.Sprintf("%s> %s", indent, unwrapped)
-		unwrappedParas = append(unwrappedParas, quoted)
+	for _, line := range lines {
+		indentedLines = append(indentedLines, strings.TrimRight(prefix+line, " "))
 	}
 
-	joinOn := fmt.Sprintf("\n%s>\n", indent)
-
-	return strings.Join(unwrappedParas, joinOn)
+	return strings.Join(indentedLines, "\n")
 }
 
 const descriptionIndent = "  "

--- a/tools/report/report_test.go
+++ b/tools/report/report_test.go
@@ -1,0 +1,68 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDescription(t *testing.T) {
+	for _, tc := range []struct {
+		Scenario string
+		Input    string
+		Expected string
+	}{
+		{
+			Scenario: "One line",
+			Input:    "One line",
+			Expected: "  > One line",
+		},
+		{
+			Scenario: "Two lines one para",
+			Input: `First line
+Second line
+`,
+			Expected: `  > First line
+  > Second line`,
+		},
+		{
+			Scenario: "Multiple para",
+			Input: `First line
+Second line
+
+Third line
+Fourth line
+`,
+			Expected: `  > First line
+  > Second line
+  > 
+  > Third line
+  > Fourth line`,
+		},
+		{
+			Scenario: "Bullet list",
+			Input: `First line
+Second line
+
+- list a
+- list b
+
+Third line
+Fourth line
+`,
+			Expected: `  > First line
+  > Second line
+  > 
+  > - list a
+  > - list b
+  > 
+  > Third line
+  > Fourth line`,
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			actual := formatDescription(tc.Input, descriptionIndent)
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Stop trying to unwrap paragraphs or otherwise clean up formatting,
since the linter job enforces that in our input files now. Simply
prefix each line with the formatting needed to turn it into a block
quote, leaving all of the other text unmodified so it renders using
the nested structure.

/cc @russellb