### PR TITLE
NO-ISSUE: CONVENTIONS: Explain no plan for node-role.kubernetes.io/control-plane taint

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -424,7 +424,11 @@ spec:
 ```
 
 Tolerating this taint should suffice for the vast majority of core OpenShift
-operators.  In exceptional cases, an operator may tolerate one or more of the
+operators. Despite `node-role.kubernetes.io/control-plane` labels, there is no
+plan to add a corresponding taint, and no need for control plane components to
+tolerate a `node-role.kubernetes.io/control-plane` taint.
+
+In exceptional cases, an operator may tolerate one or more of the
 following taints if doing so is necessary to form a functional Kubernetes node:
 
 * `node.kubernetes.io/disk-pressure`


### PR DESCRIPTION
Adding a new `node-role.kubernetes.io/control-plane` _label_ was straightforward, because existing consumers could continue using the legacy `node-role.kubernetes.io/master` label.  Removing the `node-role.kubernetes.io/master` label would risk disrupting consumers.

But adding a new taint is disruptive, because folks who want to run on control-plane nodes would need to grow tolerations for the incoming taint.  Currently, a handful of components are tolerating the control-plane taint (e.g. openshift/cluster-kube-apiserver-operator#1664), preparing for a world where that taint might exist (openshift/enhancements#1583).  But the cost of dancing existing components (both OpenShift and customer workloads) that would need to transition over to the new taint is high enough that we don't expect the new taint to ever exist.