### PR TITLE
Pin and pre-load images

### DIFF
--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -116,6 +116,13 @@ request for details). That capability will be used to pin all the images
 required for the upgrade, so that they aren't garbage collected by kubelet and
 CRI-O.
 
+In addition when the CRI-O service is upgraded and restarted it removes all the
+images. This used to be done by the `crio-wipe` service, but is now done
+internally by CRI-O. It can be avoided setting the `version_file_persist`
+configuration parameter to "", but that would affect all images, not just the
+pinned ones. This behavior needs to be changed so that pinned images aren't
+removed, regardless of the value of `version_file_persist`.
+
 The changes to pin the images will be done in a `/etc/crio/crio.conf.d/pin.conf`
 file, something like this:
 

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -80,8 +80,8 @@ parts of https://github.com/openshift/enhancements/pull/1432.
 
 ### Workflow Description
 
-1. The administrator of a cluster uses the new `PinnedImageSet` object to
-request that a set of container images are pinned and pre-loaded:
+1. The administrator of a cluster uses the new `PinnedImageSet` custom resource
+to request that a set of container images are pinned and pre-loaded:
 
     ```yaml
     apiVersion: machineconfiguration.openshift.io/v1alpha1
@@ -104,10 +104,10 @@ pulled in all the nodes that match the node selector.
 
 ### API Extensions
 
-A new `PinnedImageSet` object will be added to the
+A new `PinnedImageSet` custom resource definition will be added to the
 `machineconfiguration.openshift.io` API group.
 
-The new object is defined in detail in
+The new custom resource definition is described in detail in
 https://github.com/openshift/api/pull/1609.
 
 ### Implementation Details/Notes/Constraints
@@ -128,8 +128,8 @@ aren't removed, regardless of the value of `version_file_persist`.
 The changes to pin the images will be done in a file inside the
 `/etc/crio/crio.conf.d` directory. To avoid potential conflicts with files
 manually created by the administrator the name of this file will be the name of
-the `PinnedImageSet` object concatenated with the UUID assiged by the API
-server. For example, if the object is this:
+the `PinnedImageSet` custom resource concatenated with the UUID assiged by the
+API server. For example, if the custom resource is this:
 
 ```yaml
 apiVersion: machineconfiguration.openshift.io/v1alpha1
@@ -163,11 +163,11 @@ pinned_images=[
 ]
 ```
 
-In addition to the list of images to be pinned, the `PinnedImageSet` object
-will also contain a node selector. This is intended to support different sets
-of images for different kinds of nodes. For example, to pin different images
-for control plane and worker nodes the user could create two `PinnedImageSet`
-objects:
+In addition to the list of images to be pinned, the `PinnedImageSet` custom
+resource will also contain a node selector. This is intended to support
+different sets of images for different kinds of nodes. For example, to pin
+different images for control plane and worker nodes the user could create two
+`PinnedImageSet` custom resources:
 
 ```yaml
 # For control plane nodes:
@@ -204,11 +204,11 @@ have them consuming disk space in worker nodes.
 When no node selector is specified the images will be pinned in all the nodes
 of the cluster.
 
-When a `PinnedImageSet` object is added, modified or deleted the machine config
-operator will create, modify or delete the configuration file, reload the CRI-O
-configuration (with the equivalent of `systemctl reload crio`) and then it will
-use the CRI-O gRPC API to run the equivalent of `crictl pull` for each of the
-images.
+When a `PinnedImageSet` custom resource is added, modified or deleted the
+machine config operator will create, modify or delete the configuration file,
+reload the CRI-O configuration (with the equivalent of `systemctl reload crio`)
+and then it will use the CRI-O gRPC API to run the equivalent of `crictl pull`
+for each of the images.
 
 Note that this will happen in all the nodes of the cluster that match the node
 selector.
@@ -305,12 +305,12 @@ Not applicable, no feature will be removed.
 
 ### Upgrade / Downgrade Strategy
 
-Upgrades from versions that don't support the `PinnedImageSet` object don't
-require any special handling because the object is optional: there will be no
-such objects in the upgraded cluster.
+Upgrades from versions that don't support the `PinnedImageSet` custom resource
+don't require any special handling because the custom resource is optional:
+there will be no such custom resource in the upgraded cluster.
 
-Downgrades to versions that don't support the `PinnedImageSet` object don't
-require any changes. The existing pinned images will be ignored in the
+Downgrades to versions that don't support the `PinnedImageSet` custom resource
+don't require any changes. The existing pinned images will be ignored in the
 downgraded cluster, and will eventually be garbage collected.
 
 ### Version Skew Strategy
