### PR TITLE
hack: fix the template lint job

### DIFF
--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -20,16 +20,19 @@ do
     # at least 2 # to start the line because the title header will be
     # different from the text in the template, and we check for a
     # title separately.
-    grep '^##' $TEMPLATE \
+    missing=$(grep '^##' $TEMPLATE \
         | grep -v '\[optional\]' \
         | while read header_line
     do
         if ! grep -q "^${header_line}" $file
         then
             echo "$file missing \"$header_line\""
-            RC=1
         fi
-    done
+    done)
+    if [ -n "$missing" ]; then
+        echo "$missing"
+        RC=1
+    fi
 
     # Now look for a title, one # followed by a space to start a line.
     if ! grep -q '^# ' $file


### PR DESCRIPTION
Placing the while loop for checking headers into a pipe meant the
variable it set with a return code was in a subshell, which did not
affect the return code of the parent. This version collects all of the
information about missing headers and if there are any it prints the
list and then sets the parent script return code correctly.

/assign @wking