### PR TITLE
Track host ports used by metallb

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -88,6 +88,9 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9103  | ovn-kubernetes node kube-rbac-proxy | sdn || metrics |
 | 9105  | ovn-kubernetes node kube-rbac-proxy-ovn-metrics | sdn | 4.10 | metrics |
 | 9106  | sdn controller kube-rbac-proxy | sdn | 4.10 | control plane only, sdn only |
+| 9120  | metallb | sdn | 4.9 | metrics|
+| 9121  | metallb | sdn | 4.9 | metrics|
+| 9122  | metallb | sdn | 4.9 | leader election protocol |
 | 9200-9219  | various CSI drivers | storage | 4.8 | metrics |
 | 9258  | cluster-cloud-controller-manager-operator | cluster infra | 4.9 | metrics, control plane only |
 | 9446  | baremetal-operator | kni | 4.9 | healthz; baremetal provisioning, control plane only |
@@ -126,6 +129,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 4500  | ovn-kubernetes IPsec | sdn | 4.7 | ovn-kubernetes only |
 | 4789  | openshift-sdn / ovn-kubernetes VXLAN | sdn | 3.0 | openshift-sdn always, ovn-kubernetes when using Windows hybrid networking |
 | 6081  | ovn-kubernetes geneve | sdn | 4.3 | ovn-kubernetes only |
+| 9122  | metallb | sdn | 4.9 | leader election protocol |
 
 
 ## Localhost-only
@@ -145,6 +149,8 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 11443 | kube-scheduler | workloads || recovery-controller |
 | 29100 | openshift-sdn | sdn |4.10| metrics |
 | 29101 | openshift-sdn | sdn || metrics |
+| 29150 | metallb | sdn | 4.9 | metrics |
+| 29151 | metallb | sdn | 4.9 | metrics |
 | 29105 | ovn-kubernetes | sdn |4.10| metrics, ovn-kubernetes only|
 | 29102 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 | 29103 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |


### PR DESCRIPTION
The metallb speakers are hostnetworked pods. There are a few ports that
need to be exposed outside of the nodes, for metrics and for leader
election, and another couple for the local non-encrypted metrics.

Here we start tracking them.

Note: the process of pinning to the right ports is still in progress (to the point that metrics are not working :P ), but we'll bring them back to 4.9.