### PR TITLE
OKD: add snippet regarding OKD branding

### DIFF
--- a/enhancements/okd-on-fedora-coreos-in-prow.md
+++ b/enhancements/okd-on-fedora-coreos-in-prow.md
@@ -75,6 +75,13 @@ This is a proposal to:
   - by encouraging and directing community contributors to send patches and bug fixes directly to the upstream OpenShift codebase
   - create documentation and share knowledge about OKD  
 
+### OKD branding
+
+The branding for OKD differs from OpenShift, and it is crucial to display the appropriate login page and documentation links.
+When building specific components that rely on the OKD variant of code for the correct branding, Dockerfiles must use the `TAGS`
+variable and set the value to `scos` when building CentOS Stream-based images and `fcos` when building Fedora CoreOS-based images.
+By default, this value is set to `ocp` and is overridden through the CI configuration for building these images.
+
 ### Graduation Criteria
 
 - [x] [OKD repository](https://github.com/openshift/okd/) exists for community issue and bug triage, and development tracking.


### PR DESCRIPTION
The branding for OKD is different from Openshift and is controlled in some places by go files which have the `//go:build !ocp` directive, but the dockerfile hardcodes ocp. To get around this, the TAGS variable for introduced in some repos to build the OKD variant of code. Document for posterity.