### PR TITLE
AUTH-387: auth: add enhancement for unsupported direct kube-apiserver oidc config

### DIFF
--- a/enhancements/authentication/direct-oidc-study/setup_keycloak.sh
+++ b/enhancements/authentication/direct-oidc-study/setup_keycloak.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# run from the cluster-authentication-operator repo
+OPENSHIFT_KEEP_IDP=true WHAT=TestKeycloakAsOIDCPasswordGrantCheckAndGroupSync make run-e2e-test
+
+KC_NS="$(oc get ns -l'e2e-test=openshift-authentication-operator' --no-headers | head -1 | cut -d' ' -f1)"
+KC_URL="https://$(oc get route -n $KC_NS test-route --template='{{ .spec.host }}')/realms/master"
+
+oc patch cm -n openshift-config-managed default-ingress-cert -p '{"metadata":{"namespace":"openshift-config"}}' --dry-run=client -o yaml | oc apply -f -
+oc patch proxy cluster -p '{"spec":{"trustedCA":{"name":"default-ingress-cert"}}}' --type=merge
+
+curl -k "${KC_URL}/.well-known/openid-configuration" > oauthMetadata
+oc create configmap oauth-meta --from-file ./oauthMetadata -n openshift-config
+
+oc patch authentication cluster -p '{"spec":{"oauthMetadata":{"name":"oauth-meta"},"type":"None"}}' --type=merge
+
+oc patch kubeapiserver cluster -p '{"spec":{"unsupportedConfigOverrides":{"apiServerArguments":{"oidc-ca-file":["/etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt"],"oidc-client-id":["admin-cli"], "oidc-issuer-url":["'"${KC_URL}"'"]}}}}' --type=merge
+
+# this should get us a token
+curl -k "$KC_URL/protocol/openid-connect/token" -d "grant_type=password" -d "client_id=admin-cli" -d "scope=openid" -d "username=admin" -d "password=password" | jq -r '.id_token'
+

