### PR TITLE
Fix broken documentation url

### DIFF
--- a/enhancements/console/dynamic-plugins.md
+++ b/enhancements/console/dynamic-plugins.md
@@ -23,7 +23,7 @@ status: implemented
 - [x] Design details are appropriately documented from clear requirements
 - [x] Test plan is defined
 - [x] Graduation criteria for dev preview, tech preview, GA
-- [x] User-facing documentation is created in [openshift-docs](https://docs.openshift.com/container-platform/4.12/web_console/dynamic-plug-ins.html)
+- [x] User-facing documentation is created in [openshift-docs](https://docs.openshift.com/container-platform/4.12/web_console/dynamic-plug-in/dynamic-plug-in.html)
 
 ## Summary
 


### PR DESCRIPTION
Current documentation URL sends you to a not existing page
<img width="1937" alt="image" src="https://user-images.githubusercontent.com/20617822/233122377-1d51ed7a-ba01-46b4-b561-ca9324f86650.png">
