### PR TITLE
storage: mark ebs-operator.md as replaced

### DIFF
--- a/enhancements/storage/csi-driver-install.md
+++ b/enhancements/storage/csi-driver-install.md
@@ -11,10 +11,11 @@ approvers:
   - "@knobunc"
   - "@shawn-hurley"
 creation-date: 2019-11-04
-last-updated: 2020-03-10
+last-updated: 2023-09-05
 status: implementable
 see-also:
 replaces:
+  - /enhancements/storage/csi-ebs-operator.md
 superseded-by:
 ---
 

--- a/enhancements/storage/csi-driver-install.md
+++ b/enhancements/storage/csi-driver-install.md
@@ -12,7 +12,7 @@ approvers:
   - "@shawn-hurley"
 creation-date: 2019-11-04
 last-updated: 2023-09-05
-status: implementable
+status: implemented
 see-also:
 replaces:
   - /enhancements/storage/csi-ebs-operator.md

--- a/enhancements/storage/csi-ebs-operator.md
+++ b/enhancements/storage/csi-ebs-operator.md
@@ -9,11 +9,12 @@ reviewers:
 approvers:
   - "@..."
 creation-date: 2020-03-09
-last-updated: 2020-03-13
-status: implementable
+last-updated: 2023-09-05
+status: replaced
 see-also:
 replaces:
 superseded-by:
+-  /enhancements/storage/csi-driver-install.md
 ---
 
 # CSI Operator for AWS EBS


### PR DESCRIPTION
It's a failed experiment, fully replaced by csi-driver-install.md
Also mark csi-driver-install.md as implemented, it has been so for a long time.