### PR TITLE
tools: fix linter handling of deleted and renamed files

### DIFF
--- a/hack/find_changed.sh
+++ b/hack/find_changed.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Find the enhancements files that have changed in the current PR.
+
+set -o errexit
+set -o pipefail
+
+for f in $(git log --name-only --pretty= "${PULL_BASE_SHA:-origin/master}.." -- \
+               | (grep '^enhancements.*\.md$' || true) \
+               | sort -u); do
+    # Filter out anything that no longer exists, probably because of a
+    # rename in the middle of the PR chain.
+    if [ ! -f ${f} ]; then
+        echo "Skipping deleted or renamed file ${f}" 1>&2
+        continue
+    fi
+
+    echo $f
+done

--- a/hack/metadata-lint.sh
+++ b/hack/metadata-lint.sh
@@ -8,12 +8,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(git log --name-only --pretty= "${PULL_BASE_SHA:-origin/master}.." -- \
-                    | (grep '^enhancements.*\.md$' || true) \
-                    | sort -u)
+CHANGED_FILES=$(${SCRIPTDIR}/find_changed.sh)
 
 (cd tools && go build -o ../enhancement-tool -mod=mod ./main.go)
 

--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -7,24 +7,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TEMPLATE=$(dirname $0)/../guidelines/enhancement_template.md
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEMPLATE=${SCRIPTDIR}/../guidelines/enhancement_template.md
 
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(git log --name-only --pretty= "${PULL_BASE_SHA:-origin/master}.." -- \
-                    | (grep '^enhancements.*\.md$' || true) \
-                    | sort -u)
+CHANGED_FILES=$(${SCRIPTDIR}/find_changed.sh)
 
 RC=0
 for file in $CHANGED_FILES
 do
-    # Look for files that were renamed.
-    if [ ! -f ${file} ]; then
-        echo "Skipping deleted file ${file}"
-        continue
-    fi
-
     echo "Checking ${file}"
 
     # Iterate over the required headers in the template. We look for


### PR DESCRIPTION
We have a couple of lint steps that only apply to files modified
within the current PR. This patch fixes the way those steps calculate
the changed file list so that files that were deleted are not included
and files that were renamed are only included under their new name.

/assign @bparees
/cc @kikisdeliveryservice
/cc @aravindhp