### PR TITLE
lint: only apply template lint rules to new files

### DIFF
--- a/hack/find_new.sh
+++ b/hack/find_new.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Find the enhancements files that are new in the current PR.
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -o errexit
+set -o pipefail
+
+FILELIST=/tmp/$$.filelist
+git ls-tree --name-only -r "${PULL_BASE_SHA:-origin/master}" enhancements > $FILELIST
+
+for f in $(${SCRIPTDIR}/find_changed.sh); do
+    if ! grep -q $f $FILELIST; then
+        echo $f
+    fi
+done

--- a/hack/metadata-lint.sh
+++ b/hack/metadata-lint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 # Ensure the enhancement metadata includes the required information
 
 set -o errexit
@@ -15,8 +13,11 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # incompatible with existing documents.
 CHANGED_FILES=$(${SCRIPTDIR}/find_changed.sh)
 
-if [ -n "$CHANGED_FILES" ]; then
-    (cd tools && go build -o ../enhancement-tool -mod=mod ./main.go)
-
-    ./enhancement-tool metadata-lint ${CHANGED_FILES}
+if [ -z "$CHANGED_FILES" ]; then
+    echo "OK, no changed enhancements found"
+    exit 0
 fi
+
+(cd tools && go build -o ../enhancement-tool -mod=mod ./main.go)
+
+./enhancement-tool metadata-lint ${CHANGED_FILES}

--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -14,7 +14,12 @@ TEMPLATE=${SCRIPTDIR}/../guidelines/enhancement_template.md
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(${SCRIPTDIR}/find_changed.sh)
+CHANGED_FILES=$(${SCRIPTDIR}/find_new.sh)
+
+if [ -z "$CHANGED_FILES" ]; then
+    echo "OK, no new enhancement files found"
+    exit 0
+fi
 
 RC=0
 for file in $CHANGED_FILES

--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -14,15 +14,15 @@ TEMPLATE=${SCRIPTDIR}/../guidelines/enhancement_template.md
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(${SCRIPTDIR}/find_new.sh)
+NEW_FILES=$(${SCRIPTDIR}/find_new.sh)
 
-if [ -z "$CHANGED_FILES" ]; then
+if [ -z "$NEW_FILES" ]; then
     echo "OK, no new enhancement files found"
     exit 0
 fi
 
 RC=0
-for file in $CHANGED_FILES
+for file in $NEW_FILES
 do
     echo "Checking ${file}"
 


### PR DESCRIPTION
Ignore existing files during template lint. We don't expect authors to 
update to use the new template, so this change ignores existing files so we
don't have to manually override the job failure each time.

/assign @bparees
/cc @kikisdeliveryservice