### PR TITLE
lint: only apply metadata lint rules to new files

### DIFF
--- a/hack/metadata-lint.sh
+++ b/hack/metadata-lint.sh
@@ -11,13 +11,13 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
-CHANGED_FILES=$(${SCRIPTDIR}/find_changed.sh)
+NEW_FILES=$(${SCRIPTDIR}/find_new.sh)
 
-if [ -z "$CHANGED_FILES" ]; then
+if [ -z "$NEW_FILES" ]; then
     echo "OK, no changed enhancements found"
     exit 0
 fi
 
 (cd tools && go build -o ../enhancement-tool -mod=mod ./main.go)
 
-./enhancement-tool metadata-lint ${CHANGED_FILES}
+./enhancement-tool metadata-lint ${NEW_FILES}


### PR DESCRIPTION
The metadata portion of the template changes over time, and we only
want to apply the new rules to new files.

/assign @bparees
/cc @kikisdeliveryservice