### PR TITLE
MG-86: Proposal for disableUpload in must-gather-operator spec

### DIFF
--- a/enhancements/must-gather-operator-disable-upload.md
+++ b/enhancements/must-gather-operator-disable-upload.md
@@ -191,7 +191,7 @@ This enhancement is applicable to single-node deployments and MicroShift environ
 * Adds another user-visible configuration option to the API.
 * Requires users to understand the implications of disabling upload.
 
-## Alternatives
+## Alternatives (Not Implemented)
 
 * **Post-processing Flag**: Could have implemented a flag to delete uploaded data after upload, but the requirement is to prevent upload entirely.
 
@@ -243,6 +243,10 @@ This enhancement is applicable to single-node deployments and MicroShift environ
 * Customer validation in staging environments
 * User-facing documentation created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 * Performance impact assessment completed
+
+### Removing a deprecated feature
+
+- None
 
 ## Upgrade / Downgrade Strategy
 


### PR DESCRIPTION
This PR includes proposal to introduce a new API field in must-gather-operator spec for disabling upload of  must-gather  bundle. 

Changes include:

1.  `disableUpload`:  Field is added to MustGather CRD allowing users to collect must-gather data without uploading to Red Hat's SFTP server.
2. `caseID` and `caseManagementAccountSecretRef` required only when upload enabled.