### PR TITLE
[fix] Ingress custom http error pages

### DIFF
--- a/enhancements/ingress/customize-error-code-pages.md
+++ b/enhancements/ingress/customize-error-code-pages.md
@@ -67,7 +67,7 @@ metadata:
   name: default
   namespace: openshift-ingress-operator
 spec:
-  httpErrorCodePage: 
+  httpErrorCodePages: 
     name: "my-custom-error-code-pages" 
 ```
 2. The configmap keys shall have the format `error-page-`<error code>`.http`. Right now only error-page-503.http and

--- a/enhancements/ingress/customize-error-code-pages.md
+++ b/enhancements/ingress/customize-error-code-pages.md
@@ -67,7 +67,8 @@ metadata:
   name: default
   namespace: openshift-ingress-operator
 spec:
-  httpErrorCodePage: "my-custom-error-code-pages" 
+  httpErrorCodePage: 
+    name: "my-custom-error-code-pages" 
 ```
 2. The configmap keys shall have the format `error-page-`<error code>`.http`. Right now only error-page-503.http and
    error-page-404.http will be available.


### PR DESCRIPTION
I have tested on Openshift 4.9 and there's an error when configuring spec.httpErrorCodePages as String instead of an Object String.

spec.httpErrorCodePages: Invalid value: "string": spec.httpErrorCodePages in body must be of type object: "string"