### PR TITLE
Add Egress IP health monitoring port

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -9,7 +9,7 @@ reviewers:
 approvers:
   - "@russelb"
 creation-date: 2020-08-26
-last-updated: 2022-05-09
+last-updated: 2022-08-31
 status: informational
 ---
 
@@ -88,6 +88,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9103  | ovn-kubernetes node kube-rbac-proxy | sdn || metrics |
 | 9105  | ovn-kubernetes node kube-rbac-proxy-ovn-metrics | sdn | 4.10 | metrics |
 | 9106  | sdn controller kube-rbac-proxy | sdn | 4.10 | control plane only, sdn only |
+| 9107  | ovn-kubernetes node | sdn | 4.12 | egressip-node-healthcheck-port, sdn interface only, ovn-kubernetes only |
 | 9120  | metallb | sdn | 4.9 | metrics|
 | 9121  | metallb | sdn | 4.9 | metrics|
 | 9122  | metallb | sdn | 4.9 | leader election protocol |


### PR DESCRIPTION
Reserve port 9107 for egress IP health monitoring support.
This port is expected to be used by gRPC and configured
in ovnkube via flag: --egressip-node-healthcheck-port

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Reported-at: https://issues.redhat.com/browse/SDN-3156