### PR TITLE
tools: update enhancement newsletter to separate updates from new docs

### DIFF
--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/enhancements/tools/enhancements"
 	"github.com/openshift/enhancements/tools/report"
 	"github.com/openshift/enhancements/tools/stats"
 	"github.com/openshift/enhancements/tools/util"
@@ -48,16 +47,9 @@ func newReportCommand() *cobra.Command {
 			// in the report, so the other rules aren't even applied.
 			ignore := stats.Bucket{
 				Rule: func(prd *stats.PullRequestDetails) bool {
-					group, _, err := enhancements.GetGroup(*prd.Pull.Number)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "WARNING: failed to get group of PR %d: %s\n",
-							*prd.Pull.Number, err)
-						group = "uncategorized"
-					}
-
 					// ignore pull requests with only changes in the
 					// hack, tools, or this-week directories
-					return group == "hack" || group == "tools" || group == "this-week"
+					return prd.Group == "hack" || prd.Group == "tools" || prd.Group == "this-week"
 				},
 			}
 

--- a/tools/cmd/show-pr.go
+++ b/tools/cmd/show-pr.go
@@ -106,6 +106,7 @@ func newShowPRCommand() *cobra.Command {
 			fmt.Printf("Reviews:        %3d / %3d\n", prd.RecentReviewCount, len(prd.Reviews))
 			fmt.Printf("PR Comments:    %3d / %3d\n", prd.RecentPRCommentCount, len(prd.PullRequestComments))
 			fmt.Printf("Issue comments: %3d / %3d\n", prd.RecentIssueCommentCount, len(prd.IssueComments))
+			fmt.Printf("Is New:         %v\n", prd.IsNew)
 			fmt.Printf("Modified files:\n")
 			for _, file := range prd.ModifiedFiles {
 				fmt.Printf("\t(%s) %s\n", file.Mode, file.Name)

--- a/tools/cmd/show-pr.go
+++ b/tools/cmd/show-pr.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/enhancements/tools/enhancements"
 	"github.com/openshift/enhancements/tools/report"
 	"github.com/openshift/enhancements/tools/stats"
 	"github.com/openshift/enhancements/tools/util"
@@ -37,10 +36,6 @@ func newShowPRCommand() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err,
 					fmt.Sprintf("failed to interpret pull request ID %q as a number", args[0]))
-			}
-			group, isEnhancement, err := enhancements.GetGroup(prID)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("failed to determine group for PR %d", prID))
 			}
 
 			ghClient := util.NewGithubClient(configSettings.Github.Token)