@@ -322,8 +322,8 @@ Not applicable.
 #### Failure Modes
 
 Image pulling may fail due to lack of disk space or other reasons. This will be
-reported via the conditions in the `PinnedImageSet` objects. See the risks and
-mitigations section for details.
+reported via the conditions in the `PinnedImageSet` custom resource. See the
+risks and mitigations section for details.
 
 #### Support Procedures
 

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -3,11 +3,11 @@ title: pin-and-pre-load-images
 authors:
 - "@jhernand"
 reviewers:
-- "@avishayt"
-- "@danielerez"
-- "@mrunalp"
-- "@nmagnezi"
-- "@oourfali"
+- "@avishayt"   # To ensure that this will be usable with the appliance.
+- "@danielerez" # To ensure that this will be usable with the appliance.
+- "@mrunalp"    # To ensure that this can be implemented with CRI-O and MCO.
+- "@nmagnezi"   # To ensure that this will be usable with the appliance.
+- "@oourfali"   # To ensure that this will be usable with the appliance.
 approvers:
 - "@sdodson"
 - "@zaneb"

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -260,13 +260,14 @@ status:
 
 Note that even with this check it will still be possible (but less likely) to
 have failures to pull images due to disk space: the heuristic could be wrong,
-and there may be other components pulling images or consuming disk space in some
-other way. Those failures will be detected and reported in the status of the `PinnedImageSet` when CRI-O fails to pull the image.
+and there may be other components pulling images or consuming disk space in
+some other way. Those failures will be detected and reported in the status of
+the `PinnedImageSet` when CRI-O fails to pull the image.
 
-The steps above will happen in all the nodes of the cluster. The daemon set will
-be provided with enough information to ensure that each pod applies only the
-changes required for the node where it runs, according to the node selectors in
-the `PinnedImageSet` custom resources.
+The steps above will happen in all the nodes of the cluster. The daemon set
+will be provided with enough information to ensure that each pod applies only
+the changes required for the node where it runs, according to the node
+selectors in the `PinnedImageSet` custom resources.
 
 When all the images have been successfully pinned and pulled in all the matching
 nodes the `PinnedImageSetController` will set the `Ready` condition to `True`:

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -122,8 +122,8 @@ In addition when the CRI-O service is upgraded and restarted it removes all the
 images. This used to be done by the `crio-wipe` service, but is now done
 internally by CRI-O. It can be avoided setting the `version_file_persist`
 configuration parameter to "", but that would affect all images, not just the
-pinned ones. This behavior needs to be changed so that pinned images aren't
-removed, regardless of the value of `version_file_persist`.
+pinned ones. This behavior needs to be changed in CRI-O so that pinned images
+aren't removed, regardless of the value of `version_file_persist`.
 
 The changes to pin the images will be done in a file inside the
 `/etc/crio/crio.conf.d` directory. To avoid potential conflicts with files

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -210,6 +210,9 @@ reload the CRI-O configuration (with the equivalent of `systemctl reload crio`)
 and then it will use the CRI-O gRPC API to run the equivalent of `crictl pull`
 for each of the images.
 
+Note that currently CRI-O doesn't reset pinned images on reload, support for
+that will need to be added.
+
 Note that this will happen in all the nodes of the cluster that match the node
 selector.
 

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -69,7 +69,10 @@ container images.
 
 ### Non-Goals
 
-None.
+We wish to use the mechanism described in this enhancement to orchestrate
+upgrades without a registry server. But that orchestration is not a goal
+of this enhancement; it will be part of a separate enhancement based on
+parts of https://github.com/openshift/enhancements/pull/1432.
 
 ## Proposal
 

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -299,6 +299,10 @@ status:
     message: Node 'node12' failed to pull image `quay.io/...` because ...
 ```
 
+We will consider using the new _machine-config-operator_ state reporting
+mechanism introduced [https://github.com/openshift/api/pull/1596](here) to
+report additional details about the progress or issues of each node.
+
 Additional information may be needed inside the `status` field of the
 `PinnedImageSet` custom resources in order to implement the mechanisms described
 above. For example, it may be necessary to have conditions per node, something

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -22,7 +22,7 @@ tracking-link:
 - https://issues.redhat.com/browse/RFE-4482
 see-also:
 - https://github.com/openshift/enhancements/pull/1432
-- https://github.com/openshift/machine-config-operator/pull/3839
+- https://github.com/openshift/api/pull/1609
 replaces: []
 superseded-by: []
 ---
@@ -108,7 +108,7 @@ A new `PinnedImageSet` object will be added to the
 `machineconfiguration.openshift.io` API group.
 
 The new object is defined in detail in
-https://github.com/openshift/machine-config-operator/pull/3839.
+https://github.com/openshift/api/pull/1609.
 
 ### Implementation Details/Notes/Constraints
 

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -99,7 +99,8 @@ to request that a set of container images are pinned and pre-loaded:
       ...
     ```
 
