### PR TITLE
host-port-registry: Reserve 9447 port for BMO webhook

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -88,6 +88,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9200-9219  | various CSI drivers | storage | 4.8 | metrics |
 | 9258  | cluster-cloud-controller-manager-operator | cluster infra | 4.9 | metrics, control plane only |
 | 9446  | baremetal-operator | kni | 4.9 | healthz; baremetal provisioning, control plane only |
+| 9447  | baremetal-operator | kni | 4.10 | webhook; baremetal provisioning, control plane only |
 | 9537  | crio      | node || metrics |
 | 9641  | ovn-kubernetes northd | sdn | 4.3 | control plane only, ovn-kubernetes only |
 | 9642  | ovn-kubernetes southd | sdn | 4.3 | control plane only, ovn-kubernetes only |


### PR DESCRIPTION
Baremetal Operator runs a ValidatingWebhook to validate requests.
This PR reserves 9447 port for that service.

This PR depends on https://github.com/openshift/cluster-baremetal-operator/pull/213