### PR TITLE
enhancements/update/update-blocker-lifecycle: Pivot to "update recommendations"

### DIFF
--- a/enhancements/update/update-blocker-lifecycle/README.md
+++ b/enhancements/update/update-blocker-lifecycle/README.md
@@ -5,7 +5,7 @@ authors:
 reviewers:
   - "@LalatenduMohanty"
 approvers:
-  - TBD
+  - "@sdodson"
 creation-date: 2020-09-11
 last-updated: 2021-06-17
 status: implementable

--- a/enhancements/update/update-blocker-lifecycle/README.md
+++ b/enhancements/update/update-blocker-lifecycle/README.md
@@ -6,6 +6,8 @@ reviewers:
   - "@LalatenduMohanty"
 approvers:
   - "@sdodson"
+api-approvers:
+  - None
 creation-date: 2020-09-11
 last-updated: 2021-06-17
 status: implementable


### PR DESCRIPTION
Users are occasionally confused by the "blocked edges" wording, which is internal shorthand.

The fact that update recommendations are tracked as a directed graph (hence "edges") isn't all that relevant for most users, so talk about "updates" instead of "edges".

While we occasionally drop update recommendations to reduce the chances that users update into serious issues, from [docs][1]:

> When an update recommendation is supported, it remains supported for the life of 4.10, even if the update recommendation is later dropped or made conditional.

Updating is still possible, we just don't think it's a good idea (unless maybe you're elbow deep in a support case, and a support tech decides to recommend an update based on context that is not available to the update service).  So replace "blocked" with "not recommended", to convey the "still possible" aspect.

Also ask for some more specifics in the impact statement template, as we gear up to support conditional updates fff9d3c349 (#821).  I haven't gone as far as "tell us what PromQL to use in our conditional recommendation", but I'm easing things in that direction.

[1]: https://docs.openshift.com/container-platform/4.10/updating/understanding-upgrade-channels-release.html#upgrade-version-paths_understanding-upgrade-channels-releases