### PR TITLE
Allow overriding the base commit for template linting when running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ##@ General
 
 RUNTIME ?= podman # container command for linter and report-upload
+PULL_BASE_SHA ?= origin/master # Allow the template check base ref to be overriden
 
 .PHONY: help
 help:  ## Display this help
@@ -17,6 +18,7 @@ lint:  ## run the markdown linter
 		--rm=true \
 		--env RUN_LOCAL=true \
 		--env VALIDATE_MARKDOWN=true \
+		--env PULL_BASE_SHA=$(PULL_BASE_SHA) \
 		-v $$(pwd):/workdir:Z \
 		enhancements-markdownlint:latest
 


### PR DESCRIPTION
I was trying to run the tool locally to verify my updates to a doc before pushing. Because I don't have my local copy of the enhancements repo as origin (mine is named `openshift`), this caused the template check to fail.

With this change you can now `PULL_BASE_SHA=openshift/master make lint` and it works.

I imagine I'm not the only one who might be affected by this so thought I would propose this as a UX improvement