### PR TITLE
template: ask for backup/restore considerations

### DIFF
--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -232,6 +232,11 @@ adds configuration options through API resources, should any of those
 behaviors also be exposed to MicroShift admins through the
 configuration file for MicroShift?
 
+### Backup/restore Considerations
+
+How does your feature impact backup and restore of the cluster ? Are the
+impacted APIs idempotent ?
+
 ### Implementation Details/Notes/Constraints
 
 What are some important details that didn't come across above in the


### PR DESCRIPTION
We have designed features without any regard for backup/restore of the cluster, and it shows.

For instance, the primary UDN impacted API is **not** idempotent: if we provision the namespaces and workloads first, and only then the NADs / UDNs, the network topology will look totally different, which might give the user something other than what they desired in the first place. 
