### PR TITLE
Shared Resources via OpenShift Builds Operator

### DIFF
--- a/enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
+++ b/enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
@@ -26,7 +26,7 @@ creation-date: 2020-03-17
 last-updated: 2021-10-06
 
 <!-- status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced -->
-status: implementable
+status: implemented
 
 
 

--- a/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md
+++ b/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md
@@ -124,7 +124,7 @@ lifecycle management of Shipwright, whose logic is implemented in the upstream
 
 #### Shipwright Builds
 
-- To disable Shipwright Builds by default, set the `SHIPWRIGHT_BUILD_DEFAULT_DISABLED` envionrment
+- To disable Shipwright Builds by default, set the `SHIPWRIGHT_BUILD_DEFAULT_DISABLED` environment
   variable to `true` in the operator `Subscription` object:
 
   ```yaml
@@ -144,7 +144,7 @@ lifecycle management of Shipwright, whose logic is implemented in the upstream
 - If OpenShift Pipelines is not installed and `spec.shipwright.build.managementState` is set to
   `Enabled`, the operator does not install Shipwright Builds and reports that OpenShift Pipelines
   should be installed in its status.
-- If Shipwright Builds is enabled and then later disabled, the following should occur:
+- If Shipwright Builds is enabled and then later set to `Removed`, the following should occur:
   - Shipwright build controllers should be deleted.
   - CRDs and associated admission webhooks should remain in place.
 
@@ -168,7 +168,7 @@ lifecycle management of Shipwright, whose logic is implemented in the upstream
           value: "true"
   ```
 
-- If the CSI driver is disabled after it has been enabled, the following should occur:
+- If the CSI driver is `Removed` after it has been enabled, the following should occur:
   - The `CSIDriver` object for the driver should be deleted.
   - The `DaemonSet` for the CSI driver should be deleted.
   - CRDs and associated admission webhooks should remain in place.
@@ -176,7 +176,7 @@ lifecycle management of Shipwright, whose logic is implemented in the upstream
 
 ### API Extensions
 
-The OpenShift Builds will introduce a new configuration CRD, `OpenShiftBuild`. It will contain 
+The OpenShift Builds operator will introduce a new configuration CRD, `OpenShiftBuild`. It will contain 
 `spec` fields that configure the Shared Resource CSI driver in addition to Shipwright-related
 components. The operator will also deploy (directly or indirectly) the following:
 
@@ -219,7 +219,7 @@ Admins or users may want to use the Shared Resource CSI Driver without Shipwrigh
 example, developers or teams that heavily rely on the `BuildConfig` APIs today. To address this
 concern, the OpenShift Builds operator will not rely on OLM API resolution to automate the
 installation and deployment of OpenShift Pipelines. The operator will instead report an appropriate
-status message if `spec.shipwright.build.enabled` is set to `true` and it detects that OpenShift
+status message if `spec.shipwright.build.managementState` is set to `Enabled` and it detects that OpenShift
 Pipelines has not been installed.
 
 The operator will also allow admins to opt out of enabling Shipwright Builds and/or the Shared

--- a/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md
+++ b/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md
@@ -124,7 +124,7 @@ lifecycle management of Shipwright, whose logic is implemented in the upstream
 
 ### API Extensions
 
-The OpenShift Builds will intoroduce a new configuration CRD, `OpenShiftBuild`. It will contain 
+The OpenShift Builds will introduce a new configuration CRD, `OpenShiftBuild`. It will contain 
 `spec` fields that configure the Shared Resource CSI driver in addition to Shipwright-related
 components. The operator will also deploy (directly or indirectly) the following:
 
@@ -147,7 +147,7 @@ The Shared Resource CSI driver itself will need to be removed from the OpenShift
 components will need to be re-productized as an OLM operand.
 
 Notably, the design of this operator does **_not_** intend to use OLM API dependency resolution
-to automate the deployment and management of OpenShift Pipelines. Cluster admimins will need to
+to automate the deployment and management of OpenShift Pipelines. Cluster admins will need to
 separately (and manually) install OpenShift Pipelines.
 
 