-1. The machine config operators ensures that all the images are pinned and
+1. A new `PinnedImageSetController` sub-controller of the
+_machine-config-controller_ ensures that all the images are pinned and
 pulled in all the nodes that match the node selector.
 
 ### API Extensions

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -9,9 +9,8 @@ reviewers:
 - "@nmagnezi"   # To ensure that this will be usable with the appliance.
 - "@oourfali"   # To ensure that this will be usable with the appliance.
 approvers:
-- "@sdodson"
-- "@zaneb"
-- "@LalatenduMohanty"
+- "@sinnykumari"
+- "@mrunalp"
 api-approvers:
 - "@sdodson"
 - "@zaneb"

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -242,6 +242,9 @@ status:
     message: Node 'node12' failed to pull image `quay.io/...` because ...
 ```
 
+This logic to handle the pinned image sets and generate the configuration files
+will be part of a new sub-controller in MCC.
+
 ### Risks and Mitigations
 
 Pre-loading disk images can consume a large amount of disk space. For example,

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -41,7 +41,10 @@ operations that require pulling images. For example, an upgrade may require
 pulling more than one hundred images. Failures to pull those images cause
 retries that interfere with the upgrade process and may eventually make it
 fail. One way to improve that is to pull the images in advance, before they are
-actually needed, and ensure that they aren't removed.
+actually needed, and ensure that they aren't removed. Doing that provides a
+more consistent upgrade time in those environments. That is important when
+scheduling upgrades into maintenance windows, even if the upgrade might not
+otherwise fail.
 
 ### User Stories
 

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -1,0 +1,232 @@
+---
+title: pin-and-pre-load-images
+authors:
+- "@jhernand"
+reviewers:
+- "@avishayt"
+- "@danielerez"
+- "@mrunalp"
+- "@nmagnezi"
+- "@oourfali"
+approvers:
+- "@sdodson"
+- "@zaneb"
+- "@LalatenduMohanty"
+api-approvers:
+- "@sdodson"
+- "@zaneb"
+- "@deads2k"
+- "@JoelSpeed"
+creation-date: 2023-09-21
+last-updated: 2023-09-21
+tracking-link:
+- https://issues.redhat.com/browse/RFE-4482
+see-also:
+- https://github.com/openshift/enhancements/pull/1432
+- https://github.com/openshift/machine-config-operator/pull/3839
+replaces: []
+superseded-by: []
+---
+
+# Pin and pre-load images
+
+## Summary
+
+Provide an mechanism to pin and pre-load container images.
+
+## Motivation
+
+Slow and/or unreliable connections to the image registry servers interfere with
+operations that require pulling images. For example, an upgrade may require
+pulling more than one hundred images. Failures to pull those images cause
+retries that interfere with the upgrade process and may eventually make it
+fail. One way to improve that is to pull the images in advance, before they are
+actually needed, and ensure that they aren't removed.
+
+### User Stories
+
+#### Pre-load and pin upgrade images
+
+As the administrator of a cluster that has a low bandwidth and/or unreliable
+connection to an image registry server I want to pin and pre-load all the
+images required for the upgrade in advance, so that when I decide to actually
+perform the upgrade there will be no need to contact that slow and/or
+unreliable registry server and the upgrade will successfully complete in a
+predictable time.
+
+#### Pre-load and pin application images
+
+As the administrator of a cluster that has a low bandwidth and/or unreliable
+connection to an image registry server I want to pin and pre-load the images
+required by my application in advance, so that when I decide to actually deploy
+it there will be no need to contact that slow and/or unreliable registry server
+and my application will successfully deploy in a predictable time.
+
+### Goals
+
+Provide a mechanism that cluster administrators can use to pin and pre-load
+container images.
+
+### Non-Goals
+
+None.
+
+## Proposal
+
+### Workflow Description
+
+1. The administrator of a cluster uses the `ContainerRuntimeConfig` object to
+request that a set of container images are pinned and pre-loaded:
+
+    ```yaml
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: ContainerRuntimeConfig
+    metadata:
+      name: ...
+    spec:
+      containerRuntimeConfig:
+        pinnedImages:
+        - quay.io/openshift-release-dev/ocp-release@sha256:...
+        - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...
+        - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...
+        ...
+    ```
+
+1. The machine config operators ensures that all the images are pinned and
+pulled in all the nodes of the cluster.
+
+### API Extensions
+
+There are no new object kinds introduced by this enhancement, but new fields
+will be added to existing `ContainerRuntimeConfig` objects.
+
+The new fields for the `ContainerRuntimeConfig` object are defined in detail in
+https://github.com/openshift/machine-config-operator/pull/3839.
+
+### Implementation Details/Notes/Constraints
+
+Starting with version 4.14 of OpenShift CRI-O will have the capability to pin
+certain images (see [this](https://github.com/cri-o/cri-o/pull/6862) pull
+request for details). That capability will be used to pin all the images
+required for the upgrade, so that they aren't garbage collected by kubelet and
+CRI-O.
+
+The changes to pin the images will be done in a `/etc/crio/crio.conf.d/pin.conf`
+file, something like this:
+
+```toml
+pinned_images=[
+  "quay.io/openshift-release-dev/ocp-release@sha256:...",
+  "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
+  "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
+  ...
+]
+```
+
+The images need to be pre-loaded and the CRI-O service needs to be reloaded
+when this configuration changes. To support that a new field will be added to
+the `ContainerRuntimeConfig` object:
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: ...
+spec:
+  containerRuntimeConfig:
+    pinnedImages:
+    - quay.io/openshift-release-dev/ocp-release@sha256:...
+    - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...
+    - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...
+    ...
+```
+
+When the new `pinnedImages` field is added or changed the machine config
+operator will need to pull those images (with the equivalent of `crictl pull`),
+create or update the corresponding `/etc/crio/crio.conf.d/pin.conf` file and ask
+CRI-O reload its configuration (with the equivalent of `systemctl reload
+crio.service`).
+
+The machine config operator will then will use the gRPC API of CRI-O to run the
+equivalent of `crictl pull` for each of the images. When that is completed the
+machine config operator will update the new `status.pinnedImages` field of the
+rendered machine config:
+
+```yaml
+status:
+  pinnedImages:
+  - quay.io/openshift-release-dev/ocp-release@sha256:...
+  - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...
+  - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...
+  ...
+```
+
+### Risks and Mitigations
+
+None.
+
+### Drawbacks
+
+This approach requires non trivial changes to the machine config operator.
+
+## Design Details
+
+### Open Questions
+
+None.
+
+### Test Plan
+
+We add a CI test that verifies that images are correctly pinned and pre-loaded.
+
+### Graduation Criteria
+
+The feature will ideally be introduced as `Dev Preview` in OpenShift 4.X,
+moved to `Tech Preview` in 4.X+1 and declared `GA` in 4.X+2.
+
+#### Dev Preview -> Tech Preview
+
+- Availability of the CI test.
+
+- Obtain positive feedback from at least one customer.
+
+#### Tech Preview -> GA
+
+- User facing documentation created in
+[https://github.com/openshift/openshift-docs](openshift-docs).
+
+#### Removing a deprecated feature
+
+Not applicable, no feature will be removed.
+
+### Upgrade / Downgrade Strategy
+
+Not applicable.
+
+### Version Skew Strategy
+
+Not applicable.
+
+### Operational Aspects of API Extensions
+
+Not applicable, there are no API extensions.
+
+#### Failure Modes
+
+#### Support Procedures
+
+## Implementation History
+
+There is an initial prototype exploring some of the implementation details
+described here in this [https://github.com/jhernand/upgrade-tool](repository).
+
+## Alternatives
+
+The alternative to this is to manually pull the images in all the nodes of the
+cluster, manually create the `/etc/crio/crio.conf.d/pin.conf` file and manually
+reload the CRI-O service.
+
+## Infrastructure Needed
+
+Infrastructure will be needed to run the CI test described in the test plan
+above.

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -188,7 +188,7 @@ spec:
 apiVersion: machineconfiguration.openshift.io/v1alpha1
 kind: PinnedImageSet
 metadata:
-  name: my-control-plane-pinned-images
+  name: my-worker-pinned-images
 spec:
   nodeSelector:
     matchLabels:

--- a/enhancements/machine-config/pin-and-pre-load-images.md
+++ b/enhancements/machine-config/pin-and-pre-load-images.md
@@ -147,7 +147,7 @@ spec:
 
 Then the complete path will be this:
 
-```
+```txt
 /etc/crio/crio.conf.d/my-pinned-images-550a1d88-2976-4447-9fc7-b65e457a7f42.conf
 ```
 


### PR DESCRIPTION
This patch adds an enhancement that describes a mechanism to pin and pre-load container images.

Related: https://issues.redhat.com/browse/RFE-4482
Related: https://issues.redhat.com/browse/OTA-1001
Related: https://issues.redhat.com/browse/OTA-997
Related: https://github.com/openshift/machine-config-operator/pull/3839
Related: https://github.com/openshift/enhancements/pull/1432