### PR TITLE
tools: automatically upload this-week report to hackmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,21 @@ lint:  ## run the markdown linter
 
 REPORT_FILE=this-week/$(shell date +%F).md
 .PHONY: report report-gen
-report: report-gen lint  ## run weekly newsletter report tool
+report: report-gen lint report-upload  ## run weekly newsletter report tool
 
 report-gen:
 	(cd ./tools; go run ./main.go report > ../$(REPORT_FILE))
+
+HACKMD_IMAGE=enhancements-hackmd-cli:latest
+
+.PHONY: report-upload
+report-upload: report-image
+	$(RUNTIME) run --interactive --tty --rm=true \
+		-v $$(pwd):/workdir \
+		-v $$HOME:/home \
+		--entrypoint='["/workdir/hack/hackmd-cli.sh", "'$(REPORT_FILE)'"]' \
+		$(HACKMD_IMAGE)
+
+.PHONY: report-image
+report-image:
+	$(RUNTIME) build -f ./hack/Dockerfile.hackmd-cli --tag $(HACKMD_IMAGE)

--- a/hack/Dockerfile.hackmd-cli
+++ b/hack/Dockerfile.hackmd-cli
@@ -1,0 +1,6 @@
+FROM fedora
+WORKDIR /workdir
+RUN dnf -y module enable nodejs:12 && dnf -y install nodejs
+RUN npm install -g @hackmd/hackmd-cli
+ENV HOME=/home
+ENTRYPOINT /workdir/hack/hackmd-cli.sh

--- a/hack/hackmd-cli.sh
+++ b/hack/hackmd-cli.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -xe
+
+echo "Running"
+
+if [ ! -f $HOME/.hackmd/cookies.json ]
+then
+    hackmd-cli login
+else
+    hackmd-cli whoami
+fi
+
+hackmd-cli import $1


### PR DESCRIPTION
- Add a dockerfile to install the hackmd-cli.
- Add a script to wrap hackmd-cli to ensure the user is logged in
  before trying to upload a file.
- Add Makefile targets to run the newly generated report.

This allows someone to run 'make report' and get a hackmd.io URL for
collaborative editing.

/cc @russellb