### PR TITLE
Include hypershift use case in template

### DIFF
--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -170,7 +170,9 @@ deploying an application in a cluster.
    applications, and gives the application administrator their
    credentials.
 
-#### Variation [optional]
+#### Variation and form factor considerations [optional]
+
+How does this proposal intersect with Standalone OCP, Microshift and Hypershift?
 
 If the cluster creator uses a standing desk, in step 1 above they can
 stand instead of sitting down.
@@ -202,6 +204,12 @@ of API Extensions" section.
 What are the caveats to the implementation? What are some important details that
 didn't come across above. Go in to as much detail as necessary here. This might
 be a good place to talk about core concepts and how they relate.
+
+#### Hypershift [optional]
+
+Does the design and implementation require specific details to account for the Hypershift use case?
+See https://github.com/openshift/enhancements/blob/e044f84e9b2bafa600e6c24e35d226463c2308a5/enhancements/multi-arch/heterogeneous-architecture-clusters.md?plain=1#L282
+
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
Initially Hypershift development was about getting all things working together end to end and so Hypershift introduce multiple shims for components to work as a escape hatch. As components keep developing changes and features we try to protect hypershift from components breaking changes by running presubmits jobs in those components where possible. Given the maturity of the project I'd expect any component making changes to satisfy and account for the hypershift form factor early in the design and not the other way around. This PR is a very small step in that direction.