### PR TITLE
CONSOLE-3159: Annotation update

### DIFF
--- a/enhancements/console/dynamic-plugins.md
+++ b/enhancements/console/dynamic-plugins.md
@@ -448,7 +448,7 @@ spec:
     enabled: true
 ```
 
-In the 4.11 release, a `console.openshift.io/use-i18next` annotation
+In the 4.11 release, a `console.openshift.io/use-i18n` annotation
 is being introduced. The annotation indicates whether the `ConsolePlugin` contains
 localization resources. If the annotation is set to `"true"`, the localization
 resources from the i18n namespace named after the dynamic plugin (e.g. `plugin__kubevirt`),


### PR DESCRIPTION
Updating the annotation to `console.openshift.io/use-i18n` since `i18next` will lazy load the locales eventually.

/assign @spadgett 