### PR TITLE
[WIP]adding new userequest audit policy 

### DIFF
--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -80,7 +80,7 @@ resources right). Hence, this enhancement is about
 
 - a high-level API
 - which will satisfy the needs of most customers with strong regulatory or security requirement,
-  i.e. it allows them to increase audit verbosity 
+  i.e. it allows them to increase audit verbosity     
 - without risking to log security-sensitive resources
 - and it is feasible to maintain the feature in the future when the dynamic audit API takes over.
 

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -354,6 +354,8 @@ None
 
 #### Tech Preview -> GA
 
+#### Removing a deprecated feature
+
 ### Upgrade / Downgrade Strategy
 
 If applicable, how will the component be upgraded and downgraded? Make sure this

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -152,6 +152,7 @@ we provide the following profiles:
 
 - `WriteRequestBodies`: this is like `Default`, but it logs request and response HTTP payloads for write requests (create, update, patch).
 - `AllRequestBodies`: this is like `WriteRequestBodies`, but also logs request and response HTTP payloads for read requests (get, list).
+- `UserRequests`: this logs the requests from users in the `system:authenticated:oauth` user groups and logs requests for (create, delete).
 
 All of the profiles have in common that security-sensitive resources, namely
 
@@ -230,7 +231,7 @@ apiVersion: config.openshift.io/v1
 spec:
   ...
   audit:
-    profile: Default | WriteRequestBodies | AllRequestBodies
+    profile: Default | WriteRequestBodies | AllRequestBodies | UserRequests
 ```
 
 In the future, we could add more, even more detailed profiles of logging responses, if customers need this:

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -80,7 +80,7 @@ resources right). Hence, this enhancement is about
 
 - a high-level API
 - which will satisfy the needs of most customers with strong regulatory or security requirement,
-  i.e. it allows them to increase audit verbosity and provides the specific policy required by a customer for a `UserRequests` policy.
+  i.e. it allows them to increase audit verbosity 
 - without risking to log security-sensitive resources
 - and it is feasible to maintain the feature in the future when the dynamic audit API takes over.
 
@@ -232,7 +232,7 @@ apiVersion: config.openshift.io/v1
 spec:
   ...
   audit:
-    profile: Default | WriteRequestBodies | AllRequestBodies | UserRequests
+    profile: Default | WriteRequestBodies | AllRequestBodies
 ```
 
 In the future, we could add more, even more detailed profiles of logging responses, if customers need this:

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -78,7 +78,7 @@ resources right). Hence, this enhancement is about
 
 - a high-level API
 - which will satisfy the needs of most customers with strong regulatory or security requirement,
-  i.e. it allows them to increase audit verbosity and provides the specific policy required by a  customer for a `UserRequests` policy for logging of the `system:authenticated:oauth` group.
+  i.e. it allows them to increase audit verbosity and provides the specific policy required by a customer for a `UserRequests` policy.
 - without risking to log security-sensitive resources
 - and it is feasible to maintain the feature in the future when the dynamic audit API takes over.
 

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -80,7 +80,7 @@ resources right). Hence, this enhancement is about
 
 - a high-level API
 - which will satisfy the needs of most customers with strong regulatory or security requirement,
-  i.e. it allows them to increase audit verbosity     
+  i.e. it allows them to increase audit verbosity
 - without risking to log security-sensitive resources
 - and it is feasible to maintain the feature in the future when the dynamic audit API takes over.
 

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -43,6 +43,8 @@ logs, accepting the increased resource consumption of the API servers.
 This API is intentionally **not about filtering events**. Filtering is to be done via an external mechanism (post-filtering).
 It was proven through performance tests (compare alternatives section) that this trade-off is acceptable with small two-digit percent overhead.
 
