### PR TITLE
tools: ignore special files in template lint

### DIFF
--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -25,6 +25,16 @@ do
         continue
     fi
 
+    # Handle some special case files that live in the enhancements
+    # directory but are not enhancements, and cannot be moved
+    # elsewhere.
+    case "${file}" in
+        enhancements/operator-dev-doc.md | enhancements/README.md | enhancements/rebase.md)
+            echo "Skipping non-enhancement file ${file}"
+            continue
+            ;;
+    esac
+
     echo "Checking ${file}"
 
     # Iterate over the required headers in the template. We look for


### PR DESCRIPTION
Set up the template lint script so it will ignore some files that are
in the enhancements directory but not enhancements.