### PR TITLE
README: clarify that new components require an enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A rough heuristic for an enhancement is anything that:
 - impacts upgrade/downgrade
 - needs significant effort to complete
 - requires consensus/code across multiple domains/repositories
+- proposes adding a new user-facing component
 - has phases of maturity (Dev Preview, Tech Preview, GA)
 - demands formal documentation to utilize
 


### PR DESCRIPTION
A recent request to add a new bugzilla component received the response
"new components typically require architect signoff".

This is better expressed as "requires an enhancement", and "user-facing
component" is a good rule-of-thumb for "will need a new bugzilla component".