### PR TITLE
operator-dev-doc.md: add registry.ci.openshift.org

### DIFF
--- a/dev-guide/operators.md
+++ b/dev-guide/operators.md
@@ -299,6 +299,17 @@ plus operator image build for such operators.
 
 ## Authenticating against ci registry
 (Internal Red Hat registries for developer testing)
+
+### registry.ci.openshift.org
+- Login at https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request with your github account. This may require you to have access to the internal "OpenShift" Github organization so if you have access issues, double-check that you have access to that org and try requesting it if you don't have it.
+- Once logged in, an API token will be displayed. Please copy it.
+- Then login to a `registry.json` file like this
+
+```bash
+$ podman login --authfile registry.json -u ${GITHUB_USER} -p ${TOKEN}
+```
+
+### registry.svc.ci.openshift.org
 Add the necessary credentials to your local `~/.docker/config.json` (or equivalent file) like so:
 - visit `https://api.ci.openshift.org`, `upper right corner '?'` dropdown to `Command Line Tools`
 - copy the given `oc login https://api.ci.openshift.org --token=<hidden>`, paste in your terminal


### PR DESCRIPTION
operator-dev-doc only mentions how to connect to the old registry.
This PR is adding the new one and the text is coppied from here: https://source.redhat.com/groups/public/palonsor/palonsor_wiki/how_to_perform_custom_builds_of_ocp4_components

I am not sure if I should remove the old one