--- a/enhancements/authentication/direct-oidc-study/study-oidc-in-openshift.md
+++ b/enhancements/authentication/direct-oidc-study/study-oidc-in-openshift.md
@@ -1,0 +1,425 @@
+# Getting a Keycloak instance
+
+The cluster-authentication-operator tests allow you to create and persist a Keycloak instance. Run the `setup_keycloak.sh`
+(the other file in this gist) bash script from your local copy of the cluster-authentication-operator repository.
+
+It might be better to run it with the patch from https://github.com/openshift/cluster-authentication-operator/pull/609
+in case Keycloak pod is shut down for some reason. Note that the changes you're doing to your Keycloak instance are not
+persisted and so you might need to redo some of them in this case.
+
+# Command line interface - oc
+
+## Initial config
+
+* oc login is broken - the "openshift-challenging-client" is missing:
+  * Note that the OIDC provider is running **in the very same OpenShift cluster** behind a route. If it were running separately, we would likely get issues with the provider's certificate.
+
+```
+I0515 16:37:20.986177   66477 loader.go:372] Config loaded from file:  /home/slaznick/random_kubeconfig
+I0515 16:37:20.986381   66477 round_trippers.go:466] curl -v -XHEAD  'https://api.sl-bd.group-b.devcluster.openshift.com:6443/'
+I0515 16:37:20.987348   66477 round_trippers.go:495] HTTP Trace: DNS Lookup for api.sl-bd.group-b.devcluster.openshift.com resolved to [{52.7.27.156 } {34.238.77.130 } {35.168.253.93 } {107.23.124.234 } {52.205.180.113 }]
+I0515 16:37:21.085613   66477 round_trippers.go:510] HTTP Trace: Dial to tcp:52.7.27.156:6443 succeed
+I0515 16:37:21.285965   66477 round_trippers.go:553] HEAD https://api.sl-bd.group-b.devcluster.openshift.com:6443/ 403 Forbidden in 299 milliseconds
+I0515 16:37:21.286044   66477 round_trippers.go:570] HTTP Statistics: DNSLookup 0 ms Dial 98 ms TLSHandshake 101 ms ServerProcessing 97 ms Duration 299 ms
+I0515 16:37:21.286081   66477 round_trippers.go:577] Response Headers:
+I0515 16:37:21.286117   66477 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:37:21.286149   66477 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 8db4d3d4-4c84-4a0c-9fc3-0f7e736b0bf4
+I0515 16:37:21.286181   66477 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: e20e4cbc-8ab1-4280-8053-cdbd773f31b8
+I0515 16:37:21.286213   66477 round_trippers.go:580]     Content-Length: 186
+I0515 16:37:21.286243   66477 round_trippers.go:580]     Content-Type: application/json
+I0515 16:37:21.286273   66477 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+I0515 16:37:21.286305   66477 round_trippers.go:580]     Date: Mon, 15 May 2023 14:37:21 GMT
+I0515 16:37:21.286337   66477 round_trippers.go:580]     Audit-Id: 4a4ee046-bf8a-4dab-bc17-21a920692670
+I0515 16:37:21.286368   66477 round_trippers.go:580]     Cache-Control: no-cache, private
+I0515 16:37:21.286411   66477 request_token.go:93] GSSAPI Enabled
+I0515 16:37:21.286531   66477 round_trippers.go:466] curl -v -XGET  -H "X-Csrf-Token: 1" 'https://api.sl-bd.group-b.devcluster.openshift.com:6443/.well-known/oauth-authorization-server'
+I0515 16:37:21.384583   66477 round_trippers.go:553] GET https://api.sl-bd.group-b.devcluster.openshift.com:6443/.well-known/oauth-authorization-server 200 OK in 97 milliseconds
+I0515 16:37:21.384669   66477 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 97 ms Duration 97 ms
+I0515 16:37:21.384698   66477 round_trippers.go:577] Response Headers:
+I0515 16:37:21.384735   66477 round_trippers.go:580]     Cache-Control: no-cache, private
+I0515 16:37:21.384764   66477 round_trippers.go:580]     Content-Type: application/json
+I0515 16:37:21.384792   66477 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+I0515 16:37:21.384820   66477 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 8db4d3d4-4c84-4a0c-9fc3-0f7e736b0bf4
+I0515 16:37:21.384847   66477 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: e20e4cbc-8ab1-4280-8053-cdbd773f31b8
+I0515 16:37:21.384877   66477 round_trippers.go:580]     Date: Mon, 15 May 2023 14:37:21 GMT
+I0515 16:37:21.384903   66477 round_trippers.go:580]     Audit-Id: 3e15d235-133c-4741-b0fd-bf2819f0eb65
+I0515 16:37:21.750557   66477 request_token.go:467] falling back to kubeconfig CA due to possible x509 error: x509: certificate signed by unknown authority
+```
+The above are the common, uninteresting bits that will be omitted from next logs.
+
+Below we can see that the client found the proper auth URL and tries to reach it with `client_id=openshift-challenging-client` and fails with `400`:
+
+```
+I0515 16:37:21.750616   66477 round_trippers.go:466] curl -v -XGET  -H "X-Csrf-Token: 1" 'https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master/protocol/openid-connect/auth?client_id=openshift-challenging-client&code_challenge=SOQNg9806C9_GYWp1K_Thoiz6KQLgzXQST7iTquyRc8&code_challenge_method=S256&redirect_uri=https%3A%2F%2Ftest-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com%2Frealms%2Fmaster%2Foauth%2Ftoken%2Fimplicit&response_type=code'
+I0515 16:37:21.751027   66477 round_trippers.go:495] HTTP Trace: DNS Lookup for test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com resolved to [{107.22.212.24 } {54.166.125.229 }]
+I0515 16:37:21.849199   66477 round_trippers.go:510] HTTP Trace: Dial to tcp:107.22.212.24:443 succeed
+I0515 16:37:22.072343   66477 round_trippers.go:553] GET https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master/protocol/openid-connect/auth?client_id=openshift-challenging-client&code_challenge=SOQNg9806C9_GYWp1K_Thoiz6KQLgzXQST7iTquyRc8&code_challenge_method=S256&redirect_uri=https%3A%2F%2Ftest-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com%2Frealms%2Fmaster%2Foauth%2Ftoken%2Fimplicit&response_type=code 400 Bad Request in 321 milliseconds
+I0515 16:37:22.072428   66477 round_trippers.go:570] HTTP Statistics: DNSLookup 0 ms Dial 98 ms TLSHandshake 102 ms ServerProcessing 120 ms Duration 321 ms
+I0515 16:37:22.072459   66477 round_trippers.go:577] Response Headers:
+I0515 16:37:22.072498   66477 round_trippers.go:580]     X-Frame-Options: SAMEORIGIN
+I0515 16:37:22.072525   66477 round_trippers.go:580]     Content-Security-Policy: frame-src 'self'; frame-ancestors 'self'; object-src 'none';
+I0515 16:37:22.072553   66477 round_trippers.go:580]     Content-Language: en
+I0515 16:37:22.072579   66477 round_trippers.go:580]     Set-Cookie: 3c9e6724823ac7ad9a5d50942d705e4c=39f2e9b0235c633edc00cae002808130; path=/; HttpOnly; Secure; SameSite=None
+I0515 16:37:22.072610   66477 round_trippers.go:580]     Content-Length: 1762
+I0515 16:37:22.072636   66477 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains
+I0515 16:37:22.072676   66477 round_trippers.go:580]     X-Xss-Protection: 1; mode=block
+I0515 16:37:22.072722   66477 round_trippers.go:580]     Referrer-Policy: no-referrer
+I0515 16:37:22.072765   66477 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:37:22.072795   66477 round_trippers.go:580]     X-Robots-Tag: none
+I0515 16:37:22.072831   66477 round_trippers.go:580]     Content-Type: text/html;charset=utf-8
+I0515 16:37:22.073892   66477 round_trippers.go:466] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: oc/v4.2.0 (linux/amd64) kubernetes/6e9a161" 'https://api.sl-bd.group-b.devcluster.openshift.com:6443/api/v1/namespaces/openshift/configmaps/motd'
+I0515 16:37:22.172151   66477 round_trippers.go:553] GET https://api.sl-bd.group-b.devcluster.openshift.com:6443/api/v1/namespaces/openshift/configmaps/motd 403 Forbidden in 98 milliseconds
+I0515 16:37:22.172240   66477 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 97 ms Duration 98 ms
+I0515 16:37:22.172283   66477 round_trippers.go:577] Response Headers:
+I0515 16:37:22.172320   66477 round_trippers.go:580]     Cache-Control: no-cache, private
+I0515 16:37:22.172348   66477 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: e20e4cbc-8ab1-4280-8053-cdbd773f31b8
+I0515 16:37:22.172389   66477 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:37:22.172435   66477 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 8db4d3d4-4c84-4a0c-9fc3-0f7e736b0bf4
+I0515 16:37:22.172482   66477 round_trippers.go:580]     Content-Length: 303
+I0515 16:37:22.172521   66477 round_trippers.go:580]     Date: Mon, 15 May 2023 14:37:22 GMT
+I0515 16:37:22.172566   66477 round_trippers.go:580]     Audit-Id: eabfc6c1-3ee1-4190-afce-0fe8d2c030db
+I0515 16:37:22.172598   66477 round_trippers.go:580]     Content-Type: application/json
+I0515 16:37:22.172626   66477 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+I0515 16:37:22.172706   66477 request.go:1073] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"configmaps \"motd\" is forbidden: User \"system:anonymous\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"openshift\"","reason":"Forbidden","details":{"name":"motd","kind":"configmaps"},"code":403}
+I0515 16:37:22.173975   66477 helpers.go:222] server response object: [{
+  "metadata": {},
+  "status": "Failure",
+  "message": "Internal error occurred: unexpected response: 400",
+  "reason": "InternalError",
+  "details": {
+    "causes": [
+      {
+        "message": "unexpected response: 400"
+      }
+    ]
+  },
+  "code": 500
+}]
+Error from server (InternalError): Internal error occurred: unexpected response: 400
+```
+
+## Adding the openshift-challenging-client at the OIDC side
+* oc login is still broken
+  * the redirect URI is wrong -> the client adds `/oauth/token/implicit` to the `redirect_uri` path but this is in fact OpenShift-specific and would not exist in the provider
+  * right now we only get 400 only because of the invalid `redirect_uri`
+
+```
+...
+I0515 16:41:28.523153   66921 round_trippers.go:466] curl -v -XGET  -H "X-Csrf-Token: 1" 'https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master/protocol/openid-connect/auth?client_id=openshift-challenging-client&code_challenge=pHansE692pMAM7zBqglQLhh9Pq1SedNQouGtUfppszY&code_challenge_method=S256&redirect_uri=https%3A%2F%2Ftest-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com%2Frealms%2Fmaster%2Foauth%2Ftoken%2Fimplicit&response_type=code'
+I0515 16:41:28.523495   66921 round_trippers.go:495] HTTP Trace: DNS Lookup for test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com resolved to [{107.22.212.24 } {54.166.125.229 }]
+I0515 16:41:28.622073   66921 round_trippers.go:510] HTTP Trace: Dial to tcp:107.22.212.24:443 succeed
+I0515 16:41:28.848938   66921 round_trippers.go:553] GET https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master/protocol/openid-connect/auth?client_id=openshift-challenging-client&code_challenge=pHansE692pMAM7zBqglQLhh9Pq1SedNQouGtUfppszY&code_challenge_method=S256&redirect_uri=https%3A%2F%2Ftest-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com%2Frealms%2Fmaster%2Foauth%2Ftoken%2Fimplicit&response_type=code 400 Bad Request in 325 milliseconds
+I0515 16:41:28.849040   66921 round_trippers.go:570] HTTP Statistics: DNSLookup 0 ms Dial 98 ms TLSHandshake 101 ms ServerProcessing 124 ms Duration 325 ms
+I0515 16:41:28.849075   66921 round_trippers.go:577] Response Headers:
+I0515 16:41:28.849105   66921 round_trippers.go:580]     Content-Type: text/html;charset=utf-8
+I0515 16:41:28.849132   66921 round_trippers.go:580]     Content-Length: 1776
+I0515 16:41:28.849160   66921 round_trippers.go:580]     Set-Cookie: 3c9e6724823ac7ad9a5d50942d705e4c=39f2e9b0235c633edc00cae002808130; path=/; HttpOnly; Secure; SameSite=None
+I0515 16:41:28.849190   66921 round_trippers.go:580]     X-Robots-Tag: none
+I0515 16:41:28.849218   66921 round_trippers.go:580]     Referrer-Policy: no-referrer
+I0515 16:41:28.849245   66921 round_trippers.go:580]     Content-Security-Policy: frame-src 'self'; frame-ancestors 'self'; object-src 'none';
+I0515 16:41:28.849273   66921 round_trippers.go:580]     X-Xss-Protection: 1; mode=block
+I0515 16:41:28.849300   66921 round_trippers.go:580]     X-Frame-Options: SAMEORIGIN
+I0515 16:41:28.849326   66921 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:41:28.849353   66921 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains
+I0515 16:41:28.849380   66921 round_trippers.go:580]     Content-Language: en
+I0515 16:41:28.850560   66921 round_trippers.go:466] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: oc/v4.2.0 (linux/amd64) kubernetes/6e9a161" 'https://api.sl-bd.group-b.devcluster.openshift.com:6443/api/v1/namespaces/openshift/configmaps/motd'
+I0515 16:41:28.949039   66921 round_trippers.go:553] GET https://api.sl-bd.group-b.devcluster.openshift.com:6443/api/v1/namespaces/openshift/configmaps/motd 403 Forbidden in 98 milliseconds
+I0515 16:41:28.949099   66921 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 98 ms Duration 98 ms
+I0515 16:41:28.949123   66921 round_trippers.go:577] Response Headers:
+I0515 16:41:28.949149   66921 round_trippers.go:580]     Audit-Id: 0367ba4d-e966-4a8f-adab-f407312a261f
+I0515 16:41:28.949179   66921 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 8db4d3d4-4c84-4a0c-9fc3-0f7e736b0bf4
+I0515 16:41:28.949203   66921 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: e20e4cbc-8ab1-4280-8053-cdbd773f31b8
+I0515 16:41:28.949226   66921 round_trippers.go:580]     Date: Mon, 15 May 2023 14:41:28 GMT
+I0515 16:41:28.949251   66921 round_trippers.go:580]     Content-Length: 303
+I0515 16:41:28.949275   66921 round_trippers.go:580]     Cache-Control: no-cache, private
+I0515 16:41:28.949299   66921 round_trippers.go:580]     Content-Type: application/json
+I0515 16:41:28.949322   66921 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+I0515 16:41:28.949346   66921 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:41:28.949409   66921 request.go:1073] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"configmaps \"motd\" is forbidden: User \"system:anonymous\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"openshift\"","reason":"Forbidden","details":{"name":"motd","kind":"configmaps"},"code":403}
+I0515 16:41:28.950280   66921 helpers.go:222] server response object: [{
+  "metadata": {},
+  "status": "Failure",
+  "message": "Internal error occurred: unexpected response: 400",
+  "reason": "InternalError",
+  "details": {
+    "causes": [
+      {
+        "message": "unexpected response: 400"
+      }
+    ]
+  },
+  "code": 500
+}]
+Error from server (InternalError): Internal error occurred: unexpected response: 400
+```
+
+## Relaxing the validation on the redirect_uri
+- login is again broken
+  - I relaxed the `redirect_uri` path check. This is **NOT RECOMMENDED** by OAuth2 best practices, these require strict URI comparisons
+  - The `oc` sets wrong expectations (OCP specific) on how to retrieve the token -> OIDC provider will **generally NOT send HTTP challenges** along their login form page
+  - We need the `oc login` with web browser here
+    - **(? unclear ?)** hopefully the providers will support the looser port validation of localhost URIs
+
+```
+...
+I0515 16:48:13.181826   67968 round_trippers.go:466] curl -v -XGET  -H "X-Csrf-Token: 1" 'https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master/protocol/openid-connect/auth?client_id=openshift-challenging-client&code_challenge=8eztIQeYoBy6ONOWFmTAa80i9Q918R70VOUTrEVxmy8&code_challenge_method=S256&redirect_uri=https%3A%2F%2Ftest-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com%2Frealms%2Fmaster%2Foauth%2Ftoken%2Fimplicit&response_type=code'
+I0515 16:48:13.182091   67968 round_trippers.go:495] HTTP Trace: DNS Lookup for test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com resolved to [{54.166.125.229 } {107.22.212.24 }]
+I0515 16:48:13.280097   67968 round_trippers.go:510] HTTP Trace: Dial to tcp:54.166.125.229:443 succeed
+I0515 16:48:13.503687   67968 round_trippers.go:553] GET https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master/protocol/openid-connect/auth?client_id=openshift-challenging-client&code_challenge=8eztIQeYoBy6ONOWFmTAa80i9Q918R70VOUTrEVxmy8&code_challenge_method=S256&redirect_uri=https%3A%2F%2Ftest-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com%2Frealms%2Fmaster%2Foauth%2Ftoken%2Fimplicit&response_type=code 200 OK in 321 milliseconds
+```
+The 200 above is a 200 of the login form page, notice no `WWW-Authenticate` challenge in the headers below.
+
+```
+I0515 16:48:13.503800   67968 round_trippers.go:570] HTTP Statistics: DNSLookup 0 ms Dial 97 ms TLSHandshake 99 ms ServerProcessing 123 ms Duration 321 ms
+I0515 16:48:13.503850   67968 round_trippers.go:577] Response Headers:
+I0515 16:48:13.503894   67968 round_trippers.go:580]     Referrer-Policy: no-referrer
+I0515 16:48:13.503933   67968 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains
+I0515 16:48:13.503972   67968 round_trippers.go:580]     X-Robots-Tag: none
+I0515 16:48:13.504010   67968 round_trippers.go:580]     X-Xss-Protection: 1; mode=block
+I0515 16:48:13.504046   67968 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:48:13.504084   67968 round_trippers.go:580]     X-Frame-Options: SAMEORIGIN
+I0515 16:48:13.504121   67968 round_trippers.go:580]     Set-Cookie: AUTH_SESSION_ID=6248afca-cc1e-46cc-8eca-fc540d1c6e4d; Version=1; Path=/realms/master/; SameSite=None; Secure; HttpOnly
+I0515 16:48:13.504160   67968 round_trippers.go:580]     Set-Cookie: AUTH_SESSION_ID_LEGACY=6248afca-cc1e-46cc-8eca-fc540d1c6e4d; Version=1; Path=/realms/master/; Secure; HttpOnly
+I0515 16:48:13.504198   67968 round_trippers.go:580]     Set-Cookie: KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI3YmI2YmZkYy05OTlhLTQ2NGEtODUxMC1lNmQxNWVjZjNmZTEifQ.eyJjaWQiOiJvcGVuc2hpZnQtY2hhbGxlbmdpbmctY2xpZW50IiwicHR5Ijoib3BlbmlkLWNvbm5lY3QiLCJydXJpIjoiaHR0cHM6Ly90ZXN0LXJvdXRlLWUyZS10ZXN0LWF1dGhlbnRpY2F0aW9uLW9wZXJhdG9yLWdkdzJmLmFwcHMuc2wtYmQuZ3JvdXAtYi5kZXZjbHVzdGVyLm9wZW5zaGlmdC5jb20vcmVhbG1zL21hc3Rlci9vYXV0aC90b2tlbi9pbXBsaWNpdCIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7ImlzcyI6Imh0dHBzOi8vdGVzdC1yb3V0ZS1lMmUtdGVzdC1hdXRoZW50aWNhdGlvbi1vcGVyYXRvci1nZHcyZi5hcHBzLnNsLWJkLmdyb3VwLWIuZGV2Y2x1c3Rlci5vcGVuc2hpZnQuY29tL3JlYWxtcy9tYXN0ZXIiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vdGVzdC1yb3V0ZS1lMmUtdGVzdC1hdXRoZW50aWNhdGlvbi1vcGVyYXRvci1nZHcyZi5hcHBzLnNsLWJkLmdyb3VwLWIuZGV2Y2x1c3Rlci5vcGVuc2hpZnQuY29tL3JlYWxtcy9tYXN0ZXIvb2F1dGgvdG9rZW4vaW1wbGljaXQiLCJjb2RlX2NoYWxsZW5nZV9tZXRob2QiOiJTMjU2IiwiY29kZV9jaGFsbGVuZ2UiOiI4ZXp0SVFlWW9CeTZPTk9XRm1UQWE4MGk5UTkxOFI3MFZPVVRyRVZ4bXk4In19._O2R4oHilvHczbWdc2RbreFl4jYph8sD3YwqQhNThS4; Version=1; Path=/realms/master/; Secure; HttpOnly
+I0515 16:48:13.504252   67968 round_trippers.go:580]     Set-Cookie: 3c9e6724823ac7ad9a5d50942d705e4c=39f2e9b0235c633edc00cae002808130; path=/; HttpOnly; Secure; SameSite=None
+I0515 16:48:13.504290   67968 round_trippers.go:580]     Content-Language: en
+I0515 16:48:13.504325   67968 round_trippers.go:580]     Cache-Control: no-store, must-revalidate, max-age=0
+I0515 16:48:13.504363   67968 round_trippers.go:580]     Content-Security-Policy: frame-src 'self'; frame-ancestors 'self'; object-src 'none';
+I0515 16:48:13.504411   67968 round_trippers.go:580]     Content-Length: 3546
+I0515 16:48:13.504451   67968 round_trippers.go:580]     Content-Type: text/html;charset=utf-8
+I0515 16:48:13.505569   67968 round_trippers.go:466] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: oc/v4.2.0 (linux/amd64) kubernetes/6e9a161" 'https://api.sl-bd.group-b.devcluster.openshift.com:6443/api/v1/namespaces/openshift/configmaps/motd'
+I0515 16:48:13.604870   67968 round_trippers.go:553] GET https://api.sl-bd.group-b.devcluster.openshift.com:6443/api/v1/namespaces/openshift/configmaps/motd 403 Forbidden in 99 milliseconds
+I0515 16:48:13.604943   67968 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 98 ms Duration 99 ms
+I0515 16:48:13.604970   67968 round_trippers.go:577] Response Headers:
+I0515 16:48:13.605002   67968 round_trippers.go:580]     Audit-Id: 93a8181d-bf45-400b-900a-2704c811f71f
+I0515 16:48:13.605031   67968 round_trippers.go:580]     Cache-Control: no-cache, private
+I0515 16:48:13.605059   67968 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 8db4d3d4-4c84-4a0c-9fc3-0f7e736b0bf4
+I0515 16:48:13.605087   67968 round_trippers.go:580]     Content-Length: 303
+I0515 16:48:13.605113   67968 round_trippers.go:580]     Date: Mon, 15 May 2023 14:48:13 GMT
+I0515 16:48:13.605141   67968 round_trippers.go:580]     Content-Type: application/json
+I0515 16:48:13.605167   67968 round_trippers.go:580]     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+I0515 16:48:13.605194   67968 round_trippers.go:580]     X-Content-Type-Options: nosniff
+I0515 16:48:13.605221   67968 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: e20e4cbc-8ab1-4280-8053-cdbd773f31b8
+I0515 16:48:13.605280   67968 request.go:1073] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"configmaps \"motd\" is forbidden: User \"system:anonymous\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"openshift\"","reason":"Forbidden","details":{"name":"motd","kind":"configmaps"},"code":403}
+I0515 16:48:13.606084   67968 helpers.go:222] server response object: [{
+  "metadata": {},
+  "status": "Failure",
+  "message": "Internal error occurred: unexpected response: 200",
+  "reason": "InternalError",
+  "details": {
+    "causes": [
+      {
+        "message": "unexpected response: 200"
+      }
+    ]
+  },
+  "code": 500
+}]
+Error from server (InternalError): Internal error occurred: unexpected response: 200
+```
+Notice the `200` from above.
+
+### Summary
+The `id_token` retrieved from the OIDC can only be used directly with `--token`:
+```sh
+$ oc get pods --token=$t
+Error from server (Forbidden): pods is forbidden: User "https://test-route-e2e-test-authentication-operator-gdw2f.apps.sl-bd.group-b.devcluster.openshift.com/realms/master#7ebc4d10-e992-410c-98d3-d66095f9de49" cannot list resource "pods" in API group "" in the namespace "default"
+
+```
+The username observed above could further be improved with various kube-apiserver OIDC flags, possibly along with some fine-tuning of the OIDC-local client settings.
+
+# Web interface - openshift-console
+
+## Initial config
+
+- console is broken 
+  - the "console" client does not exist
+  - console redirects to `https://<OIDC_AUTHZ_ENDPOINT_URL>?client_id=console&redirect_uri=https%3A%2F%2F<console_url>%2Fauth%2Fcallback&response_type=code&scope=user%3Afull&state=c0ff9e95`
+
+## Create the client in the OIDC
+
+- Keycloak does not allow setting your own client secret (this might differ with other OIDC providers)
+- the console-operator stomps on changes to the console OAuthClient
+
+
+1. create a "console" client on the OIDC side
+2. unmanage the `console-operator` deployment and scale replicas to 0
+3. edit the `openshift-console/console-oauth-config` with the client secret from the OIDC
+   - `console-oauth-config` only contains the `"clientSecret"` key -> the client ID is hardcoded (although the internal API/flags of the console allow setting it)
+   - don't forget to base64-encode the secret from the OIDC again if modifying the secret directly in the secret
+4. delete all console pods just to make sure they pick up the new secret
+
+**Console gets stuck in a redirect** loop (old bug I reported in OCP 4.5: https://issues.redhat.com/browse/OCPBUGS-8777). No useful logs but looking into Keycloak logs we can see that the scope `user:full` is unknown.
+
+## Add the custom scope
+
+- Keycloak allows creating custom scopes and adding them to the clients
+
+**Result:**
+
+New redirect loop, there are authorization errors.
+
+_Assumption:_ the user is missing bindings to the `system:authenticated:oauth` group.
+
+- Adding the `system:authenticated` group to `self-provisioners` clusterrolebinding does not seem to help.
+- Adding `system:authenticated` in the `cluster-admin` clusterrolebinding does not help.
+
+Console repeatedly logs:
+```
+I0516 10:35:40.138269       1 metrics.go:99] auth.Metrics loginSuccessfulSync - increase metric for role "unknown"
+I0516 10:35:41.426775       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/project.openshift.io/v1/projectrequests`
+I0516 10:35:41.426859       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/apps.openshift.io/v1`
+I0516 10:35:41.427180       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/config.openshift.io/v1/clusterversions/version`
+I0516 10:35:41.427295       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.427369       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/user.openshift.io/v1/users/~`
+I0516 10:35:41.427445       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.427525       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.427583       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.427841       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.428337       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.446268       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.446355       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/openapi/v2`
+I0516 10:35:41.463371       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/openapi/v2`
+I0516 10:35:41.525070       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/metal3.io/v1alpha1/provisionings/provisioning-configuration`
+I0516 10:35:41.525124       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.525133       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.525178       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.525335       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/config.openshift.io/v1/infrastructures/cluster`
+I0516 10:35:41.525081       1 proxy.go:115] PROXY: `https://kubernetes.default.svc/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`
+I0516 10:35:41.695630       1 metrics.go:61] auth.Metrics LoginRequested
+I0516 10:35:41.954456       1 auth.go:418] oauth success, redirecting to: "https://console-openshift-console.apps.sl-bd.group-b.devcluster.openshift.com/"
+E0516 10:35:41.963528       1 metrics.go:156] Error in auth.metrics isKubeAdmin: Unauthorized
+E0516 10:35:41.970919       1 metrics.go:142] Error in auth.metrics canGetNamespaces: Unauthorized
+```
+
+Apparently the console has trouble acting on behalf of the user, the last log line would come from self-SAR.
+
+In the audit logs we can see:
+```
+{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Metadata","auditID":"c771f01d-5995-40e4-9259-879773112159","stage":"ResponseStarted","requestURI":"/apis/authorization.k8s.io/v1/selfsubjectaccessreviews","verb":"create","user":{},"sourceIPs":["10.0.152.130"],"objectRef":{"resource":"selfsubjectaccessreviews","apiGroup":"authorization.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401},"requestReceivedTimestamp":"2023-05-16T10:27:28.826058Z","stageTimestamp":"2023-05-16T10:27:28.837875Z"}
+```
+
+Note the `"user":{}`.
+
+## Configuring the OIDC options for console directly (== don't use OpenShift auth?)
+
+**Result**: another redirect loop.
+```
+W0516 11:13:51.377143       1 main.go:226] Flag inactivity-timeout is set to less then 300 seconds and will be ignored!
+I0516 11:13:51.377183       1 main.go:370] cookies are secure!
+I0516 11:13:51.408440       1 main.go:835] Binding to [::]:8443...
+I0516 11:13:51.408471       1 main.go:837] using TLS
+I0516 11:13:54.408793       1 metrics.go:141] serverconfig.Metrics: Update ConsolePlugin metrics...
+I0516 11:13:54.417286       1 metrics.go:151] serverconfig.Metrics: Update ConsolePlugin metrics: &map[] (took 8.473194ms)
+I0516 11:13:56.408953       1 metrics.go:88] usage.Metrics: Count console users...
+I0516 11:13:56.516563       1 metrics.go:117] usage.Metrics: Ignore role binding: "console-user-settings-admin" (name doesn't match user-settings-*-rolebinding)
+I0516 11:13:56.616716       1 metrics.go:117] usage.Metrics: Ignore role binding: "system:deployers" (name doesn't match user-settings-*-rolebinding)
+I0516 11:13:56.716912       1 metrics.go:117] usage.Metrics: Ignore role binding: "system:image-builders" (name doesn't match user-settings-*-rolebinding)
+I0516 11:13:56.817148       1 metrics.go:117] usage.Metrics: Ignore role binding: "system:image-pullers" (name doesn't match user-settings-*-rolebinding)
+I0516 11:13:56.817185       1 metrics.go:174] usage.Metrics: Update console users metrics: 0 kubeadmin, 0 cluster-admins, 0 developers, 0 unknown/errors (took 408.205717ms)
+I0516 11:14:06.148484       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:14:20.653464       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:14:36.144097       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:14:50.649991       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:15:06.143964       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:15:20.650244       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:15:36.144338       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:15:50.650321       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:16:06.144880       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:16:20.649929       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:16:36.144772       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:16:50.649536       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:17:00.732471       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:01.405478       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:02.248920       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:03.362388       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:04.862731       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:05.029879       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:05.030146       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:05.030156       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:05.034345       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:05.150850       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:17:05.277770       1 metrics.go:61] auth.Metrics LoginRequested
+E0516 11:17:05.761578       1 auth.go:388] missing auth code in query param
+I0516 11:17:05.761593       1 metrics.go:107] auth.Metrics LoginFailed with reason "unknown"
+I0516 11:17:06.144158       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:17:06.935895       1 middleware.go:40] authentication failed: http: named cookie not present
+...
+```
+
+On the Keycloak side though:
+```
+023-05-16 11:18:44,711 WARN  [org.keycloak.events] (executor-thread-38) type=LOGIN_ERROR, realmId=0380c1d5-86ab-4606-abec-d33b6652c352, clientId=console, userId=null, ipAddress=213.175.37.10, error=invalid_request, response_type=code, redirect_uri=https://console-openshift-console.apps.sl-bd.group-b.devcluster.openshift.com/auth/callback, response_mode=query
+```
+
+==> We may want to configure additional scopes for the client, it's using https://github.com/openshift/console/blob/3e0bb0928ce09030bc3340c9639b2a1df9e0a007/cmd/bridge/main.go#L614
+
+* `"groups"` is not a standard scope! [OIDC Core Spec - Requesting Claims using Scope Values](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)
+
+## Add 'groups' among client scopes in Keycloak
+
+==> another redirect loop
+
+console logs:
+```
+W0516 11:27:28.351058       1 main.go:226] Flag inactivity-timeout is set to less then 300 seconds and will be ignored!
+I0516 11:27:28.351098       1 main.go:370] cookies are secure!
+I0516 11:27:28.457933       1 main.go:835] Binding to [::]:8443...
+I0516 11:27:28.458050       1 main.go:837] using TLS
+I0516 11:27:31.462739       1 metrics.go:141] serverconfig.Metrics: Update ConsolePlugin metrics...
+I0516 11:27:31.472028       1 metrics.go:151] serverconfig.Metrics: Update ConsolePlugin metrics: &map[] (took 9.268829ms)
+I0516 11:27:33.462226       1 metrics.go:88] usage.Metrics: Count console users...
+I0516 11:27:33.566037       1 metrics.go:117] usage.Metrics: Ignore role binding: "console-user-settings-admin" (name doesn't match user-settings-*-rolebinding)
+I0516 11:27:33.666267       1 metrics.go:117] usage.Metrics: Ignore role binding: "system:deployers" (name doesn't match user-settings-*-rolebinding)
+I0516 11:27:33.766544       1 metrics.go:117] usage.Metrics: Ignore role binding: "system:image-builders" (name doesn't match user-settings-*-rolebinding)
+I0516 11:27:33.866779       1 metrics.go:117] usage.Metrics: Ignore role binding: "system:image-pullers" (name doesn't match user-settings-*-rolebinding)
+I0516 11:27:33.866799       1 metrics.go:174] usage.Metrics: Update console users metrics: 0 kubeadmin, 0 cluster-admins, 0 developers, 0 unknown/errors (took 404.554644ms)
+I0516 11:27:45.071282       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:27:47.044653       1 middleware.go:40] authentication failed: No session found on server
+I0516 11:27:49.780316       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:50.393077       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:51.124024       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:52.054570       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.405513       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.565205       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.565332       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.566918       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.570078       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.684323       1 middleware.go:40] authentication failed: http: named cookie not present
+I0516 11:27:53.797454       1 metrics.go:61] auth.Metrics LoginRequested
+I0516 11:28:02.314513       1 session.go:83] Pruned 0 expired sessions.
+I0516 11:28:02.314540       1 auth.go:418] oauth success, redirecting to: "https://console-openshift-console.apps.sl-bd.group-b.devcluster.openshift.com/"
+E0516 11:28:02.350480       1 metrics.go:156] Error in auth.metrics isKubeAdmin: Unauthorized
+E0516 11:28:02.363748       1 metrics.go:142] Error in auth.metrics canGetNamespaces: Unauthorized
+```
+
+And again, no user in the `self-SARs` in the audit logs. The OIDC-specific config got us nowhere.
+
+This is because the web console appears to expect the "name" claim in the id_token but OIDC makes no assurances this is present by default. Related code: https://github.com/openshift/console/blob/3e0bb0928ce09030bc3340c9639b2a1df9e0a007/pkg/auth/loginstate.go#L30-L56
+
+# oauth-proxy
+
+## Initial config
+
+- oauth proxy from https://github.com/openshift/oauth-proxy/blob/master/contrib/sidecar.yaml
+   - **broken** - client does not exist, the OIDC will not respect our oauth clients being constructed from SAs
+
+## Config the client on Keycloak side
+
+- we can set the client-id and client-secret explicitly
+  - **broken** - unknown scopes
+
+- create the scopes in Keycloak and adding them to the client
+  - **broken**
+    - the code is trying to retrieve user attributes:
+  https://github.com/openshift/oauth-proxy/blob/1e2bb287586c22fa76ac1be84030148f8c1f95d3/providers/openshift/provider.go#L462-L487
+    - it is trying to reach the /apis/user.openshift.io/v1/users/~ endpoint but fails with:
+```
+2023/05/16 11:57:42 provider.go:593: 401 GET https://172.30.0.1/apis/user.openshift.io/v1/users/~ {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}
+2023/05/16 11:57:42 oauthproxy.go:646: error redeeming code (client:10.131.0.34:50820): unable to retrieve email address for user from token: got 401 {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}
+2023/05/16 11:57:42 oauthproxy.go:439: ErrorPage 500 Internal Error Internal Error
+```
+
+There is only very little appetite to get oauth-proxy working in these scenarios though. Why use it when OIDC could be used directly?
+
+I'm not going to proceed troubleshooting this further.

--- a/enhancements/authentication/unsupported-direct-use-of-oidc.md
+++ b/enhancements/authentication/unsupported-direct-use-of-oidc.md
@@ -43,10 +43,12 @@ built useful toolings around the binary.
 
 As the `oauth-server` is an authentication middle-man that mints
 OpenShift-specific access tokens, it is impossible to use tokens issued by a
-3rd party OIDC provider directly to authenticate to OpenShift clusters. Such
-a token gets forwarded directly to the `kube-apiserver` instead of the `oauth-server`,
-where the latter is at least aware of the 3rd parties that should be used as identity
-sources. But even if the token went directly to the `oauth-server`, there currently exists
+3rd party OIDC provider directly to authenticate to OpenShift clusters. When `oc`
+is configured to use a token to authenticate, it uses generic client-go credential
+handling and such a token gets forwarded directly to the `kube-apiserver` instead
+of the `oauth-server`. The latter is currently the only one aware of the 3rd parties that
+should be used as identity sources and so this authentication path would always fail.
+But even if the token went directly to the `oauth-server`, there currently exists
 no such mechanism for the `oauth-server` to mint an OpenShift-specific access
 token based on an access or ID token from a 3rd party OIDC provider. Not to
 mention that a client should not forward its access tokens to a different entity.
@@ -257,7 +259,9 @@ OIDC provider directly instead of attempting something of its own. Perhaps `oc l
 would not be used for cluster login at all.
 
 Even now, `oc` is capable of using an ID token directly if the kube-apiserver
-is configured accordingly. The main issue is with retrieving the token.
+is configured accordingly. The main issue is with retrieving the token but even
+should we decide we would not want to modify `oc login`, there are open-source
+solutions to this problem.
 
 #### oauth-proxy
 

--- a/enhancements/authentication/unsupported-direct-use-of-oidc.md
+++ b/enhancements/authentication/unsupported-direct-use-of-oidc.md
@@ -19,6 +19,7 @@ tracking-link: []
 see-also:
   - [oc Authorization Grant login](./improved-login-workflow.md)
   - [Configuring OIDC directly - study](./direct-oidc-study/study-oidc-in-openshift.md)
+  - [Unsupported file synchronization into kube-apiserver static pods](https://github.com/openshift/enhancements/blob/master/enhancements/kube-apiserver/unsupported-file-sync.md)
 replaces: []
 superseded-by: []
 ---
@@ -149,22 +150,9 @@ into a file.
 The OIDC configuration is very likely to require configuring additional files to be
 mounted to the kube-apiserver static pods. A typical example is the `oidc-ca-file`.
 
-This requires synchronizing additional `configMaps`/`secrets` into static pods.
-The kube-apiserver-operator should support two subfields to the `unsupportedConfigOverrides`:
-- `unsupportedConfigMaps`
-- `unsupportedSecrets`
-
-These each follow the same API:
-```
-- name: <openshift-config ref>
-  path: <cannot contain any path traversal>
-  defaultMode: <file permissions>
-```
-where:
-- `name` points to the name of the resource in the `openshift-config` namespace
-- `path` specifies a subpath of the `/etc/kubernetes/unsupported` directory where
-  the `configMap`/`secret` should be mounted
-- `defaultMode` matches the common `volume`'s `defaultMode` semantics
+To do that, the process described in
+[GitHub Pull Request: kube-apiserver: allow unsupported files sync](https://github.com/openshift/enhancements/pull/1480)
+shall be used.
 
 **OAuth metadata**<br>
 `oc login`, the web console and the `oauth-proxy` are all using the kube-apiserver's

--- a/enhancements/authentication/unsupported-direct-use-of-oidc.md
+++ b/enhancements/authentication/unsupported-direct-use-of-oidc.md
@@ -1,0 +1,368 @@
+---
+title: direct-use-of-oidc
+authors:
+  - "@stlaz"
+reviewers:
+  - "@s-urbaniak"
+  - "@liouk"
+  - "@ibihim"
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+  - "@s-urbaniak"
+api-approvers:
+  - "@deads2k"
+  - "@tkashem"
+creation-date: yyyy-mm-dd
+last-updated: yyyy-mm-dd
+tracking-link: []
+see-also:
+  - [oc Authorization Grant login](./improved-login-workflow.md)
+  - [Configuring OIDC directly - study](./direct-oidc-study/study-oidc-in-openshift.md)
+replaces: []
+superseded-by: []
+---
+
+# Direct use of OIDC as an identity provider
+
+## Summary
+
+When users authenticate to OpenShift, the authentication goes through the `oauth-server`
+which serves as middle-man actor that unifies access to multiple kinds of
+identity providers, such as LDAP, OIDC providers, providers returning HTTP Basic
+Authentication challenges, and similar.
+
+The above differs from vanilla Kubernetes where authentication is dealt directly
+by the `kube-apiserver`. This has limitations especially when it comes to being
+able to login to different kinds of identity providers in a uniform manner.
+On the other hand, `kubectl`, the binary for accessing Kubernetes APIs, has evolved
+through the years to simplify the login process to Kubernetes clusters, and communities
+built useful toolings around the binary.
+
+## Motivation
+
+As the `oauth-server` is an authentication middle-man that mints
+OpenShift-specific access tokens, it is impossible to use tokens issued by a
+3rd party OIDC provider directly to authenticate to OpenShift clusters. Such
+a token gets forwarded directly to the `kube-apiserver` instead of the `oauth-server`,
+where the latter is at least aware of the 3rd parties that should be used as identity
+sources. But even if the token went directly to the `oauth-server`, there currently exists
+no such mechanism for the `oauth-server` to mint an OpenShift-specific access
+token based on an access or ID token from a 3rd party OIDC provider. Not to
+mention that a client should not forward its access tokens to a different entity.
+
+For the reasons above, it makes sense to allow configuring OIDC-related flags of
+the `kube-apiserver` directly in order to fully leverage capabilities of the
+community-built tools around OIDC-related authentication. However, there are some
+OpenShift specifics that one needs to bear in mind should they want to use their
+own OIDC provider.
+
+### Goals
+
+- describe expectations that an OIDC provider needs to fulfill in order for its
+  integration with OpenShift to be seamless
+- provide a guide to configure OIDC directly with a use of unsupportedConfigOverrides
+- point out which OpenShift components would be affected by the `oauth-server` disappearing
+  from the cluster and what they would need to do to integrate with a direct OIDC
+  provider instead
+
+### Non-Goals
+
+- focus on a closer integration with any specific OIDC provider
+
+## Proposal
+
+### User Stories
+
+1. I am an OIDC provider developer and I would like to try out how my product integrates
+   with OpenShift
+
+### Affected core functionality the auth team cares about
+
+Throughout the time of its existence, the OpenShift authentication stack has built
+several expectations about how OAuth clients work, which claims should be present
+in a token and several others.
+
+The following points are important to realize for any administrator that would decide
+to configure OIDC directly in their cluster:
+
+- Token revocation is an unsolved problem in the Kubernetes direct OIDC configuration. This
+  is based on vanilla Kube mostly relying on ID tokens instead of access/refresh tokens
+  for its authentication. While the revocation of the latter is [standardized](https://datatracker.ietf.org/doc/html/rfc7009),
+  revocation of ID tokens is undefined.
+  A very short lifetime (~5 min) must be imposed on ID tokens to keep such a system
+  safe.
+- Since the integrated `oauth-server` is no longer involved in the login process,
+  none of the following objects get created upon login:
+  - `OAuthAuthorizeToken`/`OAuthAccessToken`
+  - `Identity`/`User`/`Groups`
+- Neither `ServiceAccount` or `OAuthClient` and the credentials derived from them
+  will be respected when applications attempt to retrieve user's credentials from
+  the identity provider. That is, unless the 3rd party identity provider implements
+  their own integration with OpenShift, which is unlikely.
+- A third-party identity provider is not likely to know about the `OAuthAccessToken`
+  scopes that OpenShift uses that some components may rely upon (e.g. `user:info`
+  scope for components that only need to be able to get the user data). This means
+  that the 3rd party OIDC needs to be flexible in order to allow requesting unknown
+  scopes and scopes with a given prefix (for the [role scopes](https://docs.openshift.com/container-platform/4.13/authentication/tokens-scoping.html#scoping-tokens-role-scope_configuring-internal-oauth)).
+- The upstream configuration for OIDC does not currently allow setting the
+  `userInfo.Extra` fields of the authentication response so even if the 3rd party
+  OIDC identity provider allows custom scopes, there is currently no way for the
+  OpenShift-specific `scopeAuthorizer` to learn of these.
+  This would be solved by the [structured OIDC configuration KEP](https://github.com/kubernetes/enhancements/issues/3331).
+- Any component that relied on an OpenShift-specific retrieval of user information
+  (==> `get` on `User` echo endpoint with a given accesstoken) would need to be rewritten to
+  either use the OIDC token's claims or retrieve that information from the UserInfo
+  endpoint of the OIDC identity provider.
+- In order for `oc`, `oauth-proxy` and OpenShift web console to work with the given
+  3rd party OIDC identity provider, the user must configure the `oauthMetadata` of
+  the `authentication.config.openshift.io/cluster` resource so that these clients are
+  redirected to the correct URLs.
+
+### Configuring an OIDC provider directly for the kube-apiserver
+
+The `kube-apiserver` binary already provides flags to [configure direct OIDC integration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens). While these are not exposed in any of the configuration
+APIs, they can be supplied in the `unsupportedConfigOverrides` field, by adding them
+under the `apiServerArguments` key in a `kubeapiserver.operator.openshift.io/cluster` patch such as
+```json
+{"spec":
+    {"unsupportedConfigOverrides":
+        {"apiServerArguments":
+            {
+              "oidc-issuer-url":["an.issuer.url"],
+              "oidc-client-id":["a-client-id"],
+              "oidc-ca-file":["/a/ca/file/path.crt"],
+              ...
+            }
+        }
+    }
+}
+```
+
+Note that the [structured OIDC configuration KEP](https://github.com/kubernetes/enhancements/issues/3331)
+introduces enhancements to the configuration but also moves the whole configuration
+into a file.
+
+**Unsupported files synchronization**<br>
+The OIDC configuration is very likely to require configuring additional files to be
+mounted to the kube-apiserver static pods. A typical example is the `oidc-ca-file`.
+
+This requires synchronizing additional `configMaps`/`secrets` into static pods.
+The kube-apiserver-operator should support two subfields to the `unsupportedConfigOverrides`:
+- `unsupportedConfigMaps`
+- `unsupportedSecrets`
+
+These each follow the same API:
+```
+- name: <openshift-config ref>
+  path: <cannot contain any path traversal>
+  defaultMode: <file permissions>
+```
+where:
+- `name` points to the name of the resource in the `openshift-config` namespace
+- `path` specifies a subpath of the `/etc/kubernetes/unsupported` directory where
+  the `configMap`/`secret` should be mounted
+- `defaultMode` matches the common `volume`'s `defaultMode` semantics
+
+**OAuth metadata**<br>
+`oc login`, the web console and the `oauth-proxy` are all using the kube-apiserver's
+`/.well-known/oauth-authorization-server` endpoint to discover the details about the
+identity provider in the cluster.
+
+The data served is configurable from the `authentications.config.io/cluster` object.
+In order to modify the default values, users should set `Type: None` and point the
+`oauthMetadata` field to a config map in the `openshift-config` namespace.
+
+This should make the authentication operator report `Upgradeable: false`.
+
+### Observed issues with direct OIDC configuration
+
+Configuring OIDC provider directly in the kube-apiserver brings issues since
+the OpenShift authentication stack does not consider this option.
+
+The following section will ignore all problems already outlined in
+[Affected core functionality the auth team cares about](#affected-core-functionality-the-auth-team-cares-about)
+and will describe issues in the main 3 users of the authentication stack:
+- web console
+- `oc login`
+- oauth-proxy
+
+Each subsection will provide a proposal of how these issues could be solved if
+we decided to allow direct OIDC configuration some time in the future.
+
+The subsections consider the public-facing configuration APIs that are present
+at the time of writing of this proposal.
+
+#### Web Console
+
+The web console makes the following assumptions:
+1. the presense of the `console` client in the OAuth2/OIDC system
+2. it can configure the client credentials
+3. it requests the `user:full` scope
+4. the ability to extract the user info from the `users.openshift.io/~` endpoint
+
+None of the above is likely to exist in a default deployment of an OIDC provider.
+
+On the other hand, the console uses the standard OAuth2 Code Grant to request tokens.
+
+[Old code](https://github.com/openshift/console/blob/3e0bb0928ce09030bc3340c9639b2a1df9e0a007/cmd/bridge/main.go#L614)
+exists in the console that apparently worked for a specific OIDC provider in the past
+but it also makes some assumptions that are not defined in the standard and so it
+is broken in different ways than the code which is used for OpenShift authentication.
+Read more in the [attached study](./direct-oidc-study/study-oidc-in-openshift.md).
+
+In order to allow proper integration with a 3rd party OIDC provider, additional
+configuration API would have to exist. It would have to include:
+1. a reference to the OAuth2 client credentials that the console can use
+2. configuration of the scopes it should use to request authorization from the
+   3rd party IdP
+
+Additional considerations:
+1. The console would likely have to forward the ID tokens it retrieves to the
+   kube-apiserver to get the `userInfo` based on the kube-apiserver configuration,
+   not on the configuration of the console to avoid discrepancies in console/kube-apiserver
+   identity configuration.
+2. From 1. we can see that the ID tokens for the console would likely have to contain
+   both the `kube-apiserver` and `console` OAuth2 clients in the audience claim
+3. ID tokens are not revocable which is commonly solved by these being short-lived.
+   The `console` should therefore implement token refresh.
+
+**Open question**: based on 3. we need refresh tokens for seamless web console use.
+During token refresh, an ID token does not necessarily have to be returned. There
+are a few options in that case:
+1. Ignore the above 1. and have the console authenticate the user itself and impersonate
+   it in the requests to the kube-apiserver.
+2. Use the access token from the token refresh flow to retrieve claims from the
+   `UserInfo` endpoint and forward those to the kube-apiserver. However, these
+   are not time-limited (no `exp` claim) and do not have to contain the `iss` and `aud` claims.
+3. Have the configuring user decide. Maybe ID tokens are present in token refresh
+   flow. Maybe at least `iss` and `aud` are present in the `UserInfo` endpoint responses.
+   The user should know.
+
+#### oc login
+
+`oc login`, like the web console, has many assumptions on its own:
+1. existence of the `openshift-challenging-client`
+2. the trust should be present either in the system bundle or in the CA bundle from the kubeconfig
+3. `oc` uses the issuer with added `/oauth/token/implicit` path as the `redirect_uri` for the implicit flow
+4. `oc` expects to be able to use HTTP challenge to authenticate to the authorization endpoint of the issuer
+
+In order to get `oc login` to work, [oc Authorization Grant Login](./improved-login-workflow.md)
+should get implemented. Additionally, it should be able to retrieve parameters
+specific to the OIDC provider deployment, such as which OAuth2 client to use
+and which scopes to request.
+
+As an alternative, `oc login` might try to use an exec plugin supplied by the
+OIDC provider directly instead of attempting something of its own. Perhaps `oc login`
+would not be used for cluster login at all.
+
+Even now, `oc` is capable of using an ID token directly if the kube-apiserver
+is configured accordingly. The main issue is with retrieving the token.
+
+#### oauth-proxy
+
+The oauth-proxy often relies on the functionality of the oauth-server that allows
+it to use its ServiceAccount as the OAuth2 client. That will no longer work, each
+oauth-proxy instance will have to run with an OAuth2 client that gets created in
+the OIDC.
+
+The proxy also relies on the user echo endpoint to get the information about the
+user. This will likely have to change similarly as with the web console.
+
+Ideally, there would be API that would help to decide component operators whether
+to deploy the oauth-proxy at all.
+
+### API Extensions
+
+None
+
+### Implementation Details/Notes/Constraints [optional]
+
+None
+
+### Risks and Mitigations
+
+The "unsupported files synchronization" introduces a way to install files to the
+master nodes.
+
+The config API that allows this is already very privileged and therefore does not
+introduce any additional threat, but it is still worth pointing out.
+
+## Design Details
+
+### Open Questions [optional]
+
+See the question at [Web Console](#web-console), which might also apply to oauth-proxy
+in case the decision was made to fix it.
+
+### Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+- What additional testing is necessary to support managed OpenShift service-based offerings?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+### Graduation Criteria
+
+At its current shape and form, the enhancement only considers the use-case through
+unsupported config overrides. Further graduation would only be considered if the
+configuration described proves to be useful to those parties that require direct
+OIDC provider integration.
+
+#### Dev Preview -> Tech Preview
+
+Read [Graduation Criteria](#graduation-criteria).
+
+#### Tech Preview -> GA
+
+Read [Graduation Criteria](#graduation-criteria).
+
+#### Removing a deprecated feature
+
+Irrelevant.
+
+### Upgrade / Downgrade Strategy
+
+Don't allow upgrades.
+
+### Version Skew Strategy
+
+Irrelevant
+
+### Operational Aspects of API Extensions
+
+TBD
+
+#### Failure Modes
+
+TBD
+
+#### Support Procedures
+
+Unsupported.
+
+## Implementation History
+
+Major milestones in the life cycle of a proposal should be tracked in `Implementation
+History`.
+
+## Drawbacks
+
+TBD
+
+## Alternatives
+
+TBD
+
+## Infrastructure Needed [optional]
+
+Irrelevant at this point

--- a/hack/find_new.sh
+++ b/hack/find_new.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 
 FILELIST=/tmp/$$.filelist
-git ls-tree --name-only -r "${PULL_BASE_SHA:-origin/master}" enhancements > $FILELIST
+git ls-tree --name-only -r "${PULL_BASE_SHA:-origin/master}" ./enhancements > $FILELIST
 
 for f in $(${SCRIPTDIR}/find_changed.sh); do
     if ! grep -q $f $FILELIST; then

--- a/hack/ignore_lib.sh
+++ b/hack/ignore_lib.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+function filter_ignored_paths() {
+    ignore_paths=$(cat ./hack/lint-ignores)
+
+    ret=$1
+    for path in ${ignore_paths[@]}; do
+        ret=${ret//$path/}
+    done
+
+    echo $ret
+}

--- a/hack/lint-ignores
+++ b/hack/lint-ignores
@@ -1,0 +1,1 @@
+enhancements/authentication/direct-oidc-study/study-oidc-in-openshift.md

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -3,6 +3,8 @@
 # trap errors, including the exit code from the command failed
 trap 'handle_exit $?' EXIT
 
+source "$(dirname "${BASH_SOURCE}")/ignore_lib.sh"
+
 function handle_exit() {
     # If the exit code we were given indicates an error, suggest that
     # the author run the linter locally.
@@ -16,7 +18,15 @@ EOF
     fi
 }
 
-markdownlint-cli2 '**/*.md'
+# ignore_paths should only be used for markdowns that are not enhancements
+
+lint_files=$(find enhancements -type f -name "*.md")
+
+lint_files=$(filter_ignored_paths $lint_files)
+
+lint_files=$(echo "$lint_files" | tr '\n' ',')
+
+markdownlint-cli2 '{'"$lint_files"'}'
 
 $(dirname $0)/template-lint.sh
 

--- a/hack/metadata-lint.sh
+++ b/hack/metadata-lint.sh
@@ -6,12 +6,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "$(dirname "${BASH_SOURCE}")/ignore_lib.sh"
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # We only look at the files that have changed in the current PR, to
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
 NEW_FILES=$(${SCRIPTDIR}/find_new.sh)
+NEW_FILES=$(filter_ignored_paths $NEW_FILES)
 
 if [ -z "$NEW_FILES" ]; then
     echo "OK, no changed enhancements found"

--- a/hack/template-lint.sh
+++ b/hack/template-lint.sh
@@ -7,6 +7,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "$(dirname "${BASH_SOURCE}")/ignore_lib.sh"
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEMPLATE=${SCRIPTDIR}/../guidelines/enhancement_template.md
@@ -15,6 +17,7 @@ TEMPLATE=${SCRIPTDIR}/../guidelines/enhancement_template.md
 # avoid problems when the template is changed in a way that is
 # incompatible with existing documents.
 NEW_FILES=$(${SCRIPTDIR}/find_new.sh)
+NEW_FILES=$(filter_ignored_paths $NEW_FILES)
 
 if [ -z "$NEW_FILES" ]; then
     echo "OK, no new enhancement files found"


### PR DESCRIPTION
This PR adds an enhancement that debates configuring an OIDC provider directly with the kube-apiserver with unsupportedConfigOverrides.

It adds a study where Keycloak was configured this way and how it influenced some basic components function.

/cc @deads2k 
/assign @openshift/openshift-team-auth 