### PR TITLE
hostport registry: add NodeObservability hostnetwork ports

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -103,6 +103,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9642  | ovn-kubernetes southd | sdn | 4.3 | control plane only, ovn-kubernetes only |
 | 9643  | ovn-kubernetes northd | sdn | 4.3 | control plane only, ovn-kubernetes only |
 | 9644  | ovn-kubernetes southd | sdn | 4.3 | control plane only, ovn-kubernetes only |
+| 9743  | node-observability-agent | node | 4.12 | Add-on operator (off OCP payload). HTTPS endpoint for the node observability API, kube-rbac-proxy protected |
 | 9978  | etcd      | etcd || metrics, control plane only |
 | 9979  | etcd      | etcd || ?, control plane only |
 | 10010 | crio | node || stream port |
@@ -158,6 +159,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 29102 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 | 29103 | ovn-kubernetes | sdn || metrics, ovn-kubernetes only |
 | 29445 | haproxy | sdn | 4.7 | on-prem internal loadbalancer, stats port |
+| 29740 | node-observability-agent | node | 4.12 | Add-on operator (off OCP payload). HTTP endpoint for the node observability API |
 
 
 ## Previously allocated


### PR DESCRIPTION
[NodeObservability Operator](https://github.com/openshift/node-observability-operator) is an add-on (off OCP payload) operator, it deploys an agent (`DaemonSet`) on the nodes which need to be observed. The observation is currently limited to CRIO and Kubelet profiling probes ([standard golang pprof endpoints](https://pkg.go.dev/net/http/pprof)) which are triggered via the agent HTTPS endpoint: **Operator**  --HTTPS-->  **Agent on the node**  --UnixDomainSocket/HTTPS-->  **CRIO/Kubelet pprof endpoint**. The agent has been set as privileged container to be able to mount the unix domain socket of CRIO. Also, this led to a dedicated SCC with quite wide permissions (almost cluster-admin).

The idea behind this PR is to reduce the cluster level permissions of NodeObservability Operator. This can be done by targeting the HTTPS CRIO pprof endpoint (instead of the socket). This needs the `hostnetwork` access as CRIO HTTPS pprof endpoint is bound on `localhost` address and cannot receive traffic from the POD network namespace. The hostnetwork access enabled for NodeObservability Operator results in 2 occupied ports which we would like to make visible by creating this PR.

Note: `9740` port can potentially be removed in the future, if `kube-rbac-proxy` will [support proxying via unix domain socket](https://github.com/brancz/kube-rbac-proxy/issues/199).

Any ideas/remarks are welcome!