@@ -272,7 +272,7 @@ Replacing the current validating webhook with
 Rather than bundle the Shared Resources CSI driver with OpenShift Builds, the driver could be
 deployed with its own OLM operator. The primary issue with this approach is that OpenShift Builds
 would still want to deploy and manage this driver, since this is part of our strategy to make use
-of entiltements in builds simpler. This would likely add a lot of unnecessary complexity:
+of entitlements in builds simpler. This would likely add a lot of unnecessary complexity:
 
 - An additional operator CRD to reconcile (ex: `SharedResourceConfig`)
 - Version skews when OLM does its API resolution, OR

--- a/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md
+++ b/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md
@@ -1,0 +1,264 @@
+---
+title: shared-resources-via-openshift-builds-operator
+authors:
+  - "@adambkaplan"
+  - "@gabemontero"
+reviewers: # Include a comment about what domain expertise a reviewer is expected to bring and what area of the enhancement you expect them to focus on. For example: - "@networkguru, for networking aspects, please look at IP bootstrapping aspect"
+  - "@cdaley"
+  - "@rgormley"
+approvers: # A single approver is preferred, the role of the approver is to raise important questions, help ensure the enhancement receives reviews from all applicable areas/SMEs, and determine when consensus is achieved such that the EP can move forward to implementation.  Having multiple approvers makes it difficult to determine who is responsible for the actual approval.
+  - "@bparees"
+api-approvers: # In case of new or modified APIs or API extensions (CRDs, aggregated apiservers, webhooks, finalizers). If there is no API change, use "None"
+  - "@bparees"
+creation-date: 2023-08-17
+last-updated: 2023-08-21
+tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement
+  - https://issues.redhat.com/browse/RHDP-701
+see-also:
+  - "enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md"
+  - "enhancements/cluster-scope-secret-volumes/shared-resource-validation.md"
+replaces:
+  - "/enhancements/subscription-content/subscription-injection.md"
+superseded-by: []
+---
+
+# Shared Resources via OpenShift Builds Operator
+
+## Summary
+
+Remove the Shared Resources CSI driver from OpenShift, and deliver it to customers with the
+forthcoming OpenShift Builds OLM Operator.
+
+
+## Motivation
+
+The Shared Resources CSI driver provides a novel way for sharing information across OpenShift
+namespaces. Though there was hope this capability would be generally useful, in practice this
+feature is mainly needed for Red Hat build workloads.
+
+Packaging this driver with the forthcoming OpenShift Builds operator provides several advantages:
+
+- Provides an extension to OpenShift Builds, which is based on the upstream [Shipwright](https://shipwright.io) project.
+- Allows release outside of OpenShift's cadence.
+- Potential to fully support customers on older versions of OCP.
+- Pathway to adoption on hosted control plane clusters.
+
+
+### User Stories
+
+
+- As a developer installing RHEL RPMs in my container image, I want to use the Shared Resource CSI
+  driver to mount my cluster's entitlement into my build.
+- As a cluster admin of a build/CI cluster, I want to manage the Shared Resource CSI driver via an
+  operator so that its installation, custom resources, and lifecycle are managed by OLM.
+- As an SRE operating hosted control plane clusters, I want the Shared Resource CSI driver to be
+  managed by OLM so that its admission webhooks are not run on the hosted control plane.
+- As a Red Hat software engineer, I want to release the Shared Resource CSI Driver via OLM so that
+  I can fully support the driver on more versions of OCP.
+
+
+### Goals
+
+- Deploy the Shared Resource CSI Driver via OLM
+- Deprecate and remove the Shared Resource CSI Driver as a tech preview feature in OpenShift.
+
+
+### Non-Goals
+
+- Automatically mount RHEL entitlements into builds.
+- Deploy OLM operator webhooks on hosted control planes.
+- Describe the low level implementation of the OpenShift Builds Operator.
+- Management of the Build capability in OCP.
+
+
+## Proposal
+
+The `CSIDriverSharedResource` feature will be officially deprecated in OCP 4.15, and removed fully
+in OCP 4.16. A blog post will announce this deprecation and its replacement with the OpenShift Builds operator.
+
+The OpenShift Builds operator will be enhanced to support the lifecycle and management of the
+Shared Resource CSI Driver and its associated components. This will be in addition to the
+lifecycle management of Shipwright, whose logic is implemented in the upstream
+[Shipwright Operator](https://github.com/shipwright-io/operator).
+
+
+### Workflow Description
+
+1. Cluster admin installs the OpenShift Builds operator via OLM, using one of the following:
+   1. OperatorHub web console in OpenShift
+   2. Creating an appropriate OLM `Subscription` object via `oc apply`, OpenShift GitOps, and so
+      forth.
+2. Once the operator is deployed, it creates an `OpenShiftBuild` custom resource instance on the
+  cluster:
+
+  ```yaml
+  apiVersion: operator.build.openshift.io/v1alpha1
+  kind: OpenShiftBuild
+  metadata:
+    name: cluster
+  spec:
+    shipwright:
+      build:
+        enabled: true
+    sharedResources:
+      enabled: false
+  ```
+
+3. The OpenShift Builds Operator reconciles the `OpenShiftBuild` instance (singleton), and reports
+  an appropriate status. If `spec.sharedResources.enabled` is `true`, the operator deploys the
+  Shared Resource CSI driver, custom resource definitions, and webhook.
+4. The operator will likewise deploy and manage Shipwright components using the `spec.shipwright.*`
+  fields.
+
+### Variations
+
+- The operator will default to enabling Shipwright Builds, deploying its associated controllers and
+  custom resources. Cluster admins can disable Shipwright Builds, which removes the controller
+  deployment. Components related to the custom resources (CRDs, conversion webhook) are not
+  removed.
+- If the operator is deployed on a cluster with the `CSIDriverSharedResource` feature gate enabled,
+  changing `spec.sharedResources.enabled` will not be respected, and an appropriate status
+  condition will report why the operator has not deployed the Shared Resource CSI driver.
+
+
+### API Extensions
+
+The OpenShift Builds will intoroduce a new configuration CRD, `OpenShiftBuild`. It will contain 
+`spec` fields that configure the Shared Resource CSI driver in addition to Shipwright-related
+components. The operator will also deploy (directly or indirectly) the following:
+
+- Custom resources for the Shipwright Operator
+- Custom resources and webhooks for Shipwright Build
+- Custom resources and webhooks for the Shared Resource CSI Driver
+
+
+### Implementation Details/Notes/Constraints [optional]
+
+As noted above, the operator will not deploy the Shared Resource CSI Driver if the cluster has
+the respective OCP feature gate enabled. This generally applies to tech preview clusters or
+clusters with custom fature gate tunings.
+
+With the start of OCP 4.16, the Shared Resource CSI driver operator will be removed from the
+[Cluster Storage Operator](https://github.com/openshift/cluster-storage-operator). The feature
+will likewise be removed from OpenShift's feature sets - any code that needs the most up to date
+set of feature sets will need to be updated (ex - openshift/library-go).
+
+The Shared Resource CSI driver itself will need to be removed from the OpenShift payload. Its
+components will need to be re-productized as an OLM operand.
+
+
+### Risks and Mitigations
+
+**Risk**: Same CSI driver will be deployed twice on tech preview clusters.
+*Mitigation*: Operator will check if the `CSIDriverSharedResource` feature is enabled before
+deploying the Shared Resource CSI driver itself.
+
+
+**Risk**: Admins or users will want the Shared Resource CSI Driver without Shipwright
+*Mitigation*: Shipwright components can be disabled via the `OpenshiftBuild` CRD.
+
+
+### Drawbacks
+
+- Shared resources no longer a part of OpenShift
+- Customers who need entitlements in builds will need to install a new operator, or resort to less
+  desirable work-arounds
+- Potential impact on Red Hat components that need shared resources and/or RHEL entitlements
+
+
+## Design Details
+
+
+### Test Plan
+
+- Shared resource logic in the OCP Builds tech preview suite will need to be migrated to the
+  OpenShift Builds operator test suites
+- OpenShift Builds operator will need a techpreview variant to ensure the shared resource CSI
+  driver is not managed by the operator on OCP 4.15 and earlier (tech preview).
+
+
+### Graduation Criteria
+
+#### Dev Preview -> Tech Preview
+
+N/A
+
+#### Tech Preview -> GA
+
+N/A
+
+#### Removing a deprecated feature
+
+- Deprecation announcement for OCP 4.15
+- Removal of `CSIDriverSharedResource` feature for OCP 4.16
+
+
+### Upgrade / Downgrade Strategy
+
+No concerns for upgrade/downgrade, as `CSIDriverSharedResource` is a tech preview feature and does
+not support upgrades.
+
+
+### Version Skew Strategy
+
+OpenShift Builds operator will be responsible for managing upgrades of the csi driver.
+
+
+### Operational Aspects of API Extensions
+
+API extensions are currently managed by OLM and the operator. Webhooks related to these
+custom resources are the responsibility of the respective operator or operand, and gnerally should
+not validate pod admission.
+
+The exception is the pod admission webhook for the Shared Resource CSI driver, which has been
+discussed previously (see [shared resource validation](enhancements/cluster-scope-secret-volumes/shared-resource-validation.md)).
+
+
+#### Failure Modes
+
+Out of scope - will be described by the OpenShift Builds operator design.
+
+
+#### Support Procedures
+
+Out of scope - will be described by the OpenShift Builds operator documentation.
+
+
+## Implementation History
+
+TBD
+
+
+## Alternatives
+
+
+### Remain in OCP
+
+The CSI driver could remain in OpenShift, but would require significant changes to its validating
+admission webhook. Validating admission webhooks proved challenging to deploy with hosted control
+planes ("hypershift") when deployed in the OCP payload. Support for these webhooks exists today for
+OLM operators, as these run in the "guest" cluster and are not part of the hosted control plane.
+Future enhancements may allow OLM operators to generally deploy webhooks onto the hosted control plane.
+
+
+### Deploy Shared Resources as separate operator
+
+Rather than bundle the Shared Resources CSI driver with OpenShift Builds, the driver could be
+deployed with its own OLM operator. The primary issue with this approach is that OpenShift Builds
+would still want to deploy and manage this driver, since this is part of our strategy to make use
+of entiltements in builds simpler. This would likely add a lot of unnecessary complexity:
+
+- An additional operator CRD to reconcile (ex: `SharedResourceConfig`)
+- Version skews when OLM does its API resolution.
+- Risk of separate deployment/management of the CSI driver.
+
+The OpenShift Builds operator already has to address these complexities for Tekton, since it has
+an indirect dependency on the OpenShift Pipelines operator. Adding another operator that has loose
+management in OLM would significantly expand the potential support matrix.
+
+
+## Infrastructure Needed [optional]
+
+None expected - the new operator can take advantage of existing resources used in OpenShift CI.
+Alternatively, the new OpenShift Builds operator may decide to "dogfood" Tekton in its tests, using
+an operating OpenShift Builds/Pipelines cluster.

--- a/enhancements/subscription-content/subscription-injection.md
+++ b/enhancements/subscription-content/subscription-injection.md
@@ -10,13 +10,14 @@ approvers:
   - "@bparees"
   - "@derekwaynecarr"
 creation-date: 2020-06-25
-last-updated: 2020-09-16
-status: implementable
+last-updated: 2023-08-17
+status: replaced
 see-also:
   - /enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
   - https://github.com/openshift/enhancements/pull/384
 replaces: []
-superseded-by: []
+superseded-by:
+  - "/enhancements/cluster-scope-secret-volumes/shared-resources-via-openshift-builds-operator.md"
 ---
 
 # Subscription Injection Operator


### PR DESCRIPTION
Proposal to remove the Shared Resource CSI driver from OpenShift,
and deploy it via the OpenShift Builds operator instead. The
primary purpose of this document is to solicit feedback on this
approach. The CSI driver is currently marked as Tech Preview, and as
such does not require a proposal for its removal.

The `CSIDriverSharedResource` feature in OCP will be marked as
deprecated in 4.15, with the intent of removal in 4.16. Clusters
which want to add this CSI driver will need to install the OpenShift
Builds operator first. Once installed, an admin will need to enable
the driver through the operator's configuration custom resource.

Alternatives considered include keeping the CSI driver in OCP and
marking it GA, or deploying the CSI driver through its own operator
and corresponding layered product. The proposal details the disadvantage
of these approaches, and why removal from OCP was chosen as the path
forward.