### PR TITLE
hack/template-lint: Actually, use PULL_BASE_SHA

### DIFF
--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -3,14 +3,17 @@
 # Check that the required section headers from the template are
 # present in the enhancement document(s).
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 TEMPLATE=$(dirname $0)/../guidelines/enhancement_template.md
 
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
 CHANGED_FILES=$(git log --name-only --pretty= "${PULL_BASE_SHA:-origin/master}.." -- \
-                    | grep '^enhancements' \
-                    | grep '\.md$' \
+                    | (grep '^enhancements.*\.md$' || true) \
                     | sort -u)
 
 RC=0

--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -8,7 +8,7 @@ TEMPLATE=$(dirname $0)/../guidelines/enhancement_template.md
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(git log --name-only --pretty= origin/master.. \
+CHANGED_FILES=$(git log --name-only --pretty= "${PULL_BASE_SHA:-origin/master}.." -- \
                     | grep '^enhancements' \
                     | grep '\.md$' \
                     | sort -u)


### PR DESCRIPTION
Instead of 320ec318e3 (#755), to [avoid][1]:

    fatal: ambiguous argument 'origin/master..': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'

[`PULL_BASE_SHA` is part of Prow][2].

When folks call us outside of Prow, fall back to `HEAD`.  This isn't a great fallback for folks using the script in local development, but:

```console
$ PULL_BASE_SHA=origin/master hack/template-lint.sh
```

or whatever is possible, if a bit of a hack, if they don't like `HEAD`. And because folks can call the upstream remote whatever they want, `origin/master` isn't all that reliable either.

Also add the `--` suggested in Git's error message, to show that we intend this to be a revision ID and not a file path.

[1]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_enhancements/744/pull-ci-openshift-enhancements-master-markdownlint/1386818564115140608/artifacts/test/build-log.txt
[2]: https://github.com/kubernetes/test-infra/blob/73e6e4703b38b43fe262ba0554d642e9aebcc0e8/prow/jobs.md#job-environment-variables