### PR TITLE
fix linter issue in installer/operators-check.md

### DIFF
--- a/enhancements/installer/operators-check.md
+++ b/enhancements/installer/operators-check.md
@@ -81,10 +81,8 @@ None
 
 The important detail is how we define _stable_. The definition proposed here is:
 
-```
-If a cluster operator does not maintain Progressing=False for at least 30 seconds,
-during a five minute period it is unstable.
-```
+> If a cluster operator does not maintain Progressing=False for at least 30 seconds,
+> during a five minute period it is unstable.
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
The linter job for #1189 was overridden, so invalid markdown landed. This
fixes the markup to make the job work for other PRs.

/assign @sdodson
/cc @patrickdillon