### PR TITLE
CFE-862 : Update Azure user-defined tags EP with GA details

### DIFF
--- a/enhancements/api-review/azure_user_defined_tags.md
+++ b/enhancements/api-review/azure_user_defined_tags.md
@@ -12,7 +12,7 @@ approvers:
 api-approvers:
   - "@JoelSpeed" ## approver for api component
 creation-date: 2022-07-12
-last-updated: 2023-01-20
+last-updated: 2023-06-06
 tracking-link:
   - https://issues.redhat.com/browse/OCPPLAN-8155
   - https://issues.redhat.com/browse/CORS-2249
@@ -307,7 +307,10 @@ to 21 characters.
 - Gather feedback from the users.
 
 #### Tech Preview -> GA
-N/A. This feature is for Tech Preview, until decided for GA.
+- Sufficient time for feedback.
+- Available by default.
+- More testing (scale, perf).
+- Incorporate feedback from the users on the TechPreview content.
 
 #### Removing a deprecated feature
 


### PR DESCRIPTION
Support for Azure user-defined tags was made available in OpenShift-4.13 as TechPreviewOnly and will be GA in OpenShift-4.14
PR is for updating the `Tech Preview -> GA` section of the EP.