### PR TITLE
NO-JIRA: Update references between CAPI enhancements

### DIFF
--- a/enhancements/cluster-api/installing-cluster-api-components-in-ocp.md
+++ b/enhancements/cluster-api/installing-cluster-api-components-in-ocp.md
@@ -17,6 +17,7 @@ last-updated: 2023-09-25
 tracking-link:
   - "https://issues.redhat.com/browse/OCPCLOUD-1910"
 see-also:
+  - "/enhancements/machine-api/converting-machine-api-to-cluster-api.md"
 replaces:
   - "https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/cluster-api-integration.md"
 superseded-by:

--- a/enhancements/machine-api/cluster-api-integration.md
+++ b/enhancements/machine-api/cluster-api-integration.md
@@ -16,6 +16,9 @@ approvers:
 creation-date: 2021-09-16
 last-updated: 2021-09-16
 status: implementable
+superseded-by:
+  - "/enhancements/machine-api/converting-machine-api-to-cluster-api.md"
+  - "/enhancements/cluster-api/installing-cluster-api-components-in-ocp.md"
 ---
 
 # Cluster API Integration

--- a/enhancements/machine-api/converting-machine-api-to-cluster-api.md
+++ b/enhancements/machine-api/converting-machine-api-to-cluster-api.md
@@ -15,8 +15,10 @@ creation-date: 2023-08-30
 last-updated: 2024-04-30
 tracking-link: 
   - https://issues.redhat.com/browse/OCPCLOUD-1578
-see-also: []
-replaces: []
+see-also: 
+  - "/enhancements/cluster-api/installing-cluster-api-components-in-ocp.md"
+replaces: 
+  - "/enhancements/machine-api/machine-api-integration.md"
 superseded-by: []
 ---
 ...


### PR DESCRIPTION
There are currently 3 different enhancements about how OpenShift is/will/was using Cluster API. This change updates the metadata to be up-to-date as of January 2025.