+The new Audit Policy will however filter user groups to allow transparency into what resources system:authenticated:oauth group users are requesting.
+
 The API is not meant to replace the [upstream dynamic audit](https://github.com/kubernetes/enhancements/blob/f1a799d5f4658ed29797c1fb9ceb7a4d0f538e93/keps/sig-auth/0014-dynamic-audit-configuration.md) API
 now and in the future. I.e. the API of this enhancement is only about the master node audit files on disk, not about webhooks or
 any other alternative audit log sink.
@@ -152,7 +154,6 @@ we provide the following profiles:
 
 - `WriteRequestBodies`: this is like `Default`, but it logs request and response HTTP payloads for write requests (create, update, patch).
 - `AllRequestBodies`: this is like `WriteRequestBodies`, but also logs request and response HTTP payloads for read requests (get, list).
-- `UserRequests`: this logs the requests from users in the `system:authenticated:oauth` user groups and logs requests for (create, delete).
 
 All of the profiles have in common that security-sensitive resources, namely
 

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -44,6 +44,7 @@ This API is intentionally **not about filtering events**. Filtering is to be don
 It was proven through performance tests (compare alternatives section) that this trade-off is acceptable with small two-digit percent overhead.
 
 The new Audit Policy will however filter user groups to allow transparency into what resources system:authenticated:oauth group users are requesting.
+Audit Profiles will be customizable to the group an admin chooses.
 
 The API is not meant to replace the [upstream dynamic audit](https://github.com/kubernetes/enhancements/blob/f1a799d5f4658ed29797c1fb9ceb7a4d0f538e93/keps/sig-auth/0014-dynamic-audit-configuration.md) API
 now and in the future. I.e. the API of this enhancement is only about the master node audit files on disk, not about webhooks or
@@ -82,7 +83,8 @@ resources right). Hence, this enhancement is about
 - which will satisfy the needs of most customers with strong regulatory or security requirement,
   i.e. it allows them to increase audit verbosity
 - without risking to log security-sensitive resources
-- and it is feasible to maintain the feature in the future when the dynamic audit API takes over.
+- and it is feasible to maintain the feature in the future when the dynamic audit API takes over
+- audit policy output files that are more specific to monitoring groups.
 
 With performance tests we have proven that there is no strong reason to pre-filter audit logs before
 writing them to disk. Filtering can be done by custom solutions implemented by customers, or by
@@ -318,6 +320,8 @@ The profile translate like this:
 With secure OAuth storage in-place (see "Logging of Token with Secure OAuth Storage" section) and
 therefore the `oauth-apiserver.openshift.io/secure-token-storage: true` annotation on the `apiservers.config.openshift.io/v1` resource,
 these policies are extended by allowing logging of `oauthaccesstokens` and `oauthauthorizetokens`.
+
+The user will enter in the name of the group and the Audit Policy Desired: `Default`, `WriteRequestBodies`, or `AllRequestBodies`. The group can be `all` or the group name the admin specifies.
 
 ### Test Plan
 

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -28,6 +28,12 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
+#### Dev Preview
+
+#### Dev Preview -> Tech Preview
+
+#### Tech Preview -> GA
+
 ## Open Questions
 
 ## Summary

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -28,12 +28,6 @@ superseded-by:
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
-#### Dev Preview
-
-#### Dev Preview -> Tech Preview
-
-#### Tech Preview -> GA
-
 ## Open Questions
 
 ## Summary
@@ -353,6 +347,12 @@ These items are invariants that should not be logged in all responses above `Met
 ### Graduation Criteria
 
 None
+
+#### Dev Preview
+
+#### Dev Preview -> Tech Preview
+
+#### Tech Preview -> GA
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/kube-apiserver/audit-policy.md
+++ b/enhancements/kube-apiserver/audit-policy.md
@@ -78,7 +78,7 @@ resources right). Hence, this enhancement is about
 
 - a high-level API
 - which will satisfy the needs of most customers with strong regulatory or security requirement,
-  i.e. it allows them to increase audit verbosity
+  i.e. it allows them to increase audit verbosity and provides the specific policy required by a  customer for a `UserRequests` policy for logging of the `system:authenticated:oauth` group.
 - without risking to log security-sensitive resources
 - and it is feasible to maintain the feature in the future when the dynamic audit API takes over.
 
@@ -333,6 +333,16 @@ challenging to test should be called out.
 All code is expected to have adequate tests (eventually with coverage
 expectations).
 
+One test suite that will be added are unit tests to ensure that any existing policies are not capable of exposing any of the following in the Audit Logs:
+
+- `secrets`
+- `routes.route.openshift.io`
+- `oauthclients.oauth.openshift.io`
+- `oauthaccesstokens.oauth.openshift.io`
+- `oauthauthorizetokens.oauth.openshift.io`.
+
+These items are invariants that should not be logged in all responses above `Metadata` level.
+
 ### Graduation Criteria
 
 None
@@ -362,6 +372,7 @@ enhancement:
   when this feature is used?
 - Will any other components on the node change? For example, changes to CSI, CRI
   or CNI may require updating that component before the kubelet.
+- How can Audit Policies made to be made more dynamic in the future?
 
 ## Implementation History
 


### PR DESCRIPTION
This is the addition to our existing Audit Policies which will add a userrequest policy.
UserRequests logs the requests of system:authenticated:oauth users on the resources they request.
This addition will also include a new test suite that will ensure that any previous Audit Policy(Policies) that are added will not expose tokens, secrets, routes and some configmaps. The tests will fail and block the merging on misconfigured policies, in particular, those logging at the incorrect -level. It also deals with the changes needed to `oc must-gather` and scalability for upcoming policies.