### PR TITLE
Enable Baremetal on other Platforms to support centralized host management

### DIFF
--- a/enhancements/baremetal/enable-baremetal-on-other-platforms.md
+++ b/enhancements/baremetal/enable-baremetal-on-other-platforms.md
@@ -4,16 +4,16 @@ authors:
   - "@asalkeld"
   - "@sadasu"
 reviewers:
-  - "@hardy"
+  - "@hardys"
   - "@romfreiman"
   - "@dhellman"
 approvers:
-  - "@hardy"
+  - "@hardys"
 creation-date: 2021-08-20
 last-updated: 2021-08-20
 status: implementable
 see-also:
-  - "/enhancements/baremetal-provisiong-config.md"
+  - "/enhancements/baremetal/baremetal-provisioning-config.md"
 replaces:
 superseded-by:
 ---
@@ -64,9 +64,12 @@ Centralized host management can deploy clusters when running on the above platfo
 
 Allow Baremetal Host API to be fully enabled on all platforms.
 
-Note that the scope of this epic is only enablement of the Metal3
-BaremetalHost API and associated controller/services - the centralized host management flow
-currently interacts directly via this API without any Machine API integration.
+Allow Machine API integration across platform types.
+- The centralized host management flow currently interacts directly via this API
+  without any Machine API integration.
+- This means further work will be required via a future enhancement to enable the
+  single cluster case where a combination of e.g VM controlplane and Baremetal
+  workers is desired.
 
 ## Proposal
 
@@ -106,8 +109,7 @@ nodes would be booted via virtual media. This removes the requirement for the
 Provisioning Network which can be expected to be available only in Baremetal platform types.
 
 2. documentation will need to be added to the centralized host management documentation
-explaining how to create a Provisioning CR. Current documentation is here:
-https://github.com/openshift/assisted-service/blob/8880093ef5ce041d4c1951ffd5ea1096991ec3ee/docs/user-guide/assisted-service-on-openshift.md#configure-bare-metal-operator
+explaining how to create and update a Provisioning CR for these platforms.
 
 ### User Stories
 
@@ -191,7 +193,6 @@ Customers can instead create a dedicated baremetal cluster to use as the hub
 cluster.
 
 Another alternative is to additionally distribute baremetal-operator as an optional
-operator with OLM. It's probably not a good idea, but worth enumerating as an alternative.
-The main downsides are the complexity of releasing and distributing the same project
-two different ways, and the potential for install-time confusion or conflict over
-which method should be used to install it.
+operator with OLM. The main downsides are the complexity of releasing and
+distributing the same project two different ways, and the potential for install-time
+confusion or conflict over which method should be used to install it.

--- a/enhancements/baremetal/enable-baremetal-on-other-platforms.md
+++ b/enhancements/baremetal/enable-baremetal-on-other-platforms.md
@@ -81,7 +81,14 @@ Currently CBO checks the platform and if it is not baremetal it will be in a "di
 1. set status.conditions Disabled=true and
 2. not read or process the Provisioning CR and thus not deploy baremetal-operator.
 
-This proposal is to allow CBO to be enabled on the Platforms: None, OpenStack or vSphere.
+This proposal is to allow CBO to be enabled on the following platforms only:
+- Baremetal (current)
+- None
+- OpenStack
+- vSphere.
+
+Note: The Hypershift use case will be explicitly disallowed by disabling CBO when
+Infrastructure.Status.ControlPlaneTopology == "External".
 
 Further (to restrict the testing matrix) the allowed configuration options
 of the Provisioning CR will be restricted to exactly those required by centralized host management.
@@ -101,7 +108,6 @@ Provisioning Network which can be expected to be available only in Baremetal pla
 2. documentation will need to be added to the centralized host management documentation
 explaining how to create a Provisioning CR. Current documentation is here:
 https://github.com/openshift/assisted-service/blob/8880093ef5ce041d4c1951ffd5ea1096991ec3ee/docs/user-guide/assisted-service-on-openshift.md#configure-bare-metal-operator
