### PR TITLE
tools: only look for summaries in enhancement markdown files

### DIFF
--- a/tools/cmd/show-pr.go
+++ b/tools/cmd/show-pr.go
@@ -93,10 +93,10 @@ func newShowPRCommand() *cobra.Command {
 			var sinceUpdated float64
 			var sinceClosed float64
 
-			if !prd.Pull.UpdatedAt.IsZero() {
+			if prd.Pull.UpdatedAt != nil && !prd.Pull.UpdatedAt.IsZero() {
 				sinceUpdated = time.Since(*prd.Pull.UpdatedAt).Hours() / 24
 			}
-			if !prd.Pull.ClosedAt.IsZero() {
+			if prd.Pull.ClosedAt != nil && !prd.Pull.ClosedAt.IsZero() {
 				sinceClosed = time.Since(*prd.Pull.ClosedAt).Hours() / 24
 			}
 

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -150,11 +150,21 @@ func GetSummary(pr int) (summary string, err error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not determine the list of modified files")
 	}
-	if len(filenames) != 1 {
-		return "", fmt.Errorf("expected 1 modified file, found %v", filenames)
+	enhancementFiles := []string{}
+	for _, name := range filenames {
+		if !strings.HasPrefix(name, "enhancements/") {
+			continue
+		}
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		enhancementFiles = append(enhancementFiles, name)
 	}
-	summary = fmt.Sprintf("(no '## Summary' section found in %s)", filenames[0])
-	fileRef := fmt.Sprintf("%s:%s", prRef(pr), filenames[0])
+	if len(enhancementFiles) != 1 {
+		return "", fmt.Errorf("expected 1 modified file, found %v", enhancementFiles)
+	}
+	summary = fmt.Sprintf("(no '## Summary' section found in %s)", enhancementFiles[0])
+	fileRef := fmt.Sprintf("%s:%s", prRef(pr), enhancementFiles[0])
 	content, err := getFileContents(fileRef)
 	if err != nil {
 		return summary, errors.Wrap(err, fmt.Sprintf("could not get content of %s", fileRef))

--- a/tools/report/report.go
+++ b/tools/report/report.go
@@ -131,10 +131,9 @@ func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 					fmt.Fprintf(os.Stderr, "WARNING: failed to get summary of PR %d: %s\n",
 						*prd.Pull.Number, err)
 				}
-			} else {
-				if prd.Pull.Body != nil {
-					summary = *prd.Pull.Body
-				}
+			}
+			if summary == "" && prd.Pull.Body != nil {
+				summary = *prd.Pull.Body
 			}
 			if summary != "" {
 				fmt.Printf("\n%s\n\n", formatDescription(summary, descriptionIndent))


### PR DESCRIPTION
If a PR includes changes in multiple files, we want to ignore images
or other things that are unlikely to contain the summary. So, before
rejecting a PR with multiple files changed, see if we can identify a
single enhancement file.

/cc @russellb