### PR TITLE
tools: add command to show time to merge data for pull requests

### DIFF
--- a/tools/cmd/pullRequests.go
+++ b/tools/cmd/pullRequests.go
@@ -1,0 +1,166 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/go-github/v32/github"
+
+	"github.com/openshift/enhancements/tools/stats"
+	"github.com/openshift/enhancements/tools/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const dateFmt = "2006-01-02"
+
+func newPullRequestsCommand() *cobra.Command {
+
+	var (
+		includeUpdates bool
+		daysBack       int
+	)
+
+	// pullRequestsCmd represents the pullRequests command
+	var pullRequestsCmd = &cobra.Command{
+		Use:   "pull-requests",
+		Short: "List pull requests and some characteristics in CSV format",
+		Long:  `Produce a CSV list of pull requests suitable for import into a spreadsheet.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			earliestDate := time.Now().AddDate(0, 0, daysBack*-1)
+
+			query := &util.PullRequestQuery{
+				Org:     orgName,
+				Repo:    repoName,
+				DevMode: devMode,
+				Client:  util.NewGithubClient(configSettings.Github.Token),
+			}
+
+			all := stats.Bucket{
+				Rule: func(prd *stats.PullRequestDetails) bool {
+
+					// FIXME: Add an option to include all PRs
+					if prd.State != "merged" {
+						return false
+					}
+
+					if !includeUpdates && !prd.IsNew {
+						return false
+					}
+
+					// FIXME: add an option to include non-enhancements
+					if !prd.IsEnhancement {
+						return false
+					}
+
+					return true
+				},
+				Cascade: false,
+			}
+			theStats := &stats.Stats{
+				Query:        query,
+				EarliestDate: earliestDate,
+				Buckets:      []*stats.Bucket{&all},
+			}
+			err := theStats.Populate()
+			if err != nil {
+				return errors.Wrap(err, "could not generate stats")
+			}
+
+			out := csv.NewWriter(os.Stdout)
+			out.Write([]string{
+				"ID",
+				"Title",
+				"State",
+				"Author",
+				"URL",
+				"New",
+				"Created",
+				"Closed",
+				"Days to Merge",
+			})
+
+			for _, prd := range all.Requests {
+
+				var (
+					createdAt, closedAt, isNew string
+					daysToMerge                int = -1
+				)
+
+				if prd.Pull.CreatedAt != nil {
+					createdAt = prd.Pull.CreatedAt.Format(dateFmt)
+				}
+				if prd.Pull.ClosedAt != nil {
+					closedAt = prd.Pull.ClosedAt.Format(dateFmt)
+				}
+				if prd.State == "merged" && prd.Pull.CreatedAt != nil && prd.Pull.ClosedAt != nil {
+					daysToMerge = int(prd.Pull.ClosedAt.Sub(*prd.Pull.CreatedAt).Hours() / 24)
+				}
+
+				user := getName(prd.Pull.User)
+
+				isNew = "false"
+				if prd.IsNew {
+					isNew = "true"
+				}
+
+				out.Write([]string{
+					fmt.Sprintf("%d", *prd.Pull.Number),
+					*prd.Pull.Title,
+					prd.State,
+					user,
+					*prd.Pull.HTMLURL,
+					isNew,
+					createdAt,
+					closedAt,
+					fmt.Sprintf("%d", daysToMerge),
+				})
+			}
+
+			out.Flush()
+
+			return nil
+		},
+	}
+
+	pullRequestsCmd.Flags().BoolVarP(&includeUpdates, "include-updates", "U", false, "include updates to existing enhancements")
+	pullRequestsCmd.Flags().StringP("output", "o", "", "output file to create (defaults to stdout)")
+	pullRequestsCmd.Flags().IntVar(&daysBack, "days-back", 90, "how many days back to query")
+
+	return pullRequestsCmd
+}
+
+func getName(user *github.User) string {
+	if user == nil {
+		return "unnamed"
+	}
+	if user.Name != nil {
+		return *user.Name
+	}
+	if user.Login != nil {
+		return *user.Login
+	}
+	return "unnamed"
+}
+
+func init() {
+	rootCmd.AddCommand(newPullRequestsCommand())
+}

--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -16,7 +16,6 @@ import (
 func newReportCommand() *cobra.Command {
 	var (
 		daysBack int
-		devMode  bool
 	)
 
 	cmd := &cobra.Command{
@@ -243,7 +242,6 @@ func newReportCommand() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&daysBack, "days-back", 7, "how many days back to query")
-	cmd.Flags().BoolVar(&devMode, "dev", false, "dev mode, stop after first page of PRs")
 
 	return cmd
 }

--- a/tools/cmd/reviewers.go
+++ b/tools/cmd/reviewers.go
@@ -44,7 +44,6 @@ func (m *multiStringArg) Set(value string) error {
 func newReviewersCommand() *cobra.Command {
 	var (
 		daysBack     int
-		devMode      bool
 		numReviewers int
 	)
 	ignoreReviewers := multiStringArg{}
@@ -106,7 +105,6 @@ func newReviewersCommand() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&daysBack, "days-back", 31, "how many days back to query, defaults to 31")
-	cmd.Flags().BoolVar(&devMode, "dev", false, "dev mode, stop after first page of PRs")
 	cmd.Flags().IntVar(&numReviewers, "num", 10, "number of reviewers to show, 0 is all")
 	cmd.Flags().Var(&ignoreReviewers, "ignore", "ignore a reviewer, can be repeated")
 

--- a/tools/cmd/root.go
+++ b/tools/cmd/root.go
@@ -14,6 +14,7 @@ import (
 var (
 	configFilename    string
 	orgName, repoName string
+	devMode           bool
 
 	configSettings *config.Settings
 
@@ -33,6 +34,7 @@ func init() {
 
 	cobra.OnInitialize(initConfig)
 
+	rootCmd.PersistentFlags().BoolVar(&devMode, "dev", false, "dev mode, stop after first page of PRs")
 	rootCmd.PersistentFlags().StringVar(&configFilename, "config", defaultConfigFilename, "config file")
 	rootCmd.PersistentFlags().StringVar(&orgName, "org", "openshift", "github organization")
 	rootCmd.PersistentFlags().StringVar(&repoName, "repo", "enhancements", "github repository")


### PR DESCRIPTION
List the pull requests in order by their ID with the calculated number of
days to merge. Default to filtering out updates and non-enhancement PRs.

/cc @russellb