### PR TITLE
Add exception to pointer guidance for structs that must be omitted

### DIFF
--- a/dev-guide/api-conventions.md
+++ b/dev-guide/api-conventions.md
@@ -109,6 +109,18 @@ This means, that any end user fetching the resource from the API can observe tha
 This has the effect of helping our users to understand how they might be able to configure their cluster, without
 having to search for features or review API schemas within the product docs.
 
+##### Pointers to structs
+
+An exception to this rule is when using a pointer to a struct in combination with an API validation that requires the field to be unset.
+
+The JSON tag `omitempty` is not compatible with struct references. Meaning any struct will always, when empty, be marshalled to `{}`. If the struct **must** genuinely be omitted, it must be a pointer.
+
+When used in combination with a validation such as `minProperties` on the parent, or a required field within the struct, the struct itself must be
+omitted to avoid validations being applied to the empty struct and returning
+false positives.
+
+For a concrete example, view this [thread](https://github.com/openshift/enhancements/pull/1411/files#r1212790070).
+
 ### Only one phrasing for each idea
 
 Each idea should have a single possible expression in the API structures, without having multiple ways to say the same thing.


### PR DESCRIPTION
A couple of times now I've needed to use a pointer with a struct to achieve the desired API behaviour, for example when the empty struct must genuinely be omitted.

An example of this is when the field has a required field within it. API validations will not execute if the serialised version does not include the field. (ie `{}` vs `{blah: {}}`)

A secondary example is when you use the `minProperties` validation on the parent, in this case we need the field to be genuinely omitted else the parent cannot use `minProperties` effectively. (`{blah: {}}` would pass `minProperties: 1` even though the intention is to have at least one non-empty field within the struct)

CC @deads2k @ingvagabund 