### PR TITLE
dev-guide/cluster-version-operator/dev/clusterversion: Drop version from 'group'

### DIFF
--- a/dev-guide/cluster-version-operator/dev/clusterversion.md
+++ b/dev-guide/cluster-version-operator/dev/clusterversion.md
@@ -58,7 +58,7 @@ $ cat <<EOF >version-patch-first-override.yaml
   path: /spec/overrides
   value:
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: network-operator
     namespace: openshift-network-operator
     unmanaged: true
@@ -71,7 +71,7 @@ $ cat <<EOF >version-patch-add-override.yaml
   path: /spec/overrides/-
   value:
     kind: Deployment
-    group: apps/v1
+    group: apps
     name: network-operator
     namespace: openshift-network-operator
     unmanaged: true


### PR DESCRIPTION
Resource manifests have an `apiVersion` property that is `{group}/{version}`:

```console
$ oc adm release extract --to manifests registry.ci.openshift.org/ocp/release:4.10.0-0.nightly-2021-12-06-201335
Extracted release payload from digest sha256:0ab310bf32a549764f37387a1da2f148485ce03a412ac9afea4f7173e4d43d5e created at 2021-12-06T20:21:17Z
$ head -n5 manifests/0000_70_cluster-network-operator_03_deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: network-operator
  namespace: openshift-network-operator
```

But for `overrides`, there's no reason to say "override this resource if the manifest is v1, but have the CVO try to continue to manage it if the manfest is v2" and such, which is why [the ComponentOverride type has a `group` property][1], and not an `apiVersion` property.

We hadn't noticed these docs mistakenly including the `/{version}` until now, because until [rhbz#2022509][2] (openshift/cluster-version-operator#689), the cluster-version operator had completely ignored the group value when making `overrides` comparisons (a good sign that not many people use `overrides`?).  Now that the CVO looks at the group property, we've noticed and can update the examples to use valid values.

[1]: https://github.com/openshift/api/blob/a19f3b9052a6238bbf6c84057297d1c275519f7d/config/v1/types_cluster_version.go#L226-L229
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2022509