### PR TITLE
enhancements/update/update-blocker-lifecycle: Prioritize critical questions

### DIFF
--- a/enhancements/update/update-blocker-lifecycle/README.md
+++ b/enhancements/update/update-blocker-lifecycle/README.md
@@ -77,14 +77,27 @@ The following statement (or a link to this section) can be pasted into bugs when
 
 We're asking the following questions to evaluate whether or not this bug warrants changing update recommendations from either the previous X.Y or X.Y.Z.
 The ultimate goal is to avoid delivering an update which introduces new risk or reduces cluster functionality in any way.
+In the absence of a declared update risk (the status quo), there is some risk that the existing fleet updates into the at-risk releases.
+Depending on the bug and estimated risk, leaving the update risk undeclared may be acceptable.
+
 Sample answers are provided to give more context and the ImpactStatementRequested label has been added to this bug.
 When responding, please remove ImpactStatementRequested and set the ImpactStatementProposed label.
 The expectation is that the assignee answers these questions.
 
-Which 4.y.z to 4.y'.z' updates increase vulnerability?  Which types of clusters?
-* reasoning: This allows us to populate [`from`, `to`, and `matchingRules` in conditional update recommendations][graph-data-block] for "the `$SOURCE_RELEASE` to `$TARGET_RELEASE` update is not recommended for clusters like `$THIS`".
-* example: Customers upgrading from 4.y.Z to 4.y+1.z running on GCP with thousands of namespaces, approximately 5% of the subscribed fleet.  Check your vulnerability with `oc ...` or the following PromQL `count (...) > 0`.
-* example: All customers upgrading from 4.y.z to 4.y+1.z fail.  Check your vulnerability with `oc adm upgrade` to show your current cluster version.
+Which 4.y.z to 4.y'.z' updates increase vulnerability?
+* reasoning: This allows us to populate [`from` and `to` in conditional update recommendations][graph-data-block] for "the `$SOURCE_RELEASE` to `$TARGET_RELEASE` update is exposed.
+* example: Customers upgrading from any 4.y (or specific 4.y.z) to 4.(y+1).z'.  Use `oc adm upgrade` to show your current cluster version.
+
+Which types of clusters?
+* reasoning: This allows us to populate [`matchingRules` in conditional update recommendations][graph-data-block] for "clusters like `$THIS`".
+* example: GCP clusters with thousands of namespaces, approximately 5% of the subscribed fleet.  Check your vulnerability with `oc ...` or the following PromQL `count (...) > 0`.
+
+The two questions above are sufficient to declare an initial update risk, and we would like as much detail as possible on them as quickly as you can get it.
+Perfectly crisp responses are nice, but are not required.
+For example "it seems like these platforms are involved, because..." in a day 1 draft impact statement is helpful, even if you follow up with "actually, it was these other platforms" on day 3.
+In the absence of a response within 7 days, we may or may not declare a conditional update risk based on our current understanding of the issue.
+
+If you can, answers to the following questions will make the conditional risk declaration more actionable for customers.
 
 What is the impact?  Is it serious enough to warrant removing update recommendations?
 * reasoning: This allows us to populate [`name` and `message` in conditional update recommendations][graph-data-block] for "...because if you update, `$THESE_CONDITIONS` may cause `$THESE_UNFORTUNATE_SYMPTOMS`".


### PR DESCRIPTION
Bug/incident lifecyle often looks like:

1. Someone reports a bug/issue.
2. Responders identify it as serious / systemic, and not a one-off.
3. Responders have a very rough handle on which cluster flavors and which A->B updates are exposed.
4. Developers work to actually root-cause the issue and work up a fix.
5. QE comes in to verify the fix, and needs a reliable reproducer.  We get more clarity on what cluster flavors and A->B updates are exposed.
6. Post-mortem root-cause analysis.  We get even more clarity on what cluster flavors and A->B updates are exposed.

There are also some costs/benefits to declaring an update risk:

a. True positive: risk matches actually vulnerable cluster: hooray, customer protected.
b. True negative: risk does not match an actually invulnerable cluster: hooray, customer not bothered.
c. False positive: risk matches actually invulnerable cluster: customer potentially confused, but maybe some digging around the discussion in the linked reference convinces them they aren't vulnerable.  Or maybe they delay their update until we ship a fix, so they don't have to manually evaluate their risk.  But even the best-case user experience here is still somewhat disruptive.
d. False negative: risk does not match an actually vulnerable cluster: customer could blindly update into and be bitten by a known bug/issue.

From an update-risk perspective, lining up with the steps from bug/incident lifecycle above:

1 No update risk declared, because we're not going to declare every bug/issue an update risk.  What would we use for source and target version?  What would we put in the message?  During this stage, there is false-negative risk that other folks make the vulnerable update and get bit, but there's not much we could have done to protect them.

2 Ok, it's a serious bug/incident.  But still, we don't have enough information to declare even a preliminary risk.  We can start pushing for the information we'll need to declare a risk, but the responders who are best-positioned to provide those details are the same developers who are starting in step (4)'s diagnosis and fix. We don't want to distract those developers more than necessary. But we also don't want to continue with the false-negative fleet risk longer than necessary.  Squishy trade-offs.

3 (and 4) We have a rough handle, and can declare a messy conditional update risk if that seems appropriate.  Depending on our confidence in our handle on the bug/incident, we may be able to get false-positive risk down to an acceptable level (e.g. "we're pretty sure this A->B issue only impacts 10% of the fleet on A, and we're ok with unknown amounts of false positives within that 10%").  We might also have a handle on the false-negative risk (e.g. "actually, mitigation/recovery isn't that bad, so more false-negatives might be ok").

5 (and 6) Devs have delivered the fix, so now we can distract them more while we try to pin down specifics on impact, mitigation, finer points of matching rules, etc., depending on how exposed we feel on the remaining fronts.

This commit tries to focus the impact-statement request on the information we cannot live without for declaring a preliminary conditional update risk in the (3/4) range, if that seems appropriate. It tries to make it clear that answers do not need to be perfect, or grounded in watertight arguments, or anything.  It allows for following up to sort out remaining ambiguity after the initial flurry of activity is calming down.  Hopefully it helps us hit a sweet spot for the amount of effort expended by responders (including developers) vs. the amount of fleet protection and admin convenience that effort is helping deliver.