### PR TITLE
Update host-port-registry for etcd port 9980

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -111,6 +111,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9644  | ovn-kubernetes southd | sdn | 4.3 | control plane only, ovn-kubernetes only |
 | 9978  | etcd      | etcd || metrics, control plane only |
 | 9979  | etcd      | etcd || ?, control plane only |
+| 9980  | etcd      | etcd || healthz, readyz |
 | 10010 | crio | node || stream port |
 | 10250 | kubelet | node || kubelet api |
 | 10251 | kube-scheduler | apiserver || healthz, control plane only |


### PR DESCRIPTION
https://github.com/openshift/cluster-etcd-operator/blob/master/bindata/etcd/pod.yaml#L198


On OCP 4.12.0:
```
$ oc get pods -o yaml -n openshift-etcd | grep -i 9980 -C 1
          path: healthz
          port: 9980
          scheme: HTTPS
--
          path: healthz
          port: 9980
          scheme: HTTPS
--
          path: healthz
          port: 9980
          scheme: HTTPS
--
          path: healthz
          port: 9980
          scheme: HTTPS
--
          path: readyz
          port: 9980
          scheme: HTTPS
...
 $ oc get pods -o yaml -n openshift-etcd | grep -i listen.port -B 9
    - command:
      - /bin/sh
      - -c
      - |
        #!/bin/sh
        set -euo pipefail

        exec nice -n -18 cluster-etcd-operator readyz \
          --target=https://localhost:2379 \
          --listen-port=9980 \
...
```

From master node:
```
$ oc debug node/master-0.<cluster>.com
# ss -lnpt | grep -i 9980
LISTEN 0      128                *:9980             *:*    users:(("cluster-etcd-op",pid=38915,fd=7))
```

CC @hasbro17 