### PR TITLE
tools: add labels to the newsletter output

### DIFF
--- a/tools/cmd/report.go
+++ b/tools/cmd/report.go
@@ -175,43 +175,45 @@ func newReportCommand() *cobra.Command {
 				fmt.Printf("\n## Enhancements for Release Priorities\n")
 
 				report.SortByID(prioritizedMerged.Requests)
-				report.ShowPRs("Prioritized Merged", prioritizedMerged.Requests, true)
+				report.ShowPRs("Prioritized Merged", prioritizedMerged.Requests, true, false)
 
 				report.SortByID(prioritizedNew.Requests)
-				report.ShowPRs("Prioritized New", prioritizedNew.Requests, true)
+				report.ShowPRs("Prioritized New", prioritizedNew.Requests, true, true)
 
 				report.SortByID(prioritizedRevived.Requests)
 				report.ShowPRs(
 					"Prioritized Revived (discussion after PR was merged)",
 					prioritizedRevived.Requests,
 					false,
+					false,
 				)
 
 				report.SortByActivityCountDesc(prioritizedActive.Requests)
-				report.ShowPRs("Prioritized Active", prioritizedActive.Requests, true)
+				report.ShowPRs("Prioritized Active", prioritizedActive.Requests, true, true)
 
 				report.SortByID(prioritizedClosed.Requests)
-				report.ShowPRs("Prioritized Closed", prioritizedClosed.Requests, false)
+				report.ShowPRs("Prioritized Closed", prioritizedClosed.Requests, false, false)
 			}
 
 			fmt.Printf("\n## Other Enhancements\n")
 
 			report.SortByID(otherMerged.Requests)
-			report.ShowPRs("Other Merged", otherMerged.Requests, true)
+			report.ShowPRs("Other Merged", otherMerged.Requests, true, false)
 
 			report.SortByID(otherNew.Requests)
-			report.ShowPRs("Other New", otherNew.Requests, true)
+			report.ShowPRs("Other New", otherNew.Requests, true, true)
 
 			report.SortByActivityCountDesc(otherActive.Requests)
-			report.ShowPRs("Other Active", otherActive.Requests, false)
+			report.ShowPRs("Other Active", otherActive.Requests, false, false)
 
 			report.SortByID(otherClosed.Requests)
-			report.ShowPRs("Other Closed", otherClosed.Requests, false)
+			report.ShowPRs("Other Closed", otherClosed.Requests, false, false)
 
 			report.SortByID(revived.Requests)
 			report.ShowPRs(
 				fmt.Sprintf("Revived (closed more than %d days ago, but with new comments)", daysBack),
 				revived.Requests,
+				false,
 				false,
 			)
 
@@ -221,6 +223,7 @@ func newReportCommand() *cobra.Command {
 					daysBack),
 				otherOld.Requests,
 				false,
+				false,
 			)
 
 			report.SortByID(stale.Requests)
@@ -228,12 +231,14 @@ func newReportCommand() *cobra.Command {
 				"Other lifecycle/stale",
 				stale.Requests,
 				false,
+				false,
 			)
 
 			report.SortByID(idle.Requests)
 			report.ShowPRs(
 				fmt.Sprintf("Idle (no comments for at least %d days)", daysBack),
 				idle.Requests,
+				false,
 				false,
 			)
 

--- a/tools/cmd/show-pr.go
+++ b/tools/cmd/show-pr.go
@@ -81,6 +81,7 @@ func newShowPRCommand() *cobra.Command {
 				fmt.Sprintf("Pull Request %d", prID),
 				all.Requests,
 				true,
+				true,
 			)
 
 			prd := all.Requests[0]

--- a/tools/report/report.go
+++ b/tools/report/report.go
@@ -71,9 +71,17 @@ func formatDescription(text string, indent string) string {
 	return strings.Join(indentedLines, "\n")
 }
 
+func formatLabels(prd *stats.PullRequestDetails) string {
+	result := []string{}
+	for _, label := range prd.Pull.Labels {
+		result = append(result, *label.Name)
+	}
+	return strings.Join(result, ", ")
+}
+
 const descriptionIndent = "  "
 
