### PR TITLE
host-port-registry: add 9446 port

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -85,6 +85,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9102  | kube-proxy | sdn | 4.7 | metrics, third-party network plugins only |
 | 9103  | ovn-kubernetes node kube-rbac-proxy | sdn || metrics |
 | 9258  | cluster-cloud-controller-manager-operator | cluster infra | 4.9 | metrics, control plane only |
+| 9446  | baremetal-operator | kni | 4.9 | healthz; baremetal provisioning, control plane only |
 | 9537  | crio      | node || metrics |
 | 9641  | ovn-kubernetes northd | sdn | 4.3 | control plane only, ovn-kubernetes only |
 | 9642  | ovn-kubernetes southd | sdn | 4.3 | control plane only, ovn-kubernetes only |


### PR DESCRIPTION
This is used by the baremetal-operator health endpoint.

See also https://github.com/openshift/cluster-baremetal-operator/pull/180