### PR TITLE
CONVENTIONS: Update CPU query sum_irate

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -470,9 +470,9 @@ for all containers in the `openshift-monitoring` namespace:
 # CPU request / usage of the SDN container
 scalar(
   max(kube_pod_container_resource_requests{namespace="openshift-sdn", container="sdn", resource="cpu"}) /
-  max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="openshift-sdn", container="sdn"}[120m]))) * 
+  max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="openshift-sdn", container="sdn"}[120m]))) *
 # CPU usage of each container in the openshift-monitoring namespace
-max by (pod, container) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="openshift-monitoring"})
+max by (pod, container) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="openshift-monitoring"})
 ```
 
 > Please note that pods which run on control-plane nodes must use the etcd container as their baseline.


### PR DESCRIPTION
Catching up with kubernetes-monitoring/kubernetes-mixin#619, which landed in OpenShift 4.9 and later [here][2].

[2]: https://github.com/openshift/cluster-monitoring-operator/pull/1214/files#diff-3125af8c4a74a5a372c15a821e3c53b7f5710c3ebd5af1fb05f4d7294e2f1afdL529