### PR TITLE
Implementation details for `--all-images`

### DIFF
--- a/enhancements/oc/must-gather.md
+++ b/enhancements/oc/must-gather.md
@@ -29,24 +29,24 @@ superseded-by:
 ## Summary
 
 To debug something broken in the cluster, it is important to have a single command for an unskilled customer to run that
-gathers all the information we may need to solve the problem.  If you're familiar with `sosreport`, the idea is to have
-that, but focused on a kuberentes cluster instead of a host.  We need avoid the versioning skew complexity and the scaling
-problems inherent in a shared repo with input from multiple products.
+gathers all the information we may need to solve the problem. If you're familiar with `sosreport`, the idea is to have
+that, but focused on a kuberentes cluster instead of a host. We need to avoid the versioning skew complexity and the
+scaling problems inherent in a shared repo with input from multiple products.
 
 ## Motivation
 
-Gather everything.  Software breaks and you aren't smart enough to know exactly what you need to debug the problem ahead of time.  You figure
-that out *after* you've debugged the problem.  This tool is about the first shotgun gathering so you only have to ask the
+Software breaks and you aren't smart enough to know exactly what you need to debug the problem ahead of time. You figure
+that out *after* you've debugged the problem. This tool is about the first shotgun gathering so you only have to ask the
 customer once.
 
-It must be simple.  You're gathering because your software is buggy and hard to use.  The more complex your gathering software, the more likely
-it is that the gathering software fails too.  Simplify your gathering software by only using a matching version of the gathering tool.
-This simplifies code and test matrices so that your tool always works.  For instance, OpenShift payloads include the exact
+It must be simple. You're gathering because your software is buggy and hard to use. The more complex your gathering software, the more likely
+it is that the gathering software fails too. Simplify your gathering software by only using a matching version of the gathering tool.
+This simplifies code and test matrices so that your tool always works. For instance, OpenShift payloads include the exact
 level of gathering used to debug that payload.
 
-Own your destiny.  You own shipping your own software.  If you can be trusted to ship your software, you can be trusted
-to ship your gathering tool to match it, don't let your gathering be gated by another product.  It may seems easier to start,
-but ultimately you'll end up constrained by different motivations, styles, and cadences.  If you can ship one image, you can
+Own your destiny. You own shipping your own software. If you can be trusted to ship your software, you can be trusted
+to ship your gathering tool to match it, don't let your gathering be gated by another product. It may seems easier to start,
+but ultimately you'll end up constrained by different motivations, styles, and cadences. If you can ship one image, you can
 ship a second one.
 
 ### Goals
@@ -64,14 +64,14 @@ ship a second one.
 
 `must-gather` for openshift is a combination of three tools:
 
-1. A client-side `inspect` command that works like a super-get.  It has semantic understand of some resources and traverses
-   links to get interesting information beyond the current.  Pods in namespaces and logs for those pods as a for instance.
-   Currently this is `openshift-must-gather inspect`, but we are porting this to `oc adm` as experiemental in 4.3.  We may
+1. A client-side `inspect` command that works like a super-get. It has semantic understanding of some resources and traverses
+   links to get interesting information beyond the current. Pods in namespaces and logs for those pods, for instance.
+   Currently, this is `openshift-must-gather inspect`, but we are porting this to `oc adm` as experimental in 4.3. We may
    change and extend arguments over time, but the intent of the command will remain.
-2. The openshift-must-gather image, produced from https://github.com/openshift/must-gather.  The entry point is a
+2. The openshift-must-gather image, produced from https://github.com/openshift/must-gather. The entry point is a
    [/gather bash script](https://github.com/openshift/must-gather/blob/master/collection-scripts/gather) owned by CEE
-   (not the developers) that describes what to gather.  It is tightly coupled to the openshift payload
-   and only contains logic to gather information from that payload.  We have e2e tests that make sure this functions.
+   (not the developers) that describes what to gather. It is tightly coupled to the OpenShift payload
+   and only contains logic to gather information from that payload. We have e2e tests that make sure this functions.
 3. `oc adm must-gather --image` which is a client-side tool that runs any must-gather compatible image by creating a pod,
    running the `/usr/bin/gather` binary, and then rsyncing the `/must-gather` and includes the logs of the pod.
 
@@ -84,7 +84,7 @@ See the [inspect enhancement](inspect.md) for details on the `inspect` command.
 To provide your own must-gather image, it must....
 
 1. Must have a zero-arg, executable file at `/usr/bin/gather` that does your default gathering
-2. Must produce data to be copied back at `/must-gather`.  The data must not contain any sensitive data.  We don't string PII information, only secret information.
+2. Must produce data to be copied back at `/must-gather`. The data must not contain any sensitive data. We don't string PII information, only secret information.
 3. Must produce a text `/must-gather/version` that indicates the product (first line) and the version (second line, `major.minor.micro-qualifier`),
    so that programmatic analysis can be developed.
 
@@ -101,12 +101,12 @@ If the `oc adm must-gather` tool's pod cannot be scheduled or run on the cluster
 ### Implementation Details/Notes/Constraints
 
 What are the caveats to the implementation? What are some important details that
-didn't come across above. Go in to as much detail as necessary here. This might
+didn't come across above? Go in to as much detail as necessary here. This might
 be a good place to talk about core concepts and how they releate.
 
 ### Risks and Mitigations
 
-What are the risks of this proposal and how do we mitigate. Think broadly. For
+What are the risks of this proposal and how do we mitigate? Think broadly. For
 example, consider both security and how this will impact the larger OKD
 ecosystem.
 
@@ -116,8 +116,8 @@ Consider including folks that also work outside your immediate sub-project.
 
 ## Design Details
 
-This is subject to change, but today we do this by running the must-gather image in an init containers and then we have
-a container that sleeps forever.  We download the result and then delete the namespace to cleanup.
+This is subject to change, but today we do this by running the must-gather image in an init container and then we have
+a container that sleeps forever. We download the result and then delete the namespace to cleanup.
 
 ### Output Format
 


### PR DESCRIPTION
* First commit is only about typos (let me know if it should rather be removed).
* Second commit includes the implementation details for the proposed `oc adm must-gather --all-images` flag.