@@ -102,8 +97,8 @@ func newShowPRCommand() *cobra.Command {
 
 			fmt.Printf("Last updated:   %s (%.02f days)\n", prd.Pull.UpdatedAt, sinceUpdated)
 			fmt.Printf("Closed:         %s (%.02f days)\n", prd.Pull.ClosedAt, sinceClosed)
-			fmt.Printf("Group:          %s\n", group)
-			fmt.Printf("Enhancement:    %v\n", isEnhancement)
+			fmt.Printf("Group:          %s\n", prd.Group)
+			fmt.Printf("Enhancement:    %v\n", prd.IsEnhancement)
 			fmt.Printf("State:          %q\n", prd.State)
 			fmt.Printf("LGTM:           %v\n", prd.LGTM)
 			fmt.Printf("Prioritized:    %v\n", prd.Prioritized)

--- a/tools/cmd/show-pr.go
+++ b/tools/cmd/show-pr.go
@@ -107,8 +107,8 @@ func newShowPRCommand() *cobra.Command {
 			fmt.Printf("PR Comments:    %3d / %3d\n", prd.RecentPRCommentCount, len(prd.PullRequestComments))
 			fmt.Printf("Issue comments: %3d / %3d\n", prd.RecentIssueCommentCount, len(prd.IssueComments))
 			fmt.Printf("Modified files:\n")
-			for _, filename := range prd.ModifiedFiles {
-				fmt.Printf("\t%s\n", filename)
+			for _, file := range prd.ModifiedFiles {
+				fmt.Printf("\t(%s) %s\n", file.Mode, file.Name)
 			}
 
 			return nil

--- a/tools/cmd/show-pr.go
+++ b/tools/cmd/show-pr.go
@@ -106,6 +106,10 @@ func newShowPRCommand() *cobra.Command {
 			fmt.Printf("Reviews:        %3d / %3d\n", prd.RecentReviewCount, len(prd.Reviews))
 			fmt.Printf("PR Comments:    %3d / %3d\n", prd.RecentPRCommentCount, len(prd.PullRequestComments))
 			fmt.Printf("Issue comments: %3d / %3d\n", prd.RecentIssueCommentCount, len(prd.IssueComments))
+			fmt.Printf("Modified files:\n")
+			for _, filename := range prd.ModifiedFiles {
+				fmt.Printf("\t%s\n", filename)
+			}
 
 			return nil
 		},

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -50,9 +50,9 @@ func ensureFetchSettings() error {
 	return nil
 }
 
-// getModifiedFiles tries to determine which files have changed in a
+// GetModifiedFiles tries to determine which files have changed in a
 // pull request.
-func getModifiedFiles(pr int) (filenames []string, err error) {
+func GetModifiedFiles(pr int) (filenames []string, err error) {
 	ref := prRef(pr)
 	out, err := exec.Command("git", "show", "--name-only", ref, "--format=").Output()
 	if err != nil {
@@ -104,7 +104,7 @@ func extractSummary(body string) string {
 // on the filename. Documents are normally named
 // "enhancements/group/title.md" or "enhancements/title.md"
 func GetGroup(pr int) (filename string, isEnhancement bool, err error) {
-	filenames, err := getModifiedFiles(pr)
+	filenames, err := GetModifiedFiles(pr)
 	if err != nil {
 		return "", false, errors.Wrap(err, "could not determine the list of modified files")
 	}
@@ -146,7 +146,7 @@ func GetGroup(pr int) (filename string, isEnhancement bool, err error) {
 // GetSummary reads the files being changed in the pull request to
 // find the summary block.
 func GetSummary(pr int) (summary string, err error) {
-	filenames, err := getModifiedFiles(pr)
+	filenames, err := GetModifiedFiles(pr)
 	if err != nil {
 		return "", errors.Wrap(err, "could not determine the list of modified files")
 	}

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -100,35 +100,31 @@ func extractSummary(body string) string {
 	return b.String()
 }
 
-// GetGroup returns the grouping of the enhancement, based
+// DeriveGroup returns the grouping of an enhancement, based
 // on the filename. Documents are normally named
 // "enhancements/group/title.md" or "enhancements/title.md"
-func GetGroup(pr int) (filename string, isEnhancement bool, err error) {
-	filenames, err := GetModifiedFiles(pr)
-	if err != nil {
-		return "", false, errors.Wrap(err, "could not determine the list of modified files")
-	}
+func DeriveGroup(filenames []string) (filename string, isEnhancement bool) {
 	// First look for an actual enhancement document...
 	// FIXME: What if we find more than one?
 	for _, name := range filenames {
 		if strings.HasPrefix(name, "enhancements/") {
 			parts := strings.Split(name, "/")
 			if len(parts) == 3 {
-				return parts[1], true, nil
+				return parts[1], true
 			}
-			return "general", true, nil
+			return "general", true
 		}
 	}
 	// Now look for some known housekeeping files...
 	for _, name := range filenames {
 		if strings.HasPrefix(name, "OWNERS") {
-			return "housekeeping", false, nil
+			return "housekeeping", false
 		}
 		if strings.HasPrefix(name, ".markdownlint-cli2.yaml") {
-			return "tools", false, nil
+			return "tools", false
 		}
 		if strings.HasPrefix(name, "hack/") {
-			return "tools", false, nil
+			return "tools", false
 		}
 	}
 	// If there was no enhancement, take the root directory of the
@@ -136,11 +132,11 @@ func GetGroup(pr int) (filename string, isEnhancement bool, err error) {
 	for _, name := range filenames {
 		if strings.Contains(name, "/") {
 			parts := strings.Split(name, "/")
-			return parts[0], false, nil
+			return parts[0], false
 		}
 	}
 	// If there was no directory, assume a "general" change like
-	return "general", false, nil
+	return "general", false
 }
 
 // GetSummary reads the files being changed in the pull request to

--- a/tools/enhancements/summary.go
+++ b/tools/enhancements/summary.go
@@ -59,10 +59,22 @@ func stringSliceContains(slice []string, target string) bool {
 	return false
 }
 
+type ModifiedFile struct {
+	Name string
+	Mode string
+}
+
 // GetModifiedFiles tries to determine which files have changed in a
 // pull request.
-func GetModifiedFiles(pr int) (filenames []string, err error) {
+func GetModifiedFiles(pr int) (files []ModifiedFile, err error) {
 	ref := prRef(pr)
+
+	// Find the list of files added or modified in the PR by starting
+	// from the oldest ancestor commit common with the origin/master
+	// branch and diffing the PR branch. Equivalent to:
+	//
+	// oldest_ancestor=$(git rev-list $(git rev-list --first-parent ^"$PR_BRANCH" "origin/master" | tail -n1)^^!)
+	// git diff --name-status ${oldest_ancestor}..${PR_BRANCH}
 
 	firstParentOut, err := exec.Command("git", "rev-list", "--first-parent", "^"+ref, "origin/master").Output()
 	if err != nil {
@@ -84,20 +96,27 @@ func GetModifiedFiles(pr int) (filenames []string, err error) {
 	}
 	oldestAncestor := strings.TrimSpace(string(oldestAncestorOut))
 
-	out, err := exec.Command("git", "log", "--oneline", "--pretty=", "--name-only",
-		oldestAncestor+".."+ref).Output()
+	out, err := exec.Command("git", "diff", "--name-status", oldestAncestor+".."+ref).Output()
 	if err != nil {
 		exitError := err.(*exec.ExitError)
 		return nil, errors.Wrap(err, fmt.Sprintf("could not get files changed in %s: %s",
 			ref, exitError.Stderr))
 	}
-	for _, name := range strings.Split(string(out), "\n") {
-		trimmed := strings.TrimSpace(name)
-		if trimmed != "" && !stringSliceContains(filenames, trimmed) {
-			filenames = append(filenames, trimmed)
+	modifiedFiles := []ModifiedFile{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if line == "" {
+			continue
+		}
+		// The diff output shows the operation (mode) and filename:
+		// A       name-of-new-file
+		// C       name-of-changed-file
+		mode := line[0:1]
+		trimmed := strings.TrimSpace(line[1:])
+		if trimmed != "" {
+			modifiedFiles = append(modifiedFiles, ModifiedFile{Name: trimmed, Mode: mode})
 		}
 	}
-	return filenames, nil
+	return modifiedFiles, nil
 }
 
 func getFileContents(ref string) ([]byte, error) {
@@ -134,12 +153,12 @@ func extractSummary(body string) string {
 // DeriveGroup returns the grouping of an enhancement, based
 // on the filename. Documents are normally named
 // "enhancements/group/title.md" or "enhancements/title.md"
-func DeriveGroup(filenames []string) (filename string, isEnhancement bool) {
+func DeriveGroup(files []ModifiedFile) (filename string, isEnhancement bool) {
 	// First look for an actual enhancement document...
 	// FIXME: What if we find more than one?
-	for _, name := range filenames {
-		if strings.HasPrefix(name, "enhancements/") {
-			parts := strings.Split(name, "/")
+	for _, f := range files {
+		if strings.HasPrefix(f.Name, "enhancements/") {
+			parts := strings.Split(f.Name, "/")
 			if len(parts) == 3 {
 				return parts[1], true
 			}
@@ -147,22 +166,22 @@ func DeriveGroup(filenames []string) (filename string, isEnhancement bool) {
 		}
 	}
 	// Now look for some known housekeeping files...
-	for _, name := range filenames {
-		if strings.HasPrefix(name, "OWNERS") {
+	for _, f := range files {
+		if strings.HasPrefix(f.Name, "OWNERS") {
 			return "housekeeping", false
 		}
-		if strings.HasPrefix(name, ".markdownlint-cli2.yaml") {
+		if strings.HasPrefix(f.Name, ".markdownlint-cli2.yaml") {
 			return "tools", false
 		}
-		if strings.HasPrefix(name, "hack/") {
+		if strings.HasPrefix(f.Name, "hack/") {
 			return "tools", false
 		}
 	}
 	// If there was no enhancement, take the root directory of the
 	// first file that has a directory.
-	for _, name := range filenames {
-		if strings.Contains(name, "/") {
-			parts := strings.Split(name, "/")
+	for _, f := range files {
+		if strings.Contains(f.Name, "/") {
+			parts := strings.Split(f.Name, "/")
 			return parts[0], false
 		}
 	}
@@ -173,19 +192,19 @@ func DeriveGroup(filenames []string) (filename string, isEnhancement bool) {
 // GetSummary reads the files being changed in the pull request to
 // find the summary block.
 func GetSummary(pr int) (summary string, err error) {
-	filenames, err := GetModifiedFiles(pr)
+	files, err := GetModifiedFiles(pr)
 	if err != nil {
 		return "", errors.Wrap(err, "could not determine the list of modified files")
 	}
 	enhancementFiles := []string{}
-	for _, name := range filenames {
-		if !strings.HasPrefix(name, "enhancements/") {
+	for _, f := range files {
+		if !strings.HasPrefix(f.Name, "enhancements/") {
 			continue
 		}
-		if !strings.HasSuffix(name, ".md") {
+		if !strings.HasSuffix(f.Name, ".md") {
 			continue
 		}
-		enhancementFiles = append(enhancementFiles, name)
+		enhancementFiles = append(enhancementFiles, f.Name)
 	}
 	if len(enhancementFiles) != 1 {
 		return "", fmt.Errorf("expected 1 modified file, found %v", enhancementFiles)

--- a/tools/report/report.go
+++ b/tools/report/report.go
@@ -76,6 +76,8 @@ const descriptionIndent = "  "
 // ShowPRs prints a section of the report by formatting the
 // PullRequestDetails as a list.
 func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool) {
+	var err error
+
 	if len(prds) == 0 {
 		return
 	}
@@ -99,12 +101,8 @@ func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 			}
 		}
 
-		group, isEnhancement, err := enhancements.GetGroup(*prd.Pull.Number)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: failed to get group of PR %d: %s\n",
-				*prd.Pull.Number, err)
-			group = "uncategorized"
-		}
+		group := prd.Group
+		isEnhancement := prd.IsEnhancement
 
 		groupPrefix := fmt.Sprintf("%s: ", group)
 		if strings.HasPrefix(*prd.Pull.Title, groupPrefix) {

--- a/tools/report/report.go
+++ b/tools/report/report.go
@@ -73,15 +73,65 @@ func formatDescription(text string, indent string) string {
 
 const descriptionIndent = "  "
 
+func showOnePR(prd *stats.PullRequestDetails, withDescription bool) {
+	author := ""
+	if prd.Pull.User != nil {
+		for _, option := range []*string{prd.Pull.User.Name, prd.Pull.User.Login} {
+			if option != nil {
+				author = *option
+				break
+			}
+		}
+	}
+
+	group := prd.Group
+	isEnhancement := prd.IsEnhancement
+
+	groupPrefix := fmt.Sprintf("%s: ", group)
+	if strings.HasPrefix(*prd.Pull.Title, groupPrefix) {
+		// avoid redundant group prefix
+		groupPrefix = ""
+	}
+
+	title := enhancements.CleanTitle(*prd.Pull.Title)
+
+	fmt.Printf("- [%d](%s): (%d/%d) %s%s (%s)\n",
+		*prd.Pull.Number,
+		*prd.Pull.HTMLURL,
+		prd.RecentActivityCount,
+		prd.AllActivityCount,
+		groupPrefix,
+		title,
+		author,
+	)
+	if withDescription {
+		var summary string
+		var err error
+
+		if isEnhancement {
+			summary, err = enhancements.GetSummary(*prd.Pull.Number)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: failed to get summary of PR %d: %s\n",
+					*prd.Pull.Number, err)
+			}
+		}
+		if summary == "" && prd.Pull.Body != nil {
+			summary = *prd.Pull.Body
+		}
+		if summary != "" {
+			fmt.Printf("\n%s\n\n", formatDescription(summary, descriptionIndent))
+		}
+	}
+}
+
 // ShowPRs prints a section of the report by formatting the
 // PullRequestDetails as a list.
 func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool) {
-	var err error
-
 	if len(prds) == 0 {
 		return
 	}
-	fmt.Printf("\n### %s Enhancements\n", name)
+
+	fmt.Printf("\n### %s Changes\n", name)
 
 	fmt.Printf("\n*&lt;PR ID&gt;: (activity this week / total activity) summary*\n")
 
@@ -90,52 +140,23 @@ func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 	} else {
 		fmt.Printf("\nThere were %d %s pull requests:\n\n", len(prds), name)
 	}
+
+	foundUpdate := false
 	for _, prd := range prds {
-		author := ""
-		if prd.Pull.User != nil {
-			for _, option := range []*string{prd.Pull.User.Name, prd.Pull.User.Login} {
-				if option != nil {
-					author = *option
-					break
-				}
-			}
+		if !prd.IsNew {
+			foundUpdate = true
+			continue
 		}
+		showOnePR(prd, withDescription)
+	}
 
-		group := prd.Group
-		isEnhancement := prd.IsEnhancement
-
-		groupPrefix := fmt.Sprintf("%s: ", group)
-		if strings.HasPrefix(*prd.Pull.Title, groupPrefix) {
-			// avoid redundant group prefix
-			groupPrefix = ""
-		}
-
-		title := enhancements.CleanTitle(*prd.Pull.Title)
-
-		fmt.Printf("- [%d](%s): (%d/%d) %s%s (%s)\n",
-			*prd.Pull.Number,
-			*prd.Pull.HTMLURL,
-			prd.RecentActivityCount,
-			prd.AllActivityCount,
-			groupPrefix,
-			title,
-			author,
-		)
-		if withDescription {
-			var summary string
-			if isEnhancement {
-				summary, err = enhancements.GetSummary(*prd.Pull.Number)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "WARNING: failed to get summary of PR %d: %s\n",
-						*prd.Pull.Number, err)
-				}
+	if foundUpdate {
+		fmt.Printf("\n#### %s Pull Requests Modifying Existing Documents\n\n", name)
+		for _, prd := range prds {
+			if prd.IsNew {
+				continue
 			}
-			if summary == "" && prd.Pull.Body != nil {
-				summary = *prd.Pull.Body
-			}
-			if summary != "" {
-				fmt.Printf("\n%s\n\n", formatDescription(summary, descriptionIndent))
-			}
+			showOnePR(prd, false)
 		}
 	}
 }

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -121,13 +121,13 @@ func (s *Stats) ProcessOne(pr *github.PullRequest) error {
 		}
 	}
 
-	group, isEnhancement, err := enhancements.GetGroup(int(*pr.Number))
 	modifiedFiles, err := enhancements.GetModifiedFiles(int(*pr.Number))
 	if err != nil {
 		return errors.Wrap(err,
 			fmt.Sprintf("could not determine group details for %s", *pr.HTMLURL))
 	}
 
+	group, isEnhancement := enhancements.DeriveGroup(modifiedFiles)
 	if err != nil {
 		return errors.Wrap(err,
 			fmt.Sprintf("could not determine group details for %s", *pr.HTMLURL))

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -38,6 +38,7 @@ type PullRequestDetails struct {
 	Group         string
 	IsEnhancement bool
 	ModifiedFiles []enhancements.ModifiedFile
+	IsNew         bool
 }
 
 // RuleFilter refers to a function that selects pull requests. A
@@ -127,6 +128,16 @@ func (s *Stats) ProcessOne(pr *github.PullRequest) error {
 			fmt.Sprintf("could not determine group details for %s", *pr.HTMLURL))
 	}
 
+	// Look for whether a file has been added in the PR to determine
+	// if this is a new enhancement.
+	var isNew bool
+	for _, f := range modifiedFiles {
+		if f.Mode == "A" {
+			isNew = true
+			break
+		}
+	}
+
 	group, isEnhancement := enhancements.DeriveGroup(modifiedFiles)
 	if err != nil {
 		return errors.Wrap(err,
@@ -148,6 +159,7 @@ func (s *Stats) ProcessOne(pr *github.PullRequest) error {
 		Group:               group,
 		IsEnhancement:       isEnhancement,
 		ModifiedFiles:       modifiedFiles,
+		IsNew:               isNew,
 	}
 	if isMerged {
 		details.State = "merged"

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -37,7 +37,7 @@ type PullRequestDetails struct {
 	Stale         bool // lifecycle/stake
 	Group         string
 	IsEnhancement bool
-	ModifiedFiles []string
+	ModifiedFiles []enhancements.ModifiedFile
 }
 
 // RuleFilter refers to a function that selects pull requests. A

--- a/tools/stats/stats.go
+++ b/tools/stats/stats.go
@@ -37,6 +37,7 @@ type PullRequestDetails struct {
 	Stale         bool // lifecycle/stake
 	Group         string
 	IsEnhancement bool
+	ModifiedFiles []string
 }
 
 // RuleFilter refers to a function that selects pull requests. A
@@ -121,6 +122,12 @@ func (s *Stats) ProcessOne(pr *github.PullRequest) error {
 	}
 
 	group, isEnhancement, err := enhancements.GetGroup(int(*pr.Number))
+	modifiedFiles, err := enhancements.GetModifiedFiles(int(*pr.Number))
+	if err != nil {
+		return errors.Wrap(err,
+			fmt.Sprintf("could not determine group details for %s", *pr.HTMLURL))
+	}
+
 	if err != nil {
 		return errors.Wrap(err,
 			fmt.Sprintf("could not determine group details for %s", *pr.HTMLURL))
@@ -140,6 +147,7 @@ func (s *Stats) ProcessOne(pr *github.PullRequest) error {
 		Stale:               stale,
 		Group:               group,
 		IsEnhancement:       isEnhancement,
+		ModifiedFiles:       modifiedFiles,
 	}
 	if isMerged {
 		details.State = "merged"


### PR DESCRIPTION
Separate out the PRs that change existing enhancements documents, and
only include a 1 line summary instead of repeating the original summary
from the document. This deemphasizes "typo fix" and other minor updates
to existing designs.

/assign @russellb