### PR TITLE
network: Remove OpenShift-SDN requirement for Bare Metal Load Balancer

### DIFF
--- a/enhancements/network/on-prem-service-load-balancers.md
+++ b/enhancements/network/on-prem-service-load-balancers.md
@@ -93,7 +93,6 @@ A SLB solution must provide these high level features:
     ECMP to send traffic to multiple Nodes for a single Service Load Balancer
 * Suitable for large scale clusters (target up to 2000 nodes).
 * Must be compatible with at least the following cluster network types:
-  [OpenShift-SDN](https://github.com/openshift/sdn) and
   [OVN-Kubernetes](https://github.com/ovn-org/ovn-kubernetes)
 
 ### Non-Goals


### PR DESCRIPTION
I think OpenShift-SDN is not a requirement for this but I want to clarify by raising this PR