-func showOnePR(prd *stats.PullRequestDetails, withDescription bool) {
+func showOnePR(prd *stats.PullRequestDetails, withDescription bool, withLabels bool) {
 	author := ""
 	if prd.Pull.User != nil {
 		for _, option := range []*string{prd.Pull.User.Name, prd.Pull.User.Login} {
@@ -119,6 +127,12 @@ func showOnePR(prd *stats.PullRequestDetails, withDescription bool) {
 			summary = *prd.Pull.Body
 		}
 		if summary != "" {
+			if withLabels {
+				labelText := formatLabels(prd)
+				if labelText != "" {
+					fmt.Printf("\n%s`%s`\n", descriptionIndent, labelText)
+				}
+			}
 			fmt.Printf("\n%s\n\n", formatDescription(summary, descriptionIndent))
 		}
 	}
@@ -126,7 +140,7 @@ func showOnePR(prd *stats.PullRequestDetails, withDescription bool) {
 
 // ShowPRs prints a section of the report by formatting the
 // PullRequestDetails as a list.
-func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool) {
+func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool, withLabels bool) {
 	if len(prds) == 0 {
 		return
 	}
@@ -147,7 +161,7 @@ func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 			foundUpdate = true
 			continue
 		}
-		showOnePR(prd, withDescription)
+		showOnePR(prd, withDescription, withLabels)
 	}
 
 	if foundUpdate {
@@ -156,7 +170,7 @@ func ShowPRs(name string, prds []*stats.PullRequestDetails, withDescription bool
 			if prd.IsNew {
 				continue
 			}
-			showOnePR(prd, false)
+			showOnePR(prd, false, false)
 		}
 	}
 }

--- a/tools/report/report.go
+++ b/tools/report/report.go
@@ -71,12 +71,19 @@ func formatDescription(text string, indent string) string {
 	return strings.Join(indentedLines, "\n")
 }
 
-func formatLabels(prd *stats.PullRequestDetails) string {
+func extractLabels(prd *stats.PullRequestDetails) []string {
 	result := []string{}
 	for _, label := range prd.Pull.Labels {
 		result = append(result, *label.Name)
 	}
-	return strings.Join(result, ", ")
+	return result
+}
+
+func formatLabels(labels []string, indent string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s`%s`", indent, strings.Join(labels, ", "))
 }
 
 const descriptionIndent = "  "
@@ -128,9 +135,10 @@ func showOnePR(prd *stats.PullRequestDetails, withDescription bool, withLabels b
 		}
 		if summary != "" {
 			if withLabels {
-				labelText := formatLabels(prd)
+				labels := extractLabels(prd)
+				labelText := formatLabels(labels, descriptionIndent)
 				if labelText != "" {
-					fmt.Printf("\n%s`%s`\n", descriptionIndent, labelText)
+					fmt.Printf("\n%s\n", labelText)
 				}
 			}
 			fmt.Printf("\n%s\n\n", formatDescription(summary, descriptionIndent))

--- a/tools/report/report_test.go
+++ b/tools/report/report_test.go
@@ -76,6 +76,36 @@ Fourth line
 	}
 }
 
+func TestFormatLabels(t *testing.T) {
+
+	for _, tc := range []struct {
+		Scenario string
+		Input    []string
+		Expected string
+	}{
+		{
+			Scenario: "None",
+			Input:    []string{},
+			Expected: "",
+		},
+		{
+			Scenario: "One",
+			Input:    []string{"label1"},
+			Expected: descriptionIndent + "`label1`",
+		},
+		{
+			Scenario: "Two",
+			Input:    []string{"label1", "label2"},
+			Expected: descriptionIndent + "`label1, label2`",
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			actual := formatLabels(tc.Input, descriptionIndent)
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}
+
 func TestFindSplit(t *testing.T) {
 	for _, tc := range []struct {
 		Scenario string


### PR DESCRIPTION
Include labels in the verbose details of pull requests to highlight
any that are being held, or that have partial approval.

Sample output: https://hackmd.io/ZGz4KyiQSraa3pMe_0G4Wg

/assign @russellb