### PR TITLE
microshift: update set of included APIs

### DIFF
--- a/enhancements/microshift/kubernetes-for-device-edge.md
+++ b/enhancements/microshift/kubernetes-for-device-edge.md
@@ -203,8 +203,6 @@ OpenShift APIs supported will be:
 
 * route.openshift.io/v1 for Routes
 * security.openshift.io/v1 for SecurityContextConstraints
-* authorization.openshift.io/v1 for RBAC APIs such as Role,
-  RoleBinding, etc.
 
 In addition to those APIs, we will enable two OpenShift controllers
 related to Ingress:


### PR DESCRIPTION
The authorization.openshift.io APIs have been removed from MicroShift,
so let's update the enhancement to avoid confusing early users.

/assign @deads2k
/assign @oglok
/assign @benluddy