### PR TITLE
tools: update make dependency to build lint image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:  ## Display this help
 image:  ## Build local container image
 	$(RUNTIME) image build -f ./hack/Dockerfile.markdownlint --tag enhancements-markdownlint:latest
 
-lint:  ## run the markdown linter
+lint: image  ## run the markdown linter
 	$(RUNTIME) run \
 		--rm=true \
 		--env RUN_LOCAL=true \


### PR DESCRIPTION
Ensure that running `make lint` builds a recent image by adding a
dependency. Podman's cache prevents the build from running every time,
but this simplifies the instructions for running the lint test locally.