### PR TITLE
dev-guide/host-port-registry: Declare cluster-version operator metrics on TCP 9099

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -79,6 +79,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 6388  | ironic (internal) | metal | 4.12 | baremetal provisioning, control plane only |
 | 6443  | kube-apiserver | apiserver || control plane only |
 | 9001  | machine-config-daemon oauth proxy | node || metrics |
+| 9099  | cluster-version operator | updates || metrics |
 | 9100  | node-exporter | monitoring || metrics |
 | 9101  | openshift-sdn kube-rbac-proxy | sdn || metrics, openshift-sdn only |
 | 9101  | kube-proxy | sdn || metrics, third-party network plugins only, deprecated |


### PR DESCRIPTION
The CVO has [served metrics on 9099 since 4.1][1], and [the CVO has also been `hostNetwork: true` since 4.1][2].  [Docs have listed the port for years][3] as an example of 9000-9999 host-level services, but there are other entries in this port registry in that range, so I'm adding the CVO here for completeness.

/assign @LalatenduMohanty 

[1]: https://github.com/openshift/cluster-version-operator/blame/5071540a66c787b02acc1e903fcc7aba1b855077/install/0001_00_cluster-version-operator_03_service.yaml#L18
[2]: https://github.com/openshift/cluster-version-operator/blame/5071540a66c787b02acc1e903fcc7aba1b855077/install/0000_00_cluster-version-operator_03_deployment.yaml#L61
[3]: https://github.com/openshift/openshift-docs/blame/d5bb208e28fa668cde5a59e7b1dcffb81628ce36/modules/installation-network-user-infra.adoc#L153