### PR TITLE
tools: add make target for generating today's report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,10 @@ lint:  ## run the markdown linter
 		--env VALIDATE_MARKDOWN=true \
 		-v $$(pwd):/workdir:Z \
 		enhancements-markdownlint:latest
+
+REPORT_FILE=this-week/$(shell date +%F).md
+.PHONY: report report-gen
+report: report-gen lint  ## run weekly newsletter report tool
+
+report-gen:
+	(cd ./tools; go run ./main.go report > ../$(REPORT_FILE))

--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -162,7 +162,7 @@ func newReportCommand() *cobra.Command {
 			fmt.Fprintf(os.Stderr, "Ignored %d pull requests\n", len(ignore.Requests))
 
 			year, month, day := time.Now().Date()
-			fmt.Printf("\n# This Week in Enhancements - %d-%.2d-%.2d\n", year, month, day)
+			fmt.Printf("# This Week in Enhancements - %d-%.2d-%.2d\n", year, month, day)
 
 			// Only print the priority section if there are prioritized pull requests
 			if anyRequests(prioritizedMerged, prioritizedClosed, prioritizedNew, prioritizedActive) {

--- a/tools/util/query.go
+++ b/tools/util/query.go
@@ -43,8 +43,8 @@ type PRCallback func(*github.PullRequest) error
 // IteratePullRequests queries for all pull requests and invokes the
 // callback with each PR individually
 func (q *PullRequestQuery) IteratePullRequests(callback PRCallback) error {
-	fmt.Printf("finding pull requests for %s/%s\n", q.org, q.repo)
-	fmt.Printf("ignoring items closed before %s\n", q.EarliestDate)
+	fmt.Fprintf(os.Stderr, "finding pull requests for %s/%s\n", q.org, q.repo)
+	fmt.Fprintf(os.Stderr, "ignoring items closed before %s\n", q.EarliestDate)
 
 	ctx := context.Background()
 	opts := &github.PullRequestListOptions{


### PR DESCRIPTION
Move some debug messages to stderr so they don't end up in the generated
file and remove an extra blank line at the top of the output file.

/cc @russellb