### PR TITLE
ESO-101: Revisits and restructures external-secrets-operator APIs for GA

### DIFF
--- a/enhancements/external-secrets-operator/external-secrets-operator.md
+++ b/enhancements/external-secrets-operator/external-secrets-operator.md
@@ -232,14 +232,6 @@ type ExternalSecretsManagerSpec struct {
 	// globalConfig is for configuring the behavior of deployments that are managed by external secrets-operator.
 	// +kubebuilder:validation:Optional
 	GlobalConfig *GlobalConfig `json:"globalConfig,omitempty"`
-
-	// optionalFeatures is for enabling the optional operator features.
-	// +patchMergeKey=name
-	// +patchStrategy=merge
-	// +listType=map
-	// +listMapKey=name
-	// +kubebuilder:validation:Optional
-	OptionalFeatures []Feature `json:"optionalFeatures,omitempty"`
 }
 
 // GlobalConfig is for configuring the external-secrets-operator behavior.
@@ -253,22 +245,6 @@ type GlobalConfig struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	CommonConfigs `json:",inline,omitempty"`
-}
-
-// Feature is for enabling the optional features.
-type Feature struct {
-	// name of the optional feature. There are no optional features currently supported.
-	// +kubebuilder:validation:Enum:=""
-	// +kubebuilder:validation:Required
-	Name string `json:"name"`
-
-	// mode indicates the feature state.
-	// Use Enabled or Disabled to indicate the preference.
-	// Enabled: Enables the optional feature and creates resources if required.
-	// Disabled: Disables the optional feature, but will not remove any resources created.
-	// +kubebuilder:validation:Enum:=Enabled;Disabled
-	// +kubebuilder:validation:Required
-	Mode Mode `json:"mode"`
 }
 
 // ExternalSecretsManagerStatus is the most recently observed status of the ExternalSecretsManager.
@@ -634,23 +610,6 @@ const (
 
 	// Disabled indicates the optional configuration is disabled.
 	Disabled Mode = "Disabled"
-
-	// DisabledAndCleanup indicates the optional configuration is disabled and created resources are automatically removed.
-	DisabledAndCleanup Mode = "DisabledAndCleanup"
-)
-
-// PurgePolicy defines the policy for purging default resources.
-type PurgePolicy string
-
-const (
-	// PurgeAll indicates to purge all the created resources.
-	PurgeAll PurgePolicy = "PurgeAll"
-
-	// PurgeNone indicates to purge none of the created resources.
-	PurgeNone PurgePolicy = "PurgeNone"
-
-	// PurgeExceptSecrets indicates to purge all the created resources except the Secret resource.
-	PurgeExceptSecrets PurgePolicy = "PurgeExceptSecrets"
 )
 ```
 


### PR DESCRIPTION
PR has following changes:
- Revisits the APIs of external-secrets-operator
- Renames `externalsecrets.operator.openshift.io` to `externalsecretsconfigs.operator.openshift.io` based on the user feedback. This improves the UX by removing the confusions with the upstream API `externalsecrets.external-secrets.io` which has the same name.
- New params are added for configuration proxy settings.