### PR TITLE
MGMT-10403: SNO + Workers enhancement - adjust upgrade non-goal to be a goal

### DIFF
--- a/enhancements/single-node/single-node-openshift-with-workers.md
+++ b/enhancements/single-node/single-node-openshift-with-workers.md
@@ -409,10 +409,13 @@ be explicitly `Workers`. Doing this means that after upgrading a cluster
 matching the above criteria from an older version that doesn't contain this
 enhancement to a newer version that does, the `DefaultPlacement` field will go
 from being empty (implying `Workers`) to being `ControlPlane`. This in turn, in
-most default configuratoins, will trigger a reconciliation of the default
+most default configurations, will trigger a reconciliation of the default
 ingress Deployment, as the `nodePlacement` in the default `IngressController`
 is empty. This reconcilliation will trigger a rollout of the default Ingress
-pods with node selectors targetting the "master" node label.
+pods with node selectors targetting the "master" node label, as desired. This
+rollout will cause a slight period of ingress downtime, but this is not a
+problem and is expected behavior in single control-plane node clusters,
+especially during an upgrade.
 
 The installer may not set `DefaultPlacement` to `ControlPlane` when the
 cluster's `ControlPlaneTopology` is set to `External`.


### PR DESCRIPTION
The non-goal in question is:

```markdown
Deal with expansion of clusters that have been installed before the
implementation of this enhancement (if possible, their expansion may be
addressed by an upgrade followed with documentation outlining the steps
that the user has to take to enable expansion, e.g. patch the default
`IngressController` to have node selector targetting the master pool
rather than the worker pool).
```

Having it be a non-goal seems to have been a mistake, as it's really
easy to solve and would save a lot of headache in terms of complexity
for users upgrading from 4.10 to 4.11 - we wouldn't have to document
the differences between a "true freshly installed 4.11" cluster and
a "cluster upgraded to 4.11", expanding it with workers should work
just the same.

Implementation of this adjustment:

https://github.com/openshift/cluster-ingress-operator/pull/767