-
 
 ### User Stories
 

--- a/enhancements/baremetal/enable-baremetal-on-other-platforms.md
+++ b/enhancements/baremetal/enable-baremetal-on-other-platforms.md
@@ -51,7 +51,7 @@ See:
 The specific goals of this proposal are to:
 
 Support the centralized host management use case by partially enabling Baremetal Host API
-on the following platforms:
+on the following on-premise platforms:
 - None
 - OpenStack
 - vSphere
@@ -99,8 +99,9 @@ of the Provisioning CR will be restricted to exactly those required by centraliz
 *Only spec.provisioningNetwork=Disabled mode will be accepted in the Provisioning CR.*
 
 If any other provisioningNetwork mode is set, the CBO webhook will refuse the change
-in the usual case, but if defined before upgrading the operator, the Reconcile loop
-must always validate the Provisioning CR.
+in the usual way, but if defined before upgrading the operator, the Reconcile loop must always
+validate the Provisioning CR
+(by setting ClusterOperator/baremetal condition[InvalidConfiguration] = true ).
 
 Note:
 
@@ -130,11 +131,10 @@ There is concern that *random* customers will use this feature out of context
 and create support burden. This is why we have not suggested enabling CBO on
 all platforms and with full feature set. However it is still a potential issue.
 
+Another mitigation for this is to avoid documenting this outside of the CIM/ZTP case.
+For that reason this change won't be documented as a standalone feature, only in the context of CIM/ZTP.
+
 ## Design Details
-
-### Open Questions [optional]
-
-1. Where will the feature be e2e tested?
 
 ### Test Plan
 

--- a/enhancements/baremetal/enable-baremetal-on-other-platforms.md
+++ b/enhancements/baremetal/enable-baremetal-on-other-platforms.md
@@ -1,0 +1,179 @@
+---
+title: enable-baremetal-on-other-platforms
+authors:
+  - "@asalkeld"
+  - "@sadasu"
+reviewers:
+  - TBD
+  - "@hardy"
+  - "@romfreiman"
+  - "@dhellman"
+approvers:
+  - TBD
+creation-date: 2021-08-20
+last-updated: 2021-08-20
+status: implementable
+see-also:
+  - "/enhancements/baremetal-provisiong-config.md"
+replaces:
+superseded-by:
+---
+
+# Enable Baremetal on other Platforms to support ZTP
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [ ] Operational readiness criteria is defined
+- [ ] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
+
+## Summary
+
+Baremetal Host API is only available when deploying an OpenShift cluster with the baremetal
+platform (via the IPI or AI (Assisted Installer) workflow). Having the ability to
+manage baremetal hosts from clusters without requiring the cluster to be on baremetal
+would be beneficial to customers.
+
+## Motivation
+
+An initial driver of this feature are the centralized host management use cases
+in edge topologies, which without this feature, is restricted to having the
+central OpenShift cluster deployed on baremetal.
+
+### Goals
+
+The specific goals of this proposal are to:
+
+Support the ZTP (Zero Touch Provisioning) use case by partially enabling Baremetal Host API
+on the following platforms:
+- None
+- OpenStack
+- vSphere
+
+We will be successful when:
+
+ZTP can deploy clusters when running on the above platforms.
+
+### Non-Goals
+
+Allow Baremetal Host API to be fully enabled on all platforms.
+
+Note that the scope of this epic is only enablement of the Metal3
+BaremetalHost API and associated controller/services - the edge ZTP flow
+currently interacts directly via this API without any Machine API integration.
+
+## Proposal
+
+BMO (baremetal-operator) provides the Baremetal Host API, it in turn is configured
+and managed by CBO (cluster-baremetal-operator).
+
+CBO reads the Provisioning CR that is created by the installer on baremetal platforms
+and uses that to configure and deploy BMO.
+
+Currently CBO checks the platform and if it is not baremetal it will be in a "disabled" state i.e. it will
+1. set status.conditions Disabled=true and
+2. not read or process the Provisioning CR and thus not deploy baremetal-operator.
+
+This proposal is to allow CBO to be enabled on the Platforms: None, OpenStack or vSphere.
+
+Further (to restrict the testing matrix) the allowed configuration options
+of the Provisioning CR will be restricted to exactly those required by ZTP.
+
+*Only spec.provisioningNetwork=Disabled mode will be accepted in the Provisioning CR.*
+
+If any other provisioningNetwork mode is set, the CBO webhook will refuse the change.
+
+Note: documentation will need to be added to the ZTP docs explaining how to create
+a Provisioning CR. Current doc are here:
+https://github.com/openshift/assisted-service/blob/8880093ef5ce041d4c1951ffd5ea1096991ec3ee/docs/user-guide/assisted-service-on-openshift.md#configure-bare-metal-operator
+
+
+### User Stories
+
+#### Story 1 - Current IPI baremetal platform use case
+
+No change.
+
+#### Story 2 - ZTP use case
+
+As a user of a hub cluster that performs central infrastructure management, and
+optionally zero-touch provisioning, I need to provision hosts using the k8s-native
+API (Baremetal Hosts CR) even when the hub cluster has a platform of None, OpenStack, or vSphere.
+
+
+### Risks and Mitigations
+
+There is concern that *random* customers will use this feature out of context
+and create support burden. This is why we have not suggested enabling CBO on
+all platforms and with full feature set. However it is still a potential issue.
+
+## Design Details
+
+### Open Questions [optional]
+
+1. Are these all the platforms that are required?
+2. Is just enabling spec.provisioningNetwork=Disabled mode sufficient?
+3. What will create the Provisioning CR?
+4. Where will the feature be e2e tested?
+
+### Test Plan
+
+#### Unit Testing
+
+We will add unit tests to confirm that cluster-baremetal-operator:
+* is enabled on the required platforms.
+* will restrict functionality on these platforms to ProvisioningNetork=Disabled.
+
+#### e2e Testing
+
+An e2e test will be written that will:
+
+1. create one of the platforms above (SNO Platform=None might be the easiest).
+2. Then create the Provisioning CR and wait for CBO to be ready
+3. provision a baremetal host.
+
+### Graduation Criteria
+
+#### Dev Preview -> Tech Preview
+
+#### Tech Preview -> GA
+
+The feature will go to GA without tech preview
+
+#### Removing a deprecated feature
+
+### Upgrade / Downgrade Strategy
+
+cluster-baremetal-operator will upgrade as it currently does, this is only a
+minor change in functionality.
+
+On the platforms (None, OpenStack and vSphere) where the operator was in a disabled
+state, after been upgraded it will move into an enabled state. However in all but ZTP
+use cases nothing will change as there is no Provisioning CR.
+
+### Version Skew Strategy
+
+None required as this is not dependant on other components.
+
+## Implementation History
+
+This PR is the current WIP implementation: https://github.com/openshift/cluster-baremetal-operator/pull/189
+
+## Drawbacks
+
+There is concern that *random* customers will use this feature out of context
+and create support burden.
+
+## Alternatives
+
+Customers can instead create a dedicated baremetal cluster to use as the hub
+cluster.
+
+Another alternative is to additionally distribute baremetal-operator as an optional
+operator with OLM. It's probably not a good idea, but worth enumerating as an alternative.
+The main downsides are the complexity of releasing and distributing the same project
+two different ways, and the potential for install-time confusion or conflict over
+which method should be used to install it.


### PR DESCRIPTION
cluster-baremetal-operator is only enabled when deploying an OpenShift cluster with the baremetal
platform (via the IPI or AI workflow). Having the ability to manage baremetal nodes from
clusters without requiring the cluster to be on baremetal would be beneficial to customers.

https://github.com/openshift/cluster-baremetal-operator/pull/189#issuecomment-892641328
/cc @hardys 