### PR TITLE
enhancements/olm: Minor updates to the platform operators proposal

### DIFF
--- a/enhancements/olm/platform-operators.md
+++ b/enhancements/olm/platform-operators.md
@@ -674,6 +674,8 @@ This may indicate the want/need for a more robust implementation for the status 
 
 For more information, see [a discussion thread centered around this topic in the o/enhancements#1170 proposal](https://github.com/openshift/enhancements/pull/1170#discussion_r915034676).
 
+See the [platform operators roadmap](https://hackmd.io/MFwDuS_XS7quls3Q4ANKLw) for more information on subsequent phases.
+
 ## Infrastructure Needed [optional]
 
 - [x] Downstream repositories created in the OpenShift organization for the new API components.

--- a/enhancements/olm/platform-operators.md
+++ b/enhancements/olm/platform-operators.md
@@ -201,7 +201,7 @@ When configuring an individual PlatformOperator resource, the resource's `spec.p
 
 > Note: The `spec.packageName` field is a required field that must be populated.
 
-```yaml=
+```yaml
 apiVersion: platform.openshift.io/v1alpha1
 kind: PlatformOperator
 metadata:
@@ -368,7 +368,7 @@ When generating the BundleDeployment resource, the PO manager will use the uniqu
 
 An example of this behavior can be seen below:
 
-```yaml=
+```yaml
 apiVersion: core.rukpak.io/v1alpha1
 kind: BundleDeployment
 metadata:


### PR DESCRIPTION
Updates the `yaml=` language code brackets that hackmd uses in favor of something that will render using github's markdown preview UI.

Add the link to the WIP platform operators roadmap.