### PR TITLE
fix Power VS install-config example

### DIFF
--- a/enhancements/installer/ibm-cloud-for-power-vs-ipi.md
+++ b/enhancements/installer/ibm-cloud-for-power-vs-ipi.md
@@ -215,7 +215,7 @@ networking:
 platform:
   powervs:
     userid: clnperez@us.ibm.com
-    serviceInstance: "some-id-string-here"
+    serviceInstanceID: "some-id-string-here"
     powervsResourceGroup: "powervs-ipi-resource-group"
     region: lon
     zone: lon04


### PR DESCRIPTION
We changed the name of `serviceInstance` to `serviceInstanceID`.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>