### PR TITLE
Ignore new markdownlint rules that fail on existing documents

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -48,3 +48,9 @@ config:
   # Trailing spaces don't cause any known issues and are often introduced when 
   # updating text to conform to max line length restrictions.
   no-trailing-spaces: false
+
+  # Rules present in newer markdownlint versions that fail across almost all
+  # existing documents
+  emphasis-style: false
+  strong-style: false
+  no-space-in-emphasis: false


### PR DESCRIPTION
The lint job on PRs began failing recently on existing documents.

This is because a few new rules have been added to markdownlint: https://github.com/DavidAnson/markdownlint/pull/448

I wasn't sure whether I should be updating the existing documents to
conform to the new rules or just ignore those new rules altogether,
so I went with the latter.