### PR TITLE
hack/template-lint: Diff from origin/master

### DIFF
--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -8,7 +8,7 @@ TEMPLATE=$(dirname $0)/../guidelines/enhancement_template.md
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(git log --name-only --pretty= master.. \
+CHANGED_FILES=$(git log --name-only --pretty= origin/master.. \
                     | grep '^enhancements' \
                     | grep '\.md$' \
                     | sort -u)


### PR DESCRIPTION
CI apparently checks out the base branch and [merges the pull request branch][1] before running tests:

    INFO[2021-04-26T18:28:37Z] Resolved source https://github.com/openshift/enhancements to master@42b44d6e, merging: #744 d8c0ef8d ...

So instead of using the local `master` branch (which includes that new merge), use `origin/master` to calculate changed files.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_enhancements/744/pull-ci-openshift-enhancements-master-markdownlint/1386749042607788032#1:build-log.txt%3A3