### PR TITLE
Add 9257 port to host port registry

### DIFF
--- a/dev-guide/host-port-registry.md
+++ b/dev-guide/host-port-registry.md
@@ -9,7 +9,7 @@ reviewers:
 approvers:
   - "@russelb"
 creation-date: 2020-08-26
-last-updated: 2022-10-26
+last-updated: 2023-11-23
 status: informational
 ---
 
@@ -98,6 +98,7 @@ Ports are assumed to be used on all nodes in all clusters unless otherwise speci
 | 9193  | cluster-machine-approver-capi ||| cluster infra | 4.11 | metrics |
 | 9194  | cluster-machine-approver-capi ||| cluster infra | 4.11 | metrics |
 | 9200-9219  | various CSI drivers ||| storage | 4.8 | metrics |
+| 9257  | cluster-cloud-controller-manager-operator ||| cluster infra | 4.15 | metrics, control plane only |
 | 9258  | cluster-cloud-controller-manager-operator ||| cluster infra | 4.9 | metrics, control plane only |
 | 9300  | kube-proxy ||| sdn | 4.12 | metrics, ingress node firewall |
 | 9301  | kube-proxy ||| sdn | 4.12 | metrics, ingress node firewall |


### PR DESCRIPTION
This is a PR to add 9257 to the host post registry as it's been added to the [Cluster Cloud Controller Manager Operator](https://github.com/openshift/cluster-cloud-controller-manager-operator) as part of [this change](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/301). Thanks!