### PR TITLE
NE-1911: Revise the Security Policy for Gateway API

### DIFF
--- a/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
+++ b/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
@@ -681,36 +681,6 @@ flowchart TD
     xRoute[xRoute] --> Gateway[Gateway]
 ```
 
-#### Automated and Manual Gateway Deployments
-
-Istio has a feature called [automated deployment](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment)
-that creates an Envoy deployment and service in the same namespace for each Gateway
-if the Gateway's `spec.addresses` field is left unset. It is enabled via the
-`PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER` env variable.
-
-Conversely, with [manual deployments](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment),
-if the Gateway has the `spec.addresses` field set, then it must manually link
-to an [ingress gateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/#configuring-ingress-using-a-gateway).
-The user needs to make their own ingress gateway  service and deployment in the same
-namespace to manually link to, or they need to use the default ingress gateway (if enabled).
-Users can also link a Gateway to a previously created automated deployment belonging to another
-Gateway.
-
-OpenShift will not inhibit or alter the functionality of automated deployments, except
-restricting creation of Gateways to specific users (see [RBAC](#rbac)).
-
-Nor will OpenShift inhibit or alter the functionality of manual deployments. Users
-are responsible for understanding and creating links to manual deployments when creating
-Gateways.
-
-The choice between automated and manual deployments depends on whether a user prefers control
-over creating their own ingress gateway deployments and services, and whether they want
-multiple Gateway objects to share a single ingress gateway deployment and service. Manual
-linking, being more expressive, can establish a many-to-one Gateway-to-Gateway-Deployment
-relationship, while automated deployments strictly establish a one-to-one
-Gateway-to-Gateway-Deployment relationship. Arguably, automated deployments are more portable
-among Gateway API implementations due to the fact manually deployments require linking an
-Istio-specific service address.
 
 #### Security Policy
 

--- a/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
+++ b/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
@@ -785,8 +785,13 @@ flowchart LR
 The Infrastructure Operator is generally responsible for installing and configuring the Gateway API provider
 (e.g., Istio), installing the Gateway API CRDs, and creating the GatewayClass. However, since the Ingress Operator
 handles the installation of OSSM and the CRDs, the Infrastructure Operator is only responsible for creating
-and managing the GatewayClass. Cluster Operators create and manage the Gateways, while Application Developers create
-and manage the routes.
+and managing the GatewayClass. Cluster Operators create and manage the Gateways and ReferenceGrants, while
+Application Developers create and manage the xRoutes.
+
+> **Note**: While initially access to ReferenceGrant will be limited to cluster-admin
+> scope due to its security sensitive nature, we will consider and re-evaluate
+> the need for more specific scopes for this resource because it could be a useful
+> feature not currently available in OpenShift. 
 
 The [Advanced 4 Tier Model](https://gateway-api.sigs.k8s.io/concepts/security-model/#write-permissions-for-advanced-4-tier-model)
 is not implementable using the default ClusterRoles. However, as mentioned above, users can create a custom

--- a/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
+++ b/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
@@ -717,7 +717,7 @@ sufficient [RBAC](#rbac) permissions.
 As mentioned in [New Controller to Manage DNS Records for Gateway Listeners](#new-controller-to-manage-dns-records-for-gateway-listeners),
 the Ingress Operator automatically creates DNS records for Gateways. However, for our initial implementation, this
 will be limited to the `openshift-ingress` namespace to avoid introducing complexities for DNS management while
-Gateway API upstream is still defining guidelines for DNS record management (see
+Gateway API upstream has no standard for DNS record management (see
 [kubernetes-sigs/gateway-api#2627](https://github.com/kubernetes-sigs/gateway-api/issues/2627)).
 
 ###### Gateway Merging Across Namespaces

--- a/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
+++ b/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
@@ -1062,21 +1062,12 @@ To answer this question, we need to do the following:
 * Verify that OpenShift Service Mesh will include support for this feature in time for this EP.
 * Evaluate any potential security concerns around this feature.
 
-**Resolution**: The answer depends on what version of OSSM is selected for dev
-preview. If we use OSSM 2.3, we will **NOT** enable ReferenceGrants. If we use OSSM 2.4,
-we will enable ReferenceGrants. This is because ReferenceGrants are non-functional in
-OSSM 2.3, but functional in OSSM 2.4.
+**Resolution**: Yes we will be enabling ReferenceGrant, but only for cluster admins.
 
-OSSM 2.3 uses Istio 1.14 and Istio 1.14 doesn't support ReferenceGrants; therefore,
-in OSSM 2.3, ReferenceGrants are **non-functional**. However, by default,
-Gateway API objects in OSSM 2.3 can reference objects across namespace boundaries,
-such as an HTTPRoute referencing a service in another namespace. A ReferenceGrant
-CRD has no impact on this functionality.
-
-OSSM 2.4 uses Istio 1.16 and Istio 1.16 supports ReferenceGrants; therefore,
-in OSSM 2.4, ReferenceGrants are **functional**. This means that, by default,
-Gateway API objects in OSSM 2.4 **CANNOT** reference objects across namespace
-boundaries without an appropriate ReferenceGrant object.
+Previous versions of OSSM (such as 2.3) did not support ReferenceGrants, and
+would even sometimes allow the cross-namespace functionality by default.
+However, Gateway API GA will be deployed using OSSM 3.x which _does_ fully
+support and enforce it, and therefore so will we.
 
 There are security risks to allowing cross-namespace references. A nefarious user
 could send network traffic to locations they would otherwise not have access to via a
@@ -1088,7 +1079,7 @@ for ReferenceGrants mitigates this risk.
 
 In the future, ReferenceGrant will likely be migrated out of Gateway API and into
 Kubernetes upstream. Until then, we will support ReferenceGrant as a part of
-Gateway API v1beta1 when using OSSM 2.4.
+Gateway API when using OSSM 3.x.
 
 #### Should we have a feature gate?
 

--- a/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
+++ b/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
@@ -624,6 +624,20 @@ will be reconciled in any namespaces, removing the need for ServiceMeshMemberRol
 Cluster-scoped mode is a Tech Preview feature in OSSM 2.3 and fully supported in
 OSSM 2.4.
 
+#### Automated Deployments
+
+When a Gateway resource is created the Istio control-plane triggers the creation
+of an underlying Deployment resource to deploy the [Envoy] proxy server, and a
+Service (of type LoadBalancer by default) to expose it outside of the cluster.
+This is all intended to be opaque to the user as an implementation detail, but if
+more information on those implementation details is needed, see [Istio's
+documentation on "Automated Deployments"][istio-auto].
+
+Automated deployment (triggered by Gateway creation) is the only supported deployment mechanism in OpenShift 4.19. See [RBAC](#rbac) for more information on which roles are allowed to create Gateways.
+
+[Envoy]:https://github.com/envoyproxy/envoy
+[istio-auto]:https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment
+
 #### Gateway Topology
 
 Users have the option to deploy their Gateways using two distinct topologies: shared gateways or dedicated gateways.

--- a/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
+++ b/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md
@@ -720,15 +720,29 @@ will be limited to the `openshift-ingress` namespace to avoid introducing comple
 Gateway API upstream has no standard for DNS record management (see
 [kubernetes-sigs/gateway-api#2627](https://github.com/kubernetes-sigs/gateway-api/issues/2627)).
 
-###### Gateway Merging Across Namespaces
+##### Gateway Merging
 
-Allowing Gateways in all namespaces can pose a potential security risk for Gateways that merge listeners
-across namespaces, as one Gateway or listener could preempt another listener in a different namespace. However,
-there currently isn't a way to merge Gateways across namespaces in Istio as the `spec.addresses`
-field is [restricted](https://github.com/istio/istio/blob/915ac2bf05dbc7a08ae61a8bc39fcd6ea1f3d11a/pilot/pkg/config/kube/gateway/context.go#L78)
-to Gateways in the same namespace. Work is underway to develop a mechanism for
-[Gateway merging](https://docs.google.com/document/d/1qj7Xog2t2fWRuzOeTsWkabUaVeOF7_2t_7appe8EXwA/edit?usp=sharing),
-and it is important to review the outcome for any potential security implications.
+Some Gateway API implementations support the concept of  Gateway or listener Merging, i.e. multiple Gateways (and their listeners) are virtually merged to optimize traffic management. Merging can be helpful in several
+situations, notably to coalesce multiple listeners together behind a single
+proxy or load-balancer to reduce costs.  However, this can be a risk for merges that happen across namespace boundaries.
+
+Istio has historically included a form of Gateway merging by way of what is in
+part a side-effect of its [Manual Deployments Option], wherein multiple
+Gateways could specify the same `spec.addresses`. This kind of merging poses
+potential security risks as one Gateway or listener could preempt another in a
+different namespace. As such [we made it possible to disable manual
+deployments][istio#55053], and then [disabled it by default in OSSM], and now
+consider it unsupported due to safety and maintainability concerns.
+
+As such there is no supported mechanism for merging Gateways with our Gateway
+4.19 release. We are tracking and participating in [GEP-1713: ListenerSets -
+Standard Mechanism to Merge Multiple Gateways][GEP-1713] in upstream Kubernetes
+to make standardized merging available in a future release.
+
+[Manual Deployments Option]:https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment
+[istio#55053]:https://github.com/istio/istio/pull/55053
+[disabled it by default in OSSM]:https://github.com/openshift-service-mesh/istio/pull/281
+[GEP-1713]:https://gateway-api.sigs.k8s.io/geps/gep-1713/
 
 ##### RBAC
 


### PR DESCRIPTION
This PR does some revisions to the Gateway API security policy. In particular:

* General changes to the Gateway Topology section
* Removes notions of Istio's "Gateway Merging" or "Manual Deployment" mode, as those are now off by default in OSSM 3.x, and **will not be supported**.
* Clarifies that `ReferenceGrant` will be present, but as `cluster-admin` only for now