### PR TITLE
require new enhancements to include all sections from the template

### DIFF
--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -112,10 +112,6 @@ bogged down.
 
 Include a story on how this proposal will be operationalized:  lifecycled, monitored and remediated at scale.
 
-#### Story 1
-
-#### Story 2
-
 ### Implementation Details/Notes/Constraints [optional]
 
 What are the caveats to the implementation? What are some important details that

--- a/hack/Dockerfile.markdownlint
+++ b/hack/Dockerfile.markdownlint
@@ -1,5 +1,6 @@
 FROM fedora
 WORKDIR /workdir
 COPY install-markdownlint.sh /tmp
+RUN dnf install -y git
 RUN /tmp/install-markdownlint.sh
 ENTRYPOINT /workdir/hack/markdownlint.sh

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -ex
 
 markdownlint-cli2 '**/*.md'
+
+$(dirname $0)/template-lint.sh

--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Check that the required section headers from the template are
+# present in the enhancement document(s).
+
+TEMPLATE=$(dirname $0)/../guidelines/enhancement_template.md
+
+# We only look at the files that have changed in the current PR, to
+# avoid problems when the template is changed in a way that is
+# incompatible with existing documents.
+CHANGED_FILES=$(git log --name-only --pretty= master.. \
+                    | grep '^enhancements' \
+                    | grep '\.md$' \
+                    | sort -u)
+
+RC=0
+for file in $CHANGED_FILES
+do
+    # Iterate over the required headers in the template. We look for
+    # at least 2 # to start the line because the title header will be
+    # different from the text in the template, and we check for a
+    # title separately.
+    grep '^##' $TEMPLATE \
+        | grep -v '\[optional\]' \
+        | while read header_line
+    do
+        if ! grep -q "^${header_line}" $file
+        then
+            echo "$file missing \"$header_line\""
+            RC=1
+        fi
+    done
+
+    # Now look for a title, one # followed by a space to start a line.
+    if ! grep -q '^# ' $file
+    then
+        echo "$file is missing a title"
+        RC=1
+    fi
+done
+
+exit $RC


### PR DESCRIPTION
We've had issues in the past with sections of the template being
dropped. This PR adds steps to the linter job to ensure that all
enhancement files being modified include all required headers from the
template. It is still up to reviewers to ensure that those sections have
meaningful content.