### PR TITLE
Add operator name and component labels

### DIFF
--- a/enhancements/monitoring/alerting-consistency.md
+++ b/enhancements/monitoring/alerting-consistency.md
@@ -123,6 +123,10 @@ these alerts if they are not actionable.
   * Runbook style documentation for resolving critical alerts is required.
     These runbooks are reviewed by OpenShift SREs and currently live in the
     [openshift/runbooks][2] repository.
+* Operator Alerts are RECOMMENDED to include `kubernetes_operator_part_of` label
+  indicating the operator name the alert is related to.
+* Operator Alerts are RECOMMENDED to include `kubernetes_operator_component` label
+  indicating the operator component name that the alert is related to.
 
 ### Critical Alerts
 


### PR DESCRIPTION
Added 2 recommended labels for operators alerts.
`kubernetes_operator_part_of` - Name of the operator the alert was fire fired from.
`kubernetes_operator_component` - Name of the component/sub operator  the alert was fire fired from.

Signed-off-by: Shirly Radco <sradco@redhat.com>