### PR TITLE
helm: fix example in the documentation

### DIFF
--- a/enhancements/helm3/console.md
+++ b/enhancements/helm3/console.md
@@ -105,13 +105,10 @@ kind: HelmChartRepository
 metadata:
   name: my-enterprise-chart-repo
 spec:
-  url: https://my.chart-repo.org/stable
-
-  # optional and only needed for UI purposes
-  displayName: myChartRepo
-
-  # optional and only needed for UI purposes
-  description: my private chart repo
+  # Optional: human readable repository name, it is used by UI for displaying purposes
+  name: my-enterprise-chart-repo
+  connectionConfig:
+     url: https://my.chart-repo.org/stable
 ```
 
 An operator would watch for changes on them and reconfigure the chart repository proxy which is used to power the UI experience in OpenShift today..
@@ -144,20 +141,18 @@ kind: HelmChartRepository
 metadata:
   name: stable
 spec:
-  url: https://kubernetes-charts.storage.googleapis.com
-
-  displayName: Public Helm stable charts
-
-  description: Public Helm stable charts hosted on HelmHub
+  name: stable
+  connectionConfig:
+    url: https://kubernetes-charts.storage.googleapis.com
 ---
 apiVersion: helm.openshift.io/v1beta1
 kind: HelmChartRepository
 metadata:
   name: incubator
 spec:
-  url: https://kubernetes-charts-incubator.storage.googleapis.com
-
-  displayName: Public Helm charts in incubator state
+  name: incubator
+  connectionConfig:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
 EOF
 
 $ kubectl get helmchartrepositories
@@ -206,7 +201,7 @@ $ helm install mysql stable/mysql
 3) Similar changes would be proposed to all `helm` application lifecycle commands to honour the presence of in-cluster representations of chart repository configurations.
 
 
-#### Alternatives
+#### Alternative Methods
 
 #### 1. The configuration could be embedded into cluster-wide [`Console` config](https://github.com/openshift/api/blob/master/config/v1/types_console.go#L26)
 

--- a/enhancements/helm3/namespace-scoped-helm-repository-crd.md
+++ b/enhancements/helm3/namespace-scoped-helm-repository-crd.md
@@ -64,14 +64,36 @@ kind: ProjectHelmChartRepository
 metadata:
   name: my-enterprise-chart-repo
 spec:
-  url: https://my.chart-repo.org/stable
-
-  # optional and only needed for UI purposes
-  displayName: myChartRepo
-
-  # optional and only needed for UI purposes
-  description: my private chart repo
+  # Optional: human readable repository name, it is used by UI for displaying purposes
+  name: my-enterprise-chart-repo
+  connectionConfig:
+    url: https://my.chart-repo.org/stable
 ```
+
+Example `Role` definition:
+```yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ns-helm-role
+  namespace: default
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - helm.openshift.io
+  resources:
+  - projecthelmchartrepositories
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+```
+Before applying operations on the CR, make sure the user/service account has correct permission by with a desired `Role` and `RoleBinding`.
 
 To add a new namespace-scoped Helm repository to a desired namespace:
 ```shell
@@ -81,9 +103,9 @@ kind: ProjectHelmChartRepository
 metadata:
   name: stable
 spec:
-  url: https://kubernetes-charts-incubator.storage.googleapis.com
-  displayName: Public Helm stable charts
-  description: Public Helm stable charts hosted on HelmHub
+  name: stable
+  connectionConfig:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
 EOF
 
 $ kubectl get projecthelmchartrepositories --namespace my-namespace
@@ -100,9 +122,9 @@ kind: HelmChartRepository
 metadata:
   name: stable
 spec:
-  url: https://kubernetes-charts.storage.googleapis.com
-  displayName: Public Helm stable charts
-  description: Public Helm stable charts hosted on HelmHub
+  name: stable
+  connectionConfig:
+    url: https://kubernetes-charts.storage.googleapis.com
 EOF
 
 $ cat <<EOF | oc apply --namespace my-namespace -f -
@@ -111,8 +133,9 @@ kind: ProjectHelmChartRepository
 metadata:
   name: incubator
 spec:
-  url: https://kubernetes-charts-incubator.storage.googleapis.com
-  displayName: Public Helm charts in incubator state
+  name: incubator
+  connectionConfig:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
 EOF
 
 $ kubectl get helmchartrepositories


### PR DESCRIPTION
Fixes CR example in the Helm enhancement doc, and adds a section with
desired RBAC setup before applying CR.

Signed-off-by: Allen Bai <abai@redhat.com>