### PR TITLE
update template to explain about keeping all sections

### DIFF
--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -62,6 +62,9 @@ To get started with this template:
    of the platform. Aim for single topic PRs to keep discussions focused. If you
    disagree with what is already in a document, open a new PR with suggested
    changes.
+1. **Keep all required headers.** If a section does not apply to an
+   enhancement, explain why but do not remove the section. This part
+   of the process is enforced by the linter CI job.
 
 The `Metadata` section above is intended to support the creation of tooling
 around the enhancement process.


### PR DESCRIPTION
Add a note to the process at the top of the template explaining that
all required sections must be kept in the published doc.

/assign @wking