### PR TITLE
Disable the no-trailing-spaces linter rule

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -44,3 +44,7 @@ config:
   blanks-around-lists: false
   single-trailing-newline: false
   no-multiple-blanks: false
+
+  # Trailing spaces don't cause any known issues and are often introduced when 
+  # updating text to conform to max line length restrictions.
+  no-trailing-spaces: false


### PR DESCRIPTION
I'm not aware of the value provided by this linter rule.  If someone else does, please let me know and we can keep it.

https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md009 says:
```
Rationale: Except when being used to create a line break, trailing whitespace has no purpose and does not affect the rendering of content.
```

Which to me says "there's no good reason to enforce this because trailing whitespace has no cost"
