### PR TITLE
Add implementation details to tokenized auth

### DIFF
--- a/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md
+++ b/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md
@@ -225,7 +225,7 @@ enabled cluster. New guidelines would include the following to use CCO has detec
   mode:
   - Create CredentialsRequest, now with `spec.cloudTokenPath` and `spec.providerSpec.stsIAMRoleARN` filed.
   - Wait for the Secret referenced in the CredentialsRequest to be created by CCO.
-    - Expect the Secrets take some time to create, do not crash and report error when it takes too long.
+    - Expect the Secret to take some time to create, do not crash and report an error when it takes too long.
 
 ### Workflow Description
 

--- a/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md
+++ b/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md
@@ -224,7 +224,7 @@ enabled cluster. New guidelines would include the following to use CCO has detec
 - When OLM starts the operator with `ROLEARN` env. variable, handle the cloud credentials *almost* as if CCO is in Mint
   mode:
   - Create CredentialsRequest, now with `spec.cloudTokenPath` and `spec.providerSpec.stsIAMRoleARN` filed.
-  - Wait for Secrets referenced in the CredentialsRequest to be created by CCO.
+  - Wait for the Secret referenced in the CredentialsRequest to be created by CCO.
     - Expect the Secrets take some time to create, do not crash and report error when it takes too long.
 
 ### Workflow Description

--- a/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md
+++ b/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md
@@ -223,7 +223,7 @@ enabled cluster. New guidelines would include the following to use CCO has detec
 - (Optional) Add the projected ServiceAccount volume to the Deployment embedded in the CSV;
 - When OLM starts the operator with `ROLEARN` env. variable, handle the cloud credentials *almost* as if CCO is in Mint
   mode:
-  - Create CredentialsRequest, now with `spec.cloudTokenPath` and `spec.providerSpec.stsIAMRoleARN` filed.
+  - Create CredentialsRequest, now with `spec.cloudTokenPath` and `spec.providerSpec.stsIAMRoleARN` filled.
   - Wait for the Secret referenced in the CredentialsRequest to be created by CCO.
     - Expect the Secret to take some time to create, do not crash and report an error when it takes too long.
 


### PR DESCRIPTION
Add env. variable + annotation name to the proposal, so operator authors don't need to read a separate godoc that's circling around. I am just reflecting current implementation.

And mark the enhancement as implementable, it has been already implemented.