### PR TITLE
Add ClusterRoles to Secrets Store CSI Driver Operator enhancement

### DIFF
--- a/enhancements/storage/csi-secrets-store.md
+++ b/enhancements/storage/csi-secrets-store.md
@@ -101,6 +101,9 @@ The only planned OpenShift API change is to add [secrets-store.csi.k8s.io](https
 When the operator is installed via OLM, two new CRD's are created as required by the CSI driver and provider plugins:
 [SecretProviderClasses](https://github.com/openshift/secrets-store-csi-driver/blob/main/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml) and
 [SecretProviderClassPodStatuses](https://github.com/openshift/secrets-store-csi-driver/blob/main/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml).
+
+ClusterRoles are created for each CRD to grant permissions for those objects to the `view`, `edit`, and `admin` roles. A user with a `view` role will be able to read `SecretProviderClass` and `SecretProviderClassPodStatuses` objects in their namespaces and a user with an `edit` role will be able to create, modify, and delete them.
+
 Once the operator is installed and ClusterCSIDriver object is created, the operator installs a ClusterRole which is used by the CSI driver to read SecretProviderClass objects created by the user, and to create/modify/delete SecretProviderClassPodStatus objects.
 
 ### Implementation Details/Notes/Constraints [optional]


### PR DESCRIPTION
Follow up on https://github.com/openshift/enhancements/pull/1423#discussion_r1233880248 and https://issues.redhat.com/browse/OCPBUGS-16281

These roles actually _are_ created by OLM already:

```
$ oc get clusterroles | grep 'secrets-store.csi.x'
secretproviderclasses.secrets-store.csi.x-k8s.io-v1-admin                   2023-08-07T17:10:45Z
secretproviderclasses.secrets-store.csi.x-k8s.io-v1-crdview                 2023-08-07T17:10:46Z
secretproviderclasses.secrets-store.csi.x-k8s.io-v1-edit                    2023-08-07T17:10:46Z
secretproviderclasses.secrets-store.csi.x-k8s.io-v1-view                    2023-08-07T17:10:46Z
secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io-v1-admin          2023-08-07T17:10:46Z
secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io-v1-crdview        2023-08-07T17:10:46Z
secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io-v1-edit           2023-08-07T17:10:46Z
secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io-v1-view           2023-08-07T17:10:46Z
```

This PR just updates the enhancement to describe the roles that get created during operator installation.

/cc @jsafrane @openshift/storage
