### PR TITLE
Add TrilokGeer and mytreya-rh as external-secrets-operator and cert-manager OWNERS

### DIFF
--- a/enhancements/cert-manager/OWNERS
+++ b/enhancements/cert-manager/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- TrilokGeer
+- mytreya-rh

--- a/enhancements/external-secrets-operator/OWNERS
+++ b/enhancements/external-secrets-operator/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- TrilokGeer
+- mytreya-rh


### PR DESCRIPTION
@TrilokGeer and @mytreya-rh lead the external-secrets-operator and cert-manager design efforts.
This PR adds the aforementioned github ids only to the specific OWNERS scoped to external-secrets-operator and cert-manager thus limiting the approver authorization only to these components via this PR.