### PR TITLE
update external provider enhancement

### DIFF
--- a/enhancements/cloud-integration/infrastructure-external-platform-type.md
+++ b/enhancements/cloud-integration/infrastructure-external-platform-type.md
@@ -412,11 +412,11 @@ type CloudControllerManagerSettings struct {
 
 // ExternalPlatformSpec holds the desired state for the generic External infrastructure provider.
 type ExternalPlatformSpec struct{
-    // ProviderName holds the arbitrary string represented cloud provider name, expected to be set at the installation time.
+    // PlatformName holds the arbitrary string represented cloud provider name, expected to be set at the installation time.
     // Intended to serve only for informational purposes and not expected to be used for decision-making.
     // +kubebuilder:default:="Unknown"
     // +optional
-    ProviderName string `json:"providerName,omitempty"`
+    PlatformName string `json:"platformName,omitempty"`
     // CloudControllerManager contains settings specific to the external Cloud Controller Manager (a.k.a. CCM or CPI)
     // +optional
     CloudControllerManager CloudControllerManagerSettings `json:"cloudControllerManager"`


### PR DESCRIPTION
this change updates a name from the code sample to be consistent with the created code. When reviewing the code for the API implementation of the external platform type, we had a realization about the variable name we are using to distinguish the provider supplied name for the infrastructure. For more information, see the discussion on original pull request[0].

[0] https://github.com/openshift/api/pull/1301