### PR TITLE
Dual stack VIPs: Add rules for openshift/api fields on upgrades

### DIFF
--- a/enhancements/network/on-prem-dual-stack-vips.md
+++ b/enhancements/network/on-prem-dual-stack-vips.md
@@ -277,7 +277,7 @@ The following table shows the rules how the fields are set:
 | 1    | _empty_                    | foo                        | [0]: foo                     | foo                          | `new` field is empty, `old` with value: set `new[0]` to value from `old` |
 | 2    | [0]: foo <br />[1]: bar    | _empty_                    | [0]: foo <br />[1]: bar      | foo                          | `new` contains values, `old` is empty: set `old` to value from `new[0]` |
 | 3    | [0]: foo <br />[1]: bar    | foo                        | [0]: foo <br />[1]: bar      | foo                          | `new` field contains values, `old` contains `new[0]`: we are fine, as `old` is part of `new` |
-| 4    | [0]: foo <br />[1]: bar    | bar                        | [0]: foo <br />[1]: bar      | bar                          | `new` contains values, `old` contains `new[1]`: we are fine, as `old` is part of `new` |
+| 4    | [0]: foo <br />[1]: bar    | bar                        | [0]: foo <br />[1]: bar      | foo                          | `new` contains values, `old` contains `new[1]`: as `new[0]` contains the clusters primary IP family, new values take precedence over old values, so set `old` to value from `new[0]` |
 | 5    | [0]: foo <br />[1]: bar    | baz                        | [0]: foo <br />[1]: bar      | foo                          | `new` contains values, `old` contains a value which is not included in `new`: new values take precedence over old values, so set `old` to value from `new[0]` (and log a warning) |
 
 ### Version Skew Strategy

--- a/enhancements/network/on-prem-dual-stack-vips.md
+++ b/enhancements/network/on-prem-dual-stack-vips.md
@@ -1,20 +1,20 @@
 ---
-title: dual-stack-vips
+title: on-prem-dual-stack-vips
 authors:
-  - @cybertron
-  - @creydr
+  - "@cybertron"
+  - "@creydr"
 reviewers:
-  - @creydr
-  - @dougsland
+  - "@creydr"
+  - "@dougsland"
 approvers:
-  - @patrickdillon
-  - @kirankt
-  - @shardy
-  - @cgwalters
-  - @kikisdeliveryservice
+  - "@patrickdillon"
+  - "@kirankt"
+  - "@shardy"
+  - "@cgwalters"
+  - "@kikisdeliveryservice"
 api-approvers:
-  - @danwinship
-  - @aojea
+  - "@danwinship"
+  - "@aojea"
 creation-date: 2022-03-01
 last-updated: 2022-08-02
 tracking-link:
@@ -89,6 +89,12 @@ Minimal risk. This is just adding another VIP, something we already have in
 our deployments. The main concern would be logic errors arising out of
 the need to handle multiple VIPs, which (if they happen) will need to be
 addressed as bugs.
+
+### Drawbacks
+
+Nothing significant. A very small amount of compute resources will be used
+to manage the new VIPs. Even this can be avoided by simply not specifying
+the second VIP if it is not needed.
 
 ## Design Details
 
@@ -297,12 +303,6 @@ NA
 ## Implementation History
 
 4.11: Initial implementation
-
-## Drawbacks
-
-Nothing significant. A very small amount of compute resources will be used
-to manage the new VIPs. Even this can be avoided by simply not specifying
-the second VIP if it is not needed.
 
 ## Alternatives
 


### PR DESCRIPTION
In #1048 we added and deprecated fields in openshift/api. 
To have consistent APIs regardless of upgrade or a fresh installation, we need one component to update the `XYPlatformStatus` fields correctly. This PR adds details how the values of these fields get updated.