### PR TITLE
dev-guide/cluster-version-operator/OWNERS: Add Petr

### DIFF
--- a/dev-guide/cluster-version-operator/OWNERS
+++ b/dev-guide/cluster-version-operator/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - smarterclayton
-  - abhinavdahiya
   - sdodson
   - wking
-  - vrutkovs
   - jottofar
   - LalatenduMohanty
+  - petr-muller


### PR DESCRIPTION
Now that he's on the updates team.  And keep Scott around, since he looks over update-y docs.  Otherwise, prune some emeritus members to align with [the CVO repository's current approvers][1].

[1]: https://github.com/openshift/cluster-version-operator/blob/abd74a216726b16785387f5372385ded46aa028b/OWNERS