### PR TITLE
Insights Operator pulling and exposing SCA entitlement certs - update

### DIFF
--- a/enhancements/insights/pulling-sca-certs-from-ocm.md
+++ b/enhancements/insights/pulling-sca-certs-from-ocm.md
@@ -97,7 +97,7 @@ The Insights Operator must provide a cluster ID as an identifier of the cluster.
 ### SCA certs in API
 
 The SCA certificate is available via the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace.
-The type of the `etc-pki-entitlement` secret is the `kubernetes.io/tls` with standard `tls.key` and `tls.crt` attributes.
+The type of the `etc-pki-entitlement` secret is an `Opaque` secret with `entitlement-key.pem` attribute for the private key and `entitlement.pem` attribute for the certificate itself.
 The secret will be available for use in other namespaces by creating a cluster-scoped `Share` resource.
 Cluster admin creates a `clusterrolebinding` to allow a service account access to the `Share` resource.
 
@@ -142,7 +142,10 @@ This feature is planned as a technical preview in OCP 4.9 and is planned to go G
 - inform a cluster user about the error state (problem with pulling the certificates)
 - the documentation is revisited and updated
 - the use of SCA certs in the `Build` is documented in the Build API documentation
-- the feature might be moved to a different OCP component
+- the feature might be moved to a different OCP component - discussed after Tech preview with following points:
+  - there was a proposal to move it to `openshift-controller-manager`, but there is no desire or reason to do so and there is probably no advantage
+  - there was a concern about investigating/debugging image build failures in the Insights operator - the investigation path should be fairly clear (and probably would not be better if it were in the `openshift-controller-manager`)
+  - Insights operator has multiple responsibilities/purposes - it's OK for now, because there is no better commponent for this at the moment
 
 #### Removing a deprecated feature
 


### PR DESCRIPTION
This is updating the original `pulling-sca-certs-from-ocm.md` enhancements in two points:

- changing the secret type to `Opaque` so that the attribute names can be renamed - the reason is that the subscription manager and consequently builds, expect PEM files. 
- providing update for the `the feature might be moved to a different OCP component` graduation criteria - the decision is to keep it in the Insights operator for now