### PR TITLE
Add enhancement spec for api tls curves

### DIFF
--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -6,9 +6,9 @@ authors:
 reviewers:
   - dsalerno # OpenShift networking stack knowledge
 approvers: 
-  - JoelSpeed
+  - joelanford
 api-approvers:
-  - JoelSpeed
+  - everettraven
 creation-date: 2025-11-19
 last-updated: 2025-11-20
 tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -253,15 +253,10 @@ The TLS implementation will proceed with only the valid and supported curves fro
 **Runtime behavior:**
 If no mutually supported curves remain after filtering, TLS handshakes will fail with errors like "no shared group". This is the expected and desired behavior—it ensures only supported cryptographic parameters are used.
 
-**Why not validate at API level:**
-Validating curve support at the API level would require maintaining a comprehensive 
-registry of:
-- All TLS implementation libraries used across OpenShift components
-- Version-specific support matrices for each library
-- Continuous updates as libraries evolve
+**API-level validation:**
+The `curves` field uses an enum to validate curve names, ensuring that only well-formed, recognized curve identifiers can be specified. This prevents typos and provides clear documentation of available options. The enum will need to be updated as new curves are standardized and support is requested, but this is a reasonable tradeoff for improved user experience.
 
-This approach is infeasible and would create a maintenance burden that outweighs 
-the benefit. Runtime failures provide clear, immediate feedback about incompatibilities.
+**Note:** Enum validation ensures curve names are syntactically valid, but cannot guarantee that a specific curve is supported by every component's underlying TLS implementation. Components will filter the configured curves to only those they support at runtime.
 
 **Recommended approach:**
 - **Most users**: Use the predefined profiles (Old, Intermediate, Modern), which are 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -81,7 +81,7 @@ spec:
 
 ### API Extensions
 
-- Adds a `curves` field to the `spec.tlsSecurityProfile` 
+- Adds a `curves` field to the `spec.tlsSecurityProfile` (https://github.com/openshift/api/pull/2583/files#diff-2101eac4196d9b14cf061c8a6a4d40f9d8e5a77fc2690f969e7293294218afe3R267)
 - The addition of this field should not affect existing API behaviour
 
 ### Topology Considerations

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -101,6 +101,9 @@ This change will effect the TLS profile of both single node and microshift deplo
 
 ### Implementation Details/Notes/Constraints
 
+#### Default curve configuration
+The [default openshift TLS profiles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-understanding_tls-security-profiles) do not currently have a default set of curves. However, the default Mozilla TLS profiles (which openshift TLS profiles are based on) *do* have curves. We are planning on specifically adding these curves to openshifts profiles in the future. This is outside the scope of this api change, the api should expose the curves field first to allow components time to implement the consumption of these curves.
+
 #### Mismatching curves and ciphersuites
 There is a case where the administrator could incorrectly specificy a set of ciphersuites
 that do not work with each other. For example using an RSA ciphersuite with a ECDHE curve (such as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and P-256). The default behavior OpenSSL as well as go's crypto/tls (both used extensively in OpenShift) is to fail at **TLS handshake time**. . The TLS server instance will start normally, but when TLS clients attempt to handshake with the TLS server, the handshake will fail with a `handshake failure`

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -98,7 +98,8 @@ N/A
 
 #### Single-node Deployments or MicroShift
 
-N/A
+This change will effect the TLS profile of both single node and microshift deployments.
+
 
 
 ### Implementation Details/Notes/Constraints

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -51,7 +51,7 @@ The current state of the OpenShift TLS stack uses a default set of curves with n
 The ability to set curves explicitely will also make it possible to align our 
 OpenShift TLS profiles to match the curves present in the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS). 
 
-This change will require working with OpenShift component owners to use this new field, however this is outside the scope of this proposal.
+This change will require working with OpenShift component owners to use this new field. The scope of this feature includes ensuring that appropriate components respect the new curves field when it is set in custom profiles. Adding default curves to the non-custom profiles (Old, Intermediate, Modern) is a separately scoped action and will be addressed in future work.
 
 ### Workflow Description
 
@@ -102,7 +102,7 @@ This change will effect the TLS profile of both single node and microshift deplo
 ### Implementation Details/Notes/Constraints
 
 #### Default curve configuration
-The [default openshift TLS profiles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-understanding_tls-security-profiles) do not currently have a default set of curves. However, the default Mozilla TLS profiles (which openshift TLS profiles are based on) *do* have curves. We are planning on specifically adding these curves to openshifts profiles in the future. This is outside the scope of this api change, the api should expose the curves field first to allow components time to implement the consumption of these curves.
+The [default openshift TLS profiles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-understanding_tls-security-profiles) (Old, Intermediate, Modern) do not currently specify any curves, instead relying on the underlying TLS implementation to select a sensible default group. However, the default Mozilla TLS profiles (which OpenShift TLS profiles are based on) *do* specify curves. We are planning on specifically adding these curves to OpenShift's non-custom profiles in the future as a separately scoped action. This API change should expose the curves field first to allow components time to implement the consumption of these curves when set in custom profiles.
 
 #### Mismatching curves and ciphersuites
 There is a case where the administrator could incorrectly specificy a set of ciphersuites
@@ -114,7 +114,9 @@ To avoid this scenario, OpenShift should implement validation to prevent known i
 
 OpenShift components could forego utilizing the curves set in the API config. However, this is a risk
 that exists in the current TLS config flow. This change will require coordination with component owners
-to comply with the new TLS config field.
+to ensure compliance with the new TLS config field, particularly for custom profiles where administrators
+explicitly set curves. For the initial scope of this enhancement, this may only apply when a custom profile
+is used, but backing implementation for core components is considered a requirement for GA promotion.
 
 ### Drawbacks
 
@@ -140,7 +142,9 @@ Once components are onboarded to utilize these curves, the cluster will be scann
 
 ### Tech Preview -> GA
 
+- **Backing implementation for core components to respect the curves field when set in custom profiles.** This is a GA blocker.
 - Verify the general support for these curves using the [tls-scanner](github.com/openshift/tls-scanner)
+- Ensure that key OpenShift components (ingress controller, API server, etc.) properly consume and apply the configured curves from custom TLS profiles
 
 ### Removing a deprecated feature
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -88,8 +88,7 @@ spec:
 
 #### Hypershift / Hosted Control Planes
 
-N/A
-
+Hypershift [does not currently consume custom TLS supported groups](https://github.com/openshift/hypershift/blob/6b0338c192c966a9c072bfc6af45202739e9e553/support/config/cipher.go#L30). However, this is planned in the future.
 
 #### Standalone Clusters
 
@@ -99,8 +98,6 @@ N/A
 #### Single-node Deployments or MicroShift
 
 This change will effect the TLS profile of both single node and microshift deployments.
-
-
 
 ### Implementation Details/Notes/Constraints
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -188,7 +188,7 @@ For operators managing components that need to respect TLS configuration:
 
 **Configuration Precedence**
 
-When multiple TLS configuration sources exist, components follow this precedence:
+When multiple TLS configuration sources exist, components follow this precedence (highest to lowest priority):
 1. Component-specific configuration (e.g., `IngressController.spec.tlsSecurityProfile`)
 2. Category-level configuration (e.g., `KubeletConfig.spec.tlsSecurityProfile` for node components)
 3. Cluster-wide default (e.g., `apiserver.config.openshift.io/cluster` for API server components)

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -48,6 +48,9 @@ Currently, administrators can specify a custom TLS profile where they can specif
 
 The current state of the OpenShift TLS stack uses a default set of curves with no way to specify them. This eases the burden on administators, however new quantum secure algorithms rely on a set of curves outside of the conventional default curves. For example, curves like [ML-KEM](https://www.ietf.org/archive/id/draft-connolly-tls-mlkem-key-agreement-05.html) provide a quantum safe mechanism for sharing secrets necessary for the TLS handshake, whereas curves like [X22519](https://datatracker.ietf.org/doc/html/rfc7748) (a commonly used conventional curve) are [weak against quantum computing](https://crypto.stackexchange.com/questions/59770/how-effective-is-quantum-computing-against-elliptic-curve-cryptography).
 
+The ability to set curves explicitely will also make it possible to align our 
+OpenShift TLS profiles to match the curves present in the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS). 
+
 This change will require working with OpenShift component owners to use this new field, however this is outside the scope of this proposal.
 
 ### Workflow Description

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -101,6 +101,19 @@ This change will effect the TLS profile of both single node and microshift deplo
 
 ### Implementation Details/Notes/Constraints
 
+#### Upstream Component TLS Curve Support
+
+The following Kubernetes components lack explicit configuration support for TLS elliptic curves:
+
+| Component | Status | Reference |
+|-----------|--------|-----------|
+| Kubelet | Does not have support for TLS curves | [types.go#L182](https://github.com/kubernetes/kubelet/blob/ce0febd5f9e2c0e97ef3b3161a9098ef3f34afcb/config/v1beta1/types.go#L182) |
+| Etcd | Does not support TLS curves | [config.go#L250](https://github.com/etcd-io/etcd/blob/ed430d025f5d1ff33d997e42569073c55f3ef513/server/embed/config.go#L250) |
+| Controller-manager | Has `--tls-cipher-suites` flag but no `--tls-curves` flag | [kube-controller-manager.md](https://github.com/kubernetes/website/blob/8d4885bbb055ec4558520a021ab1ac65064cd896/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md#L972-L998) |
+| Kube-scheduler | Pulls from SecureServing struct which lists tlsminversion and ciphers but omits curve support | [serving.go#L66](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving.go#L66) |
+
+This limitation means that TLS curve configuration will primarily benefit components that use their own TLS implementations (such as Ingress controllers using HAProxy/OpenSSL) rather than components that rely on upstream Kubernetes code. Upstream support would need to be added for these components to honor TLS curve configuration.
+
 #### Component Configuration Consumption
 
 Different OpenShift components consume TLS configuration from different sources based on their operational context:

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -1,0 +1,161 @@
+---
+title: api-tls-curves-config
+authors:
+  - richardsonnick
+  - davidesalerno
+reviewers: # Include a comment about what domain expertise a reviewer is expected to bring and what area of the enhancement you expect them to focus on. For example: - "@networkguru, for networking aspects, please look at IP bootstrapping aspect"
+  - TBD
+approvers: # A single approver is preferred, the role of the approver is to raise important questions, help ensure the enhancement receives reviews from all applicable areas/SMEs, and determine when consensus is achieved such that the EP can move forward to implementation.  Having multiple approvers makes it difficult to determine who is responsible for the actual approval.
+  - TBD
+api-approvers: # In case of new or modified APIs or API extensions (CRDs, aggregated apiservers, webhooks, finalizers). If there is no API change, use "None"
+  - TBD
+creation-date: 2025-11-19
+last-updated: yyyy-mm-dd
+tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement
+  - TBD
+---
+
+# OpenShift API TLS Curves Configuration 
+
+## Summary
+
+This enhancement adds the option to configure a list of supported TLS curves in the OpenShift API config server. This configuration mirrors the existing `ciphersuites` option in the OpenShift API config TLS settings.
+
+## Motivation
+
+As cryptographic standards evolve, there is a growing need to support Post-Quantum Cryptography (PQC) to protect against future threats. This enhancement contributes directly to the goal of enabling PQC support in OpenShift. It provides the mechanism to configure specific TLS curves in the OpenShift API, allowing administrators to explicitly enable PQC-ready curves such as ML-KEM. This ensures OpenShift clusters can be configured to meet emerging security compliance requirements and future-proof communications.
+
+### User Stories
+
+As an administrator, I want to explicitely set the supported TLS curves to ensure PQC readiness throughout OpenShift so that I can ensure the security of TLS communication in the era of quantum computing.
+
+### Goals
+
+To provide an interface that allows the setting of TLS curves to be used cluser wide.
+
+This goal is part of the larger goal to:
+ 1. Provide the necessary knobs to specify a PQC ready TLS configuration in OpenShift.
+ 2. Improve the adaptability of the cluster's TLS configuration to provide support for the constantly evolving TLS landscape.
+
+### Non-Goals
+
+1. Overhauling the current process of TLS configuration in OpenShift. This change merely extends the current TLS options.
+
+## Proposal
+
+This proposal is to expose the ability to specify the TLS curves used in OpenShift components to the OpenShift administrator.
+Currently, administrators can specify a custom TLS profile where they can specifically set which TLS ciphersuites and the minimum TLS version as opposed to using one of the preconfigured TLS profiles. Specifying the set of supported TLS curves will mirror this process of setting [supported ciphers and the minimum TLS version](https://github.com/openshift/api/blob/138912d4ee9944c989f593c51f15c41908155856/config/v1/types_tlssecurityprofile.go#L206). 
+
+The current state of the OpenShift TLS stack uses a default set of curves with no way to specify them. This eases the burden on administators, however new quantum secure algorithms rely on a set of curves outside of the conventional default curves. For example, curves like [ML-KEM](https://www.ietf.org/archive/id/draft-connolly-tls-mlkem-key-agreement-05.html) provide a quantum safe mechanism for sharing secrets necessary for the TLS handshake, whereas curves like [X22519](https://datatracker.ietf.org/doc/html/rfc7748) (a commonly used conventional curve) are [weak against quantum computing](https://crypto.stackexchange.com/questions/59770/how-effective-is-quantum-computing-against-elliptic-curve-cryptography).
+
+This change will require working with OpenShift component owners to use this new field, however this is outside the scope of this proposal.
+
+### Workflow Description
+
+Administrators will use the [existing custom TLS security profile flow](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-ingress-configuring_tls-security-profiles) for setting the supported curves. 
+
+Specifically administrators will use 
+
+`oc edit IngressController default -n openshift-ingress-operator`
+
+and edit the spec.tlsSecurityProfile field:
+
+```
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+ ...
+spec:
+  tlsSecurityProfile:
+    type: Custom 
+    custom: 
+      ciphers: 
+      - ECDHE-RSA-CHACHA20-POLY1305
+      minTLSVersion: VersionTLS13
+      curves:
+      - X25519MLKEM512
+ ...
+```
+
+### API Extensions
+
+- Adds a `curves` field to the `spec.tlsSecurityProfile` 
+- The addition of this field should not affect existing API behaviour
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+N/A
+
+
+#### Standalone Clusters
+
+N/A
+
+
+#### Single-node Deployments or MicroShift
+
+N/A
+
+
+### Implementation Details/Notes/Constraints
+
+#### Mismatching curves and ciphersuites
+There is a case where the administrator could incorrectly specificy a set of ciphersuites
+that do not work with each other. For example using an RSA ciphersuite with a ECDHE curve (such as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and P-256). The default behavior OpenSSL as well as go's crypto/tls (both used extensively in OpenShift) is to fail at **TLS handshake time**. . The TLS server instance will start normally, but when TLS clients attempt to handshake with the TLS server, the handshake will fail with a `handshake failure`
+
+I propose that this is the *desired* behavior of OpenShift. Administrators that utilize the custom TLS profile are foregoing the guaranteed correctly configured TLS profiles (such as Modern, Intermediate, etc.) and the system should comply accordingly. The landscape of TLS is constantly evolving and relying on the TLS implementation (Openssl, golang crypto/tls, etc) itself provides users more flexibility. Adding a validation system on top as part of the OpenShift would be cumbersome and restricts admins to use what we deem compatible rather than what the underylying TLS implementation is capable of.
+
+### Risks and Mitigations
+
+OpenShift components could forego utilizing the curves set in the API config. However, this is a risk
+that exists in the current TLS config flow. This change will require coordination with component owners
+to comply with the new TLS config field.
+
+### Drawbacks
+
+N/A
+
+## Alternatives (Not Implemented)
+
+N/A
+
+## Open Questions [optional]
+
+1. I propose that we should *not* include a validation system for custom TLS configurations. See "Proposal" for more context. However, this restricts the ability to ensure that the TLS config works when a new config is set, instead relying on failed handshakes to clue the administator in on any issues. There could also be "skew" between the supported curves and ciphers of the various TLS implementations utilized within OpenShift. This could make it difficult to reason about the state of the TLS capabilities of the cluster. Any thoughts?
+
+## Test Plan
+
+Utilize the `oc edit` and `oc describe` commands to verify that the API config server is exposing the correct list of curves.
+
+Once components are onboarded to utilize these curves, the cluster will be scanned with the [tls-scanner tool](github.com/openshift/tls-scanner) to verify that TLS implemenations within OpenShift expose these curves as supported. It should also be verified that the TLS implementations will fallback to a default curve set when not specified.
+
+### Dev Preview -> Tech Preview
+
+- Ability to specify supported curves.
+
+### Tech Preview -> GA
+
+- Verify the general support for these curves using the [tls-scanner](github.com/openshift/tls-scanner)
+
+### Removing a deprecated feature
+
+N/A
+
+
+## Upgrade / Downgrade Strategy
+
+In openshift versions where the TLS curves are not specified, components will not specify the set of curves to be used to their underlying TLS implementations. The TLS implementation should fallback to a sensible default set of curves when not set. This should be verified during the component onboarding work as outlined in the test plan.
+
+
+## Version Skew Strategy
+
+By default, TLS implementations (openssl, golang, etc...) fallback to a sensible default when curves are not set. Currently, openshift components that do not set curves exhibit this behavior. This should be verified during component onboarding.
+
+## Operational Aspects of API Extensions
+
+N/A
+
+## Support Procedures
+
+N/A

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -107,10 +107,10 @@ The following Kubernetes components lack explicit configuration support for TLS 
 
 | Component | Status | Reference |
 |-----------|--------|-----------|
-| Kubelet | Does not have support for TLS curves | [types.go#L182](https://github.com/kubernetes/kubelet/blob/ce0febd5f9e2c0e97ef3b3161a9098ef3f34afcb/config/v1beta1/types.go#L182) |
-| Etcd | Does not support TLS curves | [config.go#L250](https://github.com/etcd-io/etcd/blob/ed430d025f5d1ff33d997e42569073c55f3ef513/server/embed/config.go#L250) |
-| Controller-manager | Has `--tls-cipher-suites` flag but no `--tls-curves` flag | [kube-controller-manager.md](https://github.com/kubernetes/website/blob/8d4885bbb055ec4558520a021ab1ac65064cd896/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md#L972-L998) |
-| Kube-scheduler | Pulls from SecureServing struct which lists tlsminversion and ciphers but omits curve support | [serving.go#L66](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving.go#L66) |
+| Kubelet | No Support | [types.go#L182](https://github.com/kubernetes/kubelet/blob/ce0febd5f9e2c0e97ef3b3161a9098ef3f34afcb/config/v1beta1/types.go#L182) |
+| Etcd | No Support | [config.go#L250](https://github.com/etcd-io/etcd/blob/ed430d025f5d1ff33d997e42569073c55f3ef513/server/embed/config.go#L250) |
+| Controller-manager | No Support | [kube-controller-manager.md](https://github.com/kubernetes/website/blob/8d4885bbb055ec4558520a021ab1ac65064cd896/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md#L972-L998) |
+| Kube-scheduler | No Support | [serving.go#L66](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving.go#L66) |
 
 This limitation means that TLS curve configuration will primarily benefit components that use their own TLS implementations (such as Ingress controllers using HAProxy/OpenSSL) rather than components that rely on upstream Kubernetes code. Upstream support would need to be added for these components to honor TLS curve configuration.
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -107,7 +107,7 @@ N/A
 There is a case where the administrator could incorrectly specificy a set of ciphersuites
 that do not work with each other. For example using an RSA ciphersuite with a ECDHE curve (such as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and P-256). The default behavior OpenSSL as well as go's crypto/tls (both used extensively in OpenShift) is to fail at **TLS handshake time**. . The TLS server instance will start normally, but when TLS clients attempt to handshake with the TLS server, the handshake will fail with a `handshake failure`
 
-I propose that this is the *desired* behavior of OpenShift. Administrators that utilize the custom TLS profile are foregoing the guaranteed correctly configured TLS profiles (such as Modern, Intermediate, etc.) and the system should comply accordingly. The landscape of TLS is constantly evolving and relying on the TLS implementation (Openssl, golang crypto/tls, etc) itself provides users more flexibility. Adding a validation system on top as part of the OpenShift would be cumbersome and restricts admins to use what we deem compatible rather than what the underylying TLS implementation is capable of.
+To avoid this scenario, OpenShift should implement validation to prevent known invalid combinations. A validation layer will be added to check for compatible combinations of curves and ciphersuites. If a known invalid combination is detected, the configuration will be rejected, informing the user of the incompatibility immediately rather than failing at runtime.
 
 ### Risks and Mitigations
 
@@ -125,7 +125,7 @@ N/A
 
 ## Open Questions [optional]
 
-1. I propose that we should *not* include a validation system for custom TLS configurations. See "Proposal" for more context. However, this restricts the ability to ensure that the TLS config works when a new config is set, instead relying on failed handshakes to clue the administator in on any issues. There could also be "skew" between the supported curves and ciphers of the various TLS implementations utilized within OpenShift. This could make it difficult to reason about the state of the TLS capabilities of the cluster. Any thoughts?
+N/A
 
 ## Test Plan
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -3,16 +3,16 @@ title: api-tls-curves-config
 authors:
   - richardsonnick
   - davidesalerno
-reviewers: # Include a comment about what domain expertise a reviewer is expected to bring and what area of the enhancement you expect them to focus on. For example: - "@networkguru, for networking aspects, please look at IP bootstrapping aspect"
-  - TBD
-approvers: # A single approver is preferred, the role of the approver is to raise important questions, help ensure the enhancement receives reviews from all applicable areas/SMEs, and determine when consensus is achieved such that the EP can move forward to implementation.  Having multiple approvers makes it difficult to determine who is responsible for the actual approval.
-  - TBD
-api-approvers: # In case of new or modified APIs or API extensions (CRDs, aggregated apiservers, webhooks, finalizers). If there is no API change, use "None"
-  - TBD
+reviewers:
+  - dsalerno # OpenShift networking stack knowledge
+approvers: 
+  - JoelSpeed
+api-approvers:
+  - JoelSpeed
 creation-date: 2025-11-19
-last-updated: yyyy-mm-dd
+last-updated: 2025-11-20
 tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement
-  - TBD
+  - https://issues.redhat.com/browse/HPCASE-153
 ---
 
 # OpenShift API TLS Curves Configuration 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -15,23 +15,23 @@ tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic 
   - https://issues.redhat.com/browse/HPCASE-153
 ---
 
-# OpenShift API TLS Curves Configuration 
+# OpenShift API TLS Groups Configuration 
 
 ## Summary
 
-This enhancement adds the option to configure a list of supported TLS curves in the OpenShift API config server. This configuration mirrors the existing `ciphersuites` option in the OpenShift API config TLS settings.
+This enhancement adds the option to configure a list of supported TLS named groups (key exchange algorithms) in the OpenShift API config server. This configuration mirrors the existing `ciphersuites` option in the OpenShift API config TLS settings.
 
 ## Motivation
 
-As cryptographic standards evolve, there is a growing need to support Post-Quantum Cryptography (PQC) to protect against future threats. This enhancement contributes directly to the goal of enabling PQC support in OpenShift. It provides the mechanism to configure specific TLS curves in the OpenShift API, allowing administrators to explicitly enable PQC-ready curves such as ML-KEM. This ensures OpenShift clusters can be configured to meet emerging security compliance requirements and future-proof communications.
+As cryptographic standards evolve, there is a growing need to support Post-Quantum Cryptography (PQC) to protect against future threats. This enhancement contributes directly to the goal of enabling PQC support in OpenShift. It provides the mechanism to configure specific TLS named groups in the OpenShift API, allowing administrators to explicitly enable PQC-ready groups such as ML-KEM. This ensures OpenShift clusters can be configured to meet emerging security compliance requirements and future-proof communications.
 
 ### User Stories
 
-As an administrator, I want to explicitely set the supported TLS curves to ensure PQC readiness throughout OpenShift so that I can ensure the security of TLS communication in the era of quantum computing.
+As an administrator, I want to explicitly set the supported TLS groups to ensure PQC readiness throughout OpenShift so that I can ensure the security of TLS communication in the era of quantum computing.
 
 ### Goals
 
-To provide an interface that allows the setting of TLS curves to be used cluser wide.
+To provide an interface that allows the setting of TLS groups to be used cluster wide.
 
 This goal is part of the larger goal to:
  1. Provide the necessary knobs to specify a PQC ready TLS configuration in OpenShift.
@@ -43,19 +43,19 @@ This goal is part of the larger goal to:
 
 ## Proposal
 
-This proposal is to expose the ability to specify the TLS curves used in OpenShift components to the OpenShift administrator.
-Currently, administrators can specify a custom TLS profile where they can specifically set which TLS ciphersuites and the minimum TLS version as opposed to using one of the preconfigured TLS profiles. Specifying the set of supported TLS curves will mirror this process of setting [supported ciphers and the minimum TLS version](https://github.com/openshift/api/blob/138912d4ee9944c989f593c51f15c41908155856/config/v1/types_tlssecurityprofile.go#L206). 
+This proposal is to expose the ability to specify the TLS groups (key exchange algorithms) used in OpenShift components to the OpenShift administrator.
+Currently, administrators can specify a custom TLS profile where they can specifically set which TLS ciphersuites and the minimum TLS version as opposed to using one of the preconfigured TLS profiles. Specifying the set of supported TLS groups will mirror this process of setting [supported ciphers and the minimum TLS version](https://github.com/openshift/api/blob/138912d4ee9944c989f593c51f15c41908155856/config/v1/types_tlssecurityprofile.go#L206). 
 
-The current state of the OpenShift TLS stack uses a default set of curves with no way to specify them. This eases the burden on administators, however new quantum secure algorithms rely on a set of curves outside of the conventional default curves. For example, curves like [ML-KEM](https://www.ietf.org/archive/id/draft-connolly-tls-mlkem-key-agreement-05.html) provide a quantum safe mechanism for sharing secrets necessary for the TLS handshake, whereas curves like [X22519](https://datatracker.ietf.org/doc/html/rfc7748) (a commonly used conventional curve) are [weak against quantum computing](https://crypto.stackexchange.com/questions/59770/how-effective-is-quantum-computing-against-elliptic-curve-cryptography).
+The current state of the OpenShift TLS stack uses a default set of groups with no way to specify them. This eases the burden on administrators, however new quantum secure algorithms rely on groups outside of the conventional defaults. For example, groups like [ML-KEM](https://www.ietf.org/archive/id/draft-connolly-tls-mlkem-key-agreement-05.html) provide a quantum safe mechanism for sharing secrets necessary for the TLS handshake, whereas groups based on elliptic curves like [X25519](https://datatracker.ietf.org/doc/html/rfc7748) are [weak against quantum computing](https://crypto.stackexchange.com/questions/59770/how-effective-is-quantum-computing-against-elliptic-curve-cryptography).
 
-The ability to set curves explicitely will also make it possible to align our 
-OpenShift TLS profiles to match the curves present in the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS). 
+The ability to set groups explicitly will also make it possible to align our 
+OpenShift TLS profiles to match the groups present in the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS). 
 
-This change will require working with OpenShift component owners to use this new field. The scope of this feature includes ensuring that appropriate components respect the new curves field when it is set in custom profiles. Adding default curves to the non-custom profiles (Old, Intermediate, Modern) is a separately scoped action and will be addressed in future work.
+This change will require working with OpenShift component owners to use this new field. The scope of this feature includes ensuring that appropriate components respect the new `groups` field when it is set in custom profiles. Adding default groups to the non-custom profiles (Old, Intermediate, Modern) is a separately scoped action and will be addressed in future work.
 
 ### Workflow Description
 
-Administrators will use the [existing custom TLS security profile flow](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-ingress-configuring_tls-security-profiles) for setting the supported curves. 
+Administrators will use the [existing custom TLS security profile flow](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-ingress-configuring_tls-security-profiles) for setting the supported groups. 
 
 Specifically administrators will use 
 
@@ -74,21 +74,21 @@ spec:
       ciphers: 
       - ECDHE-RSA-CHACHA20-POLY1305
       minTLSVersion: VersionTLS13
-      curves:
+      groups:
       - X25519MLKEM512
  ...
 ```
 
 ### API Extensions
 
-- Adds a `curves` field to the `spec.tlsSecurityProfile` (https://github.com/openshift/api/pull/2583/files#diff-2101eac4196d9b14cf061c8a6a4d40f9d8e5a77fc2690f969e7293294218afe3R267)
+- Adds a `groups` field to the `spec.tlsSecurityProfile` (https://github.com/openshift/api/pull/2583/files#diff-2101eac4196d9b14cf061c8a6a4d40f9d8e5a77fc2690f969e7293294218afe3R267)
 - The addition of this field should not affect existing API behaviour
 
 ### Topology Considerations
 
 #### Hypershift / Hosted Control Planes
 
-Hypershift [does not currently consume custom TLS supported groups](https://github.com/openshift/hypershift/blob/6b0338c192c966a9c072bfc6af45202739e9e553/support/config/cipher.go#L30). However, this is planned in the future.
+HyperShift [does not currently consume custom TLS supported groups](https://github.com/openshift/hypershift/blob/6b0338c192c966a9c072bfc6af45202739e9e553/support/config/cipher.go#L30). However, this is planned in the future.
 
 #### Standalone Clusters
 
@@ -97,13 +97,13 @@ N/A
 
 #### Single-node Deployments or MicroShift
 
-This change will effect the TLS profile of both single node and microshift deployments.
+This change will affect the TLS profile of both single node and MicroShift deployments.
 
 ### Implementation Details/Notes/Constraints
 
-#### Upstream Component TLS Curve Support
+#### Upstream Component TLS Group Support
 
-The following Kubernetes components lack explicit configuration support for TLS elliptic curves:
+The following Kubernetes components lack explicit configuration support for TLS groups:
 
 | Component | Status | Reference |
 |-----------|--------|-----------|
@@ -112,7 +112,7 @@ The following Kubernetes components lack explicit configuration support for TLS 
 | Controller-manager | No Support | [kube-controller-manager.md](https://github.com/kubernetes/website/blob/8d4885bbb055ec4558520a021ab1ac65064cd896/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md#L972-L998) |
 | Kube-scheduler | No Support | [serving.go#L66](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving.go#L66) |
 
-This limitation means that TLS curve configuration will primarily benefit components that use their own TLS implementations (such as Ingress controllers using HAProxy/OpenSSL) rather than components that rely on upstream Kubernetes code. Upstream support would need to be added for these components to honor TLS curve configuration.
+This limitation means that TLS group configuration will primarily benefit components that use their own TLS implementations (such as Ingress controllers using HAProxy/OpenSSL) rather than components that rely on upstream Kubernetes code. Upstream support would need to be added for these components to honor TLS group configuration.
 
 #### Component Configuration Consumption
 
@@ -121,11 +121,11 @@ Different OpenShift components consume TLS configuration from different sources 
 **1. API Server Components** (kube-apiserver, openshift-apiserver, oauth-server, etc.)
 - Read TLS configuration from `apiserver.config.openshift.io/cluster`
 - Component operators watch this object and regenerate configuration when it changes
-- Example: The kube-apiserver operator reads the `tlsSecurityProfile` field and passes the curves to the kube-apiserver via command-line flags or configuration files
+- Example: The kube-apiserver operator reads the `tlsSecurityProfile` field and passes the groups to the kube-apiserver via command-line flags or configuration files
 
 **2. Kubelet Configuration**
 - Kubelet TLS configuration is managed through `kubeletconfig.machineconfiguration.openshift.io`
-- Administrators can set a TLS profile (including curves) at this level:
+- Administrators can set a TLS profile (including groups) at this level:
   ```yaml
   apiVersion: machineconfiguration.openshift.io/v1
   kind: KubeletConfig
@@ -136,7 +136,7 @@ Different OpenShift components consume TLS configuration from different sources 
       type: Custom
       custom:
         minTLSVersion: VersionTLS13
-        curves:
+        groups:
         - X25519MLKEM768
         - X25519
   ```
@@ -146,7 +146,7 @@ Different OpenShift components consume TLS configuration from different sources 
 
 **3. Ingress Controller**
 - Ingress configuration is managed through `ingresscontroller.operator.openshift.io`
-- Administrators configure TLS profiles (including curves) on the IngressController object:
+- Administrators configure TLS profiles (including groups) on the IngressController object:
   ```yaml
   apiVersion: operator.openshift.io/v1
   kind: IngressController
@@ -157,7 +157,7 @@ Different OpenShift components consume TLS configuration from different sources 
     tlsSecurityProfile:
       type: Custom
       custom:
-        curves:
+        groups:
         - X25519MLKEM768
   ```
 - The Ingress Operator watches IngressController objects
@@ -172,12 +172,12 @@ For operators managing components that need to respect TLS configuration:
    - `apiserver.config.openshift.io/cluster` for control plane components
    - Component-specific operator CRs (IngressController, KubeletConfig, etc.)
 
-2. **Extract** the `tlsSecurityProfile` including the `curves` field
+2. **Extract** the `tlsSecurityProfile` including the `groups` field
 
 3. **Translate** to the component's native configuration format:
    - For Go components: Set `tls.Config.CurvePreferences`
    - For OpenSSL-based components: Use `SSL_CTX_set1_groups_list()` or configuration directives
-   - For HAProxy: Use `curves` directive in configuration
+   - For HAProxy: Use `curves` directive in configuration (HAProxy still uses the `curves` directive name)
 
 4. **Apply** configuration by:
    - Regenerating configuration files
@@ -195,12 +195,12 @@ When multiple TLS configuration sources exist, components follow this precedence
 
 This precedence model allows for centralized defaults with selective overrides where needed.
 
-#### Default curve configuration
-The [default openshift TLS profiles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-understanding_tls-security-profiles) (Old, Intermediate, Modern) do not currently specify any curves, instead relying on the underlying TLS implementation to select a sensible default group. However, the default Mozilla TLS profiles (which OpenShift TLS profiles are based on) *do* specify curves. We are planning on specifically adding these curves to OpenShift's non-custom profiles in the future as a separately scoped action. This API change should expose the curves field first to allow components time to implement the consumption of these curves when set in custom profiles.
+#### Default group configuration
+The [default openshift TLS profiles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-understanding_tls-security-profiles) (Old, Intermediate, Modern) do not currently specify any groups, instead relying on the underlying TLS implementation to select a sensible default. However, the default Mozilla TLS profiles (which OpenShift TLS profiles are based on) *do* specify groups. We are planning on specifically adding these groups to OpenShift's non-custom profiles in the future as a separately scoped action. This API change should expose the `groups` field first to allow components time to implement the consumption of these groups when set in custom profiles.
 
 #### Go crypto/tls Implementation Limitations
 
-Components using Go's `crypto/tls` library face specific limitations that affect curve and cipher suite configuration:
+Components using Go's `crypto/tls` library face specific limitations that affect group and cipher suite configuration:
 
 **TLS 1.3 Cipher Suite Configuration**
 
@@ -209,59 +209,59 @@ In TLS 1.3, Go's `crypto/tls` does not allow cipher suite configuration ([golang
 - Administrators configuring `minTLSVersion: VersionTLS13` with custom cipher suites will find the cipher suite configuration is not applied by Go-based components
 - This is a known limitation of the Go standard library and cannot be worked around by OpenShift components
 
-**Curve Preferences Ordering**
+**Group Preferences Ordering**
 
 Starting in Go 1.24, the semantics of `CurvePreferences` are changing ([golang/go#69393](https://github.com/golang/go/issues/69393)):
 - `CurvePreferences` will no longer specify preference ordering
 - Instead, it will be a list of enabled key exchanges, with `crypto/tls` automatically determining priority and key share selection
-- This change is driven by Post-Quantum Cryptography requirements where the library needs to intelligently manage curve selection (e.g., sending both ML-KEM768X25519 and X25519 key shares)
+- This change is driven by Post-Quantum Cryptography requirements where the library needs to intelligently manage group selection (e.g., sending both ML-KEM768X25519 and X25519 key shares)
 
 **Implications for OpenShift Components**
 
 Go-based components (which represent a significant portion of OpenShift) will have these constraints:
 - When using TLS 1.3, configured cipher suites cannot be enforced
-- Curve preference ordering may not be honored as specified by administrators
+- Group preference ordering may not be honored as specified by administrators
 - Components should document these limitations in their operator conditions or status messages
 - Administrators should be aware that Go-based components have reduced configurability compared to OpenSSL-based components
 
 These limitations should be considered when evaluating component compliance with TLS configuration requirements.
 
-#### Mismatching curves and ciphersuites
+#### Mismatching groups and ciphersuites
 There is a case where the administrator could incorrectly specify a set of ciphersuites
-that do not work with the configured curves. For example, using an RSA ciphersuite with an ECDHE curve (such as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 with P-256). The default behavior of OpenSSL and Go crypto/tls (both used extensively in OpenShift) is to fail at **TLS handshake time**. The TLS server instance will start normally, but when TLS clients attempt to handshake with the TLS server, the handshake will fail with a `handshake failure`.
+that do not work with the configured groups. For example, using an RSA ciphersuite with an ECDHE group (such as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 with P-256). The default behavior of OpenSSL and Go crypto/tls (both used extensively in OpenShift) is to fail at **TLS handshake time**. The TLS server instance will start normally, but when TLS clients attempt to handshake with the TLS server, the handshake will fail with a `handshake failure`.
 
-To avoid this scenario, OpenShift should implement validation to prevent **known incompatible cipher-curve combinations**. A validation layer will be added to check for compatible combinations of curves and ciphersuites. If a known invalid combination is detected, the configuration will be rejected, informing the user of the incompatibility immediately rather than failing at runtime.
+To avoid this scenario, OpenShift should implement validation to prevent **known incompatible cipher-group combinations**. A validation layer will be added to check for compatible combinations of groups and ciphersuites. If a known invalid combination is detected, the configuration will be rejected, informing the user of the incompatibility immediately rather than failing at runtime.
 
-**Note**: This validation only covers known incompatible cipher-curve combinations, not validation of curve names themselves. Curve names (valid, invalid, or malformed) are accepted and passed to the underlying TLS implementation, which filters them as described in the "Handling unsupported curves in custom profiles" section below.
+**Note**: This validation only covers known incompatible cipher-group combinations, not validation of group names themselves. Group names (valid, invalid, or malformed) are accepted and passed to the underlying TLS implementation, which filters them as described in the "Handling unsupported groups in custom profiles" section below.
 
-#### Handling unsupported curves in custom profiles
+#### Handling unsupported groups in custom profiles
 
 Custom TLS profiles follow a "use at your own risk" model that allows administrators 
 with advanced cryptographic knowledge to configure specific parameters. This same 
-model applies to curves as it does to existing cipher suite configuration.
+model applies to groups as it does to existing cipher suite configuration.
 
 **Configuration-time behavior:**
-TLS implementations (OpenSSL, Go crypto/tls, HAProxy) accept arbitrary curve names and do not fail when configured with invalid, malformed, or unsupported curves. Instead, they silently filter out:
-- **Invalid curve names**: Curves that are not recognized (e.g., typos like "X225519" instead of "X25519")
-- **Malformed identifiers**: Curve strings that don't match expected naming patterns
-- **Unsupported curves**: Valid curve names that the specific TLS library version doesn't support (e.g., PQC curves in older library versions)
+TLS implementations (OpenSSL, Go crypto/tls, HAProxy) accept arbitrary group names and do not fail when configured with invalid, malformed, or unsupported groups. Instead, they silently filter out:
+- **Invalid group names**: Groups that are not recognized (e.g., typos like "X225519" instead of "X25519")
+- **Malformed identifiers**: Group strings that don't match expected naming patterns
+- **Unsupported groups**: Valid group names that the specific TLS library version doesn't support (e.g., PQC groups in older library versions)
 
-The TLS implementation will proceed with only the valid and supported curves from the configured list.
+The TLS implementation will proceed with only the valid and supported groups from the configured list.
 
-**Important**: This behavior means administrators can configure curve lists that result in **no valid curves** being available, which will cause TLS handshake failures and render components inoperable. Manually setting curves in custom TLS profiles incurs significant risk and requires careful testing. See the [Support Procedures](#support-procedures) section for troubleshooting guidance.
+**Important**: This behavior means administrators can configure group lists that result in **no valid groups** being available, which will cause TLS handshake failures and render components inoperable. Manually setting groups in custom TLS profiles incurs significant risk and requires careful testing. See the [Support Procedures](#support-procedures) section for troubleshooting guidance.
 
 **Runtime behavior:**
-If no mutually supported curves remain after filtering, TLS handshakes will fail with errors like "no shared group". This is the expected and desired behavior—it ensures only supported cryptographic parameters are used.
+If no mutually supported groups remain after filtering, TLS handshakes will fail with errors like "no shared group". This is the expected and desired behavior—it ensures only supported cryptographic parameters are used.
 
 **API-level validation:**
-The `curves` field uses an enum to validate curve names, ensuring that only well-formed, recognized curve identifiers can be specified. This prevents typos and provides clear documentation of available options. The enum will need to be updated as new curves are standardized and support is requested, but this is a reasonable tradeoff for improved user experience.
+The `groups` field uses an enum to validate group names, ensuring that only well-formed, recognized group identifiers can be specified. This prevents typos and provides clear documentation of available options. The enum will need to be updated as new groups are standardized and support is requested, but this is a reasonable tradeoff for improved user experience.
 
-**Note:** Enum validation ensures curve names are syntactically valid, but cannot guarantee that a specific curve is supported by every component's underlying TLS implementation. Components will filter the configured curves to only those they support at runtime.
+**Note:** Enum validation ensures group names are syntactically valid, but cannot guarantee that a specific group is supported by every component's underlying TLS implementation. Components will filter the configured groups to only those they support at runtime.
 
 **Recommended approach:**
 - **Most users**: Use the predefined profiles (Old, Intermediate, Modern), which are 
   tested and guaranteed to work across all OpenShift components. These profiles will 
-  be enhanced to include secure curve configurations in future work.
+  be enhanced to include secure group configurations in future work.
 - **Advanced users**: Custom profiles are available for specific requirements (e.g., 
   early PQC adoption, compliance mandates). Administrators using custom profiles should:
   - Understand the cryptographic implications of their configuration
@@ -275,10 +275,10 @@ configurations can cause problems."
 
 ### Risks and Mitigations
 
-OpenShift components could forego utilizing the curves set in the API config. However, this is a risk
+OpenShift components could forego utilizing the groups set in the API config. However, this is a risk
 that exists in the current TLS config flow. This change will require coordination with component owners
 to ensure compliance with the new TLS config field, particularly for custom profiles where administrators
-explicitly set curves. For the initial scope of this enhancement, this may only apply when a custom profile
+explicitly set groups. For the initial scope of this enhancement, this may only apply when a custom profile
 is used, but backing implementation for core components is considered a requirement for GA promotion.
 
 ### Drawbacks
@@ -295,19 +295,19 @@ N/A
 
 ## Test Plan
 
-Utilize the `oc edit` and `oc describe` commands to verify that the API config server is exposing the correct list of curves.
+Utilize the `oc edit` and `oc describe` commands to verify that the API config server is exposing the correct list of groups.
 
-Once components are onboarded to utilize these curves, the cluster will be scanned with the [tls-scanner tool](github.com/openshift/tls-scanner) to verify that TLS implemenations within OpenShift expose these curves as supported. It should also be verified that the TLS implementations will fallback to a default curve set when not specified.
+Once components are onboarded to utilize these groups, the cluster will be scanned with the [tls-scanner tool](github.com/openshift/tls-scanner) to verify that TLS implementations within OpenShift expose these groups as supported. It should also be verified that the TLS implementations will fall back to a default group set when not specified.
 
 ### Dev Preview -> Tech Preview
 
-- Ability to specify supported curves.
+- Ability to specify supported groups.
 
 ### Tech Preview -> GA
 
-- **Backing implementation for core components to respect the curves field when set in custom profiles.** This is a GA blocker.
-- Verify the general support for these curves using the [tls-scanner](github.com/openshift/tls-scanner)
-- Ensure that key OpenShift components (ingress controller, API server, etc.) properly consume and apply the configured curves from custom TLS profiles
+- **Backing implementation for core components to respect the `groups` field when set in custom profiles.** This is a GA blocker.
+- Verify the general support for these groups using the [tls-scanner](github.com/openshift/tls-scanner)
+- Ensure that key OpenShift components (ingress controller, API server, etc.) properly consume and apply the configured groups from custom TLS profiles
 
 ### Removing a deprecated feature
 
@@ -316,12 +316,12 @@ N/A
 
 ## Upgrade / Downgrade Strategy
 
-In openshift versions where the TLS curves are not specified, components will not specify the set of curves to be used to their underlying TLS implementations. The TLS implementation should fallback to a sensible default set of curves when not set. This should be verified during the component onboarding work as outlined in the test plan.
+In OpenShift versions where the TLS groups are not specified, components will not specify the set of groups to be used to their underlying TLS implementations. The TLS implementation should fall back to a sensible default set of groups when not set. This should be verified during the component onboarding work as outlined in the test plan.
 
 
 ## Version Skew Strategy
 
-By default, TLS implementations (openssl, golang, etc...) fallback to a sensible default when curves are not set. Currently, openshift components that do not set curves exhibit this behavior. This should be verified during component onboarding.
+By default, TLS implementations (OpenSSL, Go, etc.) fall back to a sensible default when groups are not set. Currently, OpenShift components that do not set groups exhibit this behavior. This should be verified during component onboarding.
 
 ## Operational Aspects of API Extensions
 
@@ -331,7 +331,7 @@ N/A
 
 ### Verifying Configuration
 
-**Check configured curves:**
+**Check configured groups:**
 ```bash
 # For IngressController
 oc get ingresscontroller default -n openshift-ingress-operator -o yaml | grep -A 10 tlsSecurityProfile
@@ -341,7 +341,7 @@ oc get apiserver cluster -o yaml | grep -A 10 tlsSecurityProfile
 ```
 
 **Test connectivity:**
-After applying a custom curve configuration, test connectivity to critical services:
+After applying a custom group configuration, test connectivity to critical services:
 - OpenShift console access
 - API server connectivity (`oc` commands)
 - Application routes through ingress
@@ -349,7 +349,7 @@ After applying a custom curve configuration, test connectivity to critical servi
 
 ### Troubleshooting
 
-**Symptoms of curve misconfiguration:**
+**Symptoms of group misconfiguration:**
 - TLS handshake failures in component logs
 - "no shared group" errors
 - "handshake failure" errors
@@ -371,16 +371,16 @@ Look for errors containing:
 - "tls: handshake failure"
 - "no shared group"
 
-2. **Verify component is using curves:**
-Use [tls-scanner](https://github.com/openshift/tls-scanner) to confirm which components are respecting the curve configuration and which may not have implemented support yet.
+2. **Verify component is using groups:**
+Use [tls-scanner](https://github.com/openshift/tls-scanner) to confirm which components are respecting the group configuration and which may not have implemented support yet.
 
-3. **Check for unsupported curves:**
-If components are using older TLS library versions, they may not support newer curves (e.g., post-quantum curves like ML-KEM). Review component documentation for supported curve lists.
+3. **Check for unsupported groups:**
+If components are using older TLS library versions, they may not support newer groups (e.g., post-quantum groups like ML-KEM). Review component documentation for supported group lists.
 
 ### Recovery Procedures
 
 **Quick recovery - revert to predefined profile:**
-If a custom curve configuration is causing issues, immediately revert to a predefined profile:
+If a custom group configuration is causing issues, immediately revert to a predefined profile:
 
 ```bash
 oc edit ingresscontroller default -n openshift-ingress-operator
@@ -392,7 +392,7 @@ spec:
   tlsSecurityProfile:
     type: Custom
     custom:
-      curves:
+      groups:
       - X25519MLKEM768
       - X25519
 ```
@@ -404,13 +404,13 @@ spec:
     type: Intermediate  # or Modern/Old depending on requirements
 ```
 
-This will restore known-good curve defaults.
+This will restore known-good group defaults.
 
-**Gradual recovery - adjust curve list:**
-If only specific curves are causing problems:
+**Gradual recovery - adjust group list:**
+If only specific groups are causing problems:
 1. Keep the Custom profile
-2. Remove problematic curves from the list
-3. Ensure at least one widely-supported curve remains (e.g., X25519, P-256)
+2. Remove problematic groups from the list
+3. Ensure at least one widely-supported group remains (e.g., X25519, P-256)
 4. Monitor logs and connectivity
 
 **Full rollback:**
@@ -421,7 +421,7 @@ oc rollout undo ingresscontroller/default -n openshift-ingress-operator
 
 ### Prevention
 
-- **Always include fallback curves:** When configuring custom curves (especially experimental ones like PQC curves), always include widely-supported curves in the list as fallbacks
-- **Test in non-production first:** Apply custom curve configurations to development/staging clusters before production
+- **Always include fallback groups:** When configuring custom groups (especially experimental ones like PQC groups), always include widely-supported groups in the list as fallbacks
+- **Test in non-production first:** Apply custom group configurations to development/staging clusters before production
 - **Use predefined profiles when possible:** Most users should use Old/Intermediate/Modern profiles, which are tested across all components
-- **Monitor after changes:** Watch component logs for 15-30 minutes after applying curve configuration changes
+- **Monitor after changes:** Watch component logs for 15-30 minutes after applying group configuration changes

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -6,9 +6,9 @@ authors:
 reviewers:
   - dsalerno # OpenShift networking stack knowledge
 approvers: 
-  - JoelSpeed
+  - joelanford
 api-approvers:
-  - JoelSpeed
+  - everettraven
 creation-date: 2025-11-19
 last-updated: 2026-05-07
 tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -6,126 +6,156 @@ authors:
 reviewers:
   - dsalerno # OpenShift networking stack knowledge
 approvers: 
-  - joelanford
+  - JoelSpeed
 api-approvers:
-  - everettraven
+  - JoelSpeed
 creation-date: 2025-11-19
-last-updated: 2025-11-20
+last-updated: 2026-05-07
 tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement
   - https://issues.redhat.com/browse/HPCASE-153
 ---
 
-# OpenShift API TLS Groups Configuration 
+# OpenShift API TLS Groups Configuration
 
 ## Summary
 
-This enhancement adds the option to configure a list of supported TLS named groups (key exchange algorithms) in the OpenShift API config server. This configuration mirrors the existing `ciphersuites` option in the OpenShift API config TLS settings.
+This enhancement adds the option to configure a list of supported TLS groups in
+the OpenShift API config server. This configuration mirrors the existing
+`ciphersuites` option in the OpenShift API config TLS settings.
 
 ## Motivation
 
-As cryptographic standards evolve, there is a growing need to support Post-Quantum Cryptography (PQC) to protect against future threats. This enhancement contributes directly to the goal of enabling PQC support in OpenShift. It provides the mechanism to configure specific TLS named groups in the OpenShift API, allowing administrators to explicitly enable PQC-ready groups such as ML-KEM. This ensures OpenShift clusters can be configured to meet emerging security compliance requirements and future-proof communications.
+As cryptographic standards evolve, there is a growing need to support
+Post-Quantum Cryptography (PQC) to protect against future threats. This
+enhancement contributes directly to the goal of enabling PQC support in
+OpenShift. It provides the mechanism to configure specific TLS groups in the
+OpenShift API, allowing administrators to explicitly enable PQC-ready groups
+such as X25519MLKEM768. This ensures OpenShift clusters can be configured to
+meet emerging security compliance requirements and future-proof communications.
 
 ### User Stories
 
-As an administrator, I want to explicitly set the supported TLS groups to ensure PQC readiness throughout OpenShift so that I can ensure the security of TLS communication in the era of quantum computing.
+As an administrator, I want to explicitly set the supported TLS groups to ensure
+PQC readiness throughout OpenShift so that I can ensure the security of TLS
+communication in the era of quantum computing.
 
 ### Goals
 
-To provide an interface that allows the setting of TLS groups to be used cluster wide.
+To provide an interface that allows the setting of TLS groups to be used cluster
+wide.
 
 This goal is part of the larger goal to:
- 1. Provide the necessary knobs to specify a PQC ready TLS configuration in OpenShift.
- 2. Improve the adaptability of the cluster's TLS configuration to provide support for the constantly evolving TLS landscape.
+
+1. Provide the necessary knobs to specify a PQC ready TLS configuration in
+   OpenShift.
+2. Improve the adaptability of the cluster's TLS configuration to provide
+   support for the constantly evolving TLS landscape.
 
 ### Non-Goals
 
-1. Overhauling the current process of TLS configuration in OpenShift. This change merely extends the current TLS options.
+1. Overhauling the current process of TLS configuration in OpenShift. This
+   change merely extends the current TLS options.
 
 ## Proposal
 
-This proposal is to expose the ability to specify the TLS groups (key exchange algorithms) used in OpenShift components to the OpenShift administrator.
-Currently, administrators can specify a custom TLS profile where they can specifically set which TLS ciphersuites and the minimum TLS version as opposed to using one of the preconfigured TLS profiles. Specifying the set of supported TLS groups will mirror this process of setting [supported ciphers and the minimum TLS version](https://github.com/openshift/api/blob/138912d4ee9944c989f593c51f15c41908155856/config/v1/types_tlssecurityprofile.go#L206). 
+This proposal is to expose the ability to specify the TLS groups used in
+OpenShift components to the OpenShift administrator. Currently, administrators
+can specify a custom TLS profile where they can specifically set which TLS
+ciphersuites and the minimum TLS version as opposed to using one of the
+preconfigured TLS profiles. Specifying the set of supported TLS groups will
+mirror this process of setting [supported ciphers and the minimum TLS version](https://github.com/openshift/api/blob/138912d4ee9944c989f593c51f15c41908155856/config/v1/types_tlssecurityprofile.go#L206).
 
-The current state of the OpenShift TLS stack uses a default set of groups with no way to specify them. This eases the burden on administrators, however new quantum secure algorithms rely on groups outside of the conventional defaults. For example, groups like [ML-KEM](https://www.ietf.org/archive/id/draft-connolly-tls-mlkem-key-agreement-05.html) provide a quantum safe mechanism for sharing secrets necessary for the TLS handshake, whereas groups based on elliptic curves like [X25519](https://datatracker.ietf.org/doc/html/rfc7748) are [weak against quantum computing](https://crypto.stackexchange.com/questions/59770/how-effective-is-quantum-computing-against-elliptic-curve-cryptography).
+The current state of the OpenShift TLS stack uses a default set of groups with
+no way to specify them. This eases the burden on administrators, however new
+quantum secure algorithms rely on a set of groups outside of the conventional
+default groups. For example, [X25519MLKEM768](https://www.ietf.org/archive/id/draft-connolly-tls-mlkem-key-agreement-05.html)
+provides a quantum safe mechanism for sharing secrets necessary for the TLS
+handshake, whereas conventional groups like [X25519](https://datatracker.ietf.org/doc/html/rfc7748)
+are [weak against quantum computing](https://crypto.stackexchange.com/questions/59770/how-effective-is-quantum-computing-against-elliptic-curve-cryptography).
 
-The ability to set groups explicitly will also make it possible to align our 
-OpenShift TLS profiles to match the groups present in the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS). 
+The ability to set groups explicitly will also make it possible to align our
+OpenShift TLS profiles to match the groups present in the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS).
 
-This change will require working with OpenShift component owners to use this new field. The scope of this feature includes ensuring that appropriate components respect the new `groups` field when it is set in custom profiles. Adding default groups to the non-custom profiles (Old, Intermediate, Modern) is a separately scoped action and will be addressed in future work.
+This change will require working with OpenShift component owners to use this new
+field. The scope of this feature includes ensuring that appropriate components
+respect the new groups field when it is set in custom profiles. Default groups
+are being added to the non-custom profiles (Old, Intermediate, Modern) as part
+of this implementation; see the [Default group configuration](#default-group-configuration)
+section for details.
 
 ### Workflow Description
 
-Administrators will use the [existing custom TLS security profile flow](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-ingress-configuring_tls-security-profiles) for setting the supported groups. 
+Administrators will use the [existing custom TLS security profile flow](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-ingress-configuring_tls-security-profiles)
+for setting the supported groups.
 
-Specifically administrators will use 
+Specifically administrators will use
 
 `oc edit IngressController default -n openshift-ingress-operator`
 
 and edit the spec.tlsSecurityProfile field:
 
-```
+```yaml
 apiVersion: operator.openshift.io/v1
 kind: IngressController
  ...
 spec:
   tlsSecurityProfile:
-    type: Custom 
-    custom: 
-      ciphers: 
+    type: Custom
+    custom:
+      ciphers:
       - ECDHE-RSA-CHACHA20-POLY1305
       minTLSVersion: VersionTLS13
       groups:
-      - X25519MLKEM512
+      - X25519MLKEM768
  ...
 ```
 
 ### API Extensions
 
-- Adds a `groups` field to the `spec.tlsSecurityProfile` (https://github.com/openshift/api/pull/2583/files#diff-2101eac4196d9b14cf061c8a6a4d40f9d8e5a77fc2690f969e7293294218afe3R267)
+- Adds a `groups` field to the `spec.tlsSecurityProfile`
+  (https://github.com/openshift/api/pull/2583/files#diff-2101eac4196d9b14cf061c8a6a4d40f9d8e5a77fc2690f969e7293294218afe3R267)
+- The field is gated behind the `TLSCurvePreferences` feature gate, enabled in
+  `DevPreviewNoUpgrade` and `TechPreviewNoUpgrade` tiers
 - The addition of this field should not affect existing API behaviour
 
 ### Topology Considerations
 
 #### Hypershift / Hosted Control Planes
 
-HyperShift [does not currently consume custom TLS supported groups](https://github.com/openshift/hypershift/blob/6b0338c192c966a9c072bfc6af45202739e9e553/support/config/cipher.go#L30). However, this is planned in the future.
+Hypershift [does not currently consume custom TLS supported groups](https://github.com/openshift/hypershift/blob/6b0338c192c966a9c072bfc6af45202739e9e553/support/config/cipher.go#L30).
+However, this is planned in the future.
 
 #### Standalone Clusters
 
 N/A
 
-
 #### Single-node Deployments or MicroShift
 
-This change will affect the TLS profile of both single node and MicroShift deployments.
+This change will affect the TLS profile of both single node and microshift
+deployments.
 
 ### Implementation Details/Notes/Constraints
 
-#### Upstream Component TLS Group Support
-
-The following Kubernetes components lack explicit configuration support for TLS groups:
-
-| Component | Status | Reference |
-|-----------|--------|-----------|
-| Kubelet | No Support | [types.go#L182](https://github.com/kubernetes/kubelet/blob/ce0febd5f9e2c0e97ef3b3161a9098ef3f34afcb/config/v1beta1/types.go#L182) |
-| Etcd | No Support | [config.go#L250](https://github.com/etcd-io/etcd/blob/ed430d025f5d1ff33d997e42569073c55f3ef513/server/embed/config.go#L250) |
-| Controller-manager | No Support | [kube-controller-manager.md](https://github.com/kubernetes/website/blob/8d4885bbb055ec4558520a021ab1ac65064cd896/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md#L972-L998) |
-| Kube-scheduler | No Support | [serving.go#L66](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving.go#L66) |
-
-This limitation means that TLS group configuration will primarily benefit components that use their own TLS implementations (such as Ingress controllers using HAProxy/OpenSSL) rather than components that rely on upstream Kubernetes code. Upstream support would need to be added for these components to honor TLS group configuration.
-
 #### Component Configuration Consumption
 
-Different OpenShift components consume TLS configuration from different sources based on their operational context:
+Different OpenShift components consume TLS configuration from different sources
+based on their operational context:
 
 **1. API Server Components** (kube-apiserver, openshift-apiserver, oauth-server, etc.)
+
 - Read TLS configuration from `apiserver.config.openshift.io/cluster`
-- Component operators watch this object and regenerate configuration when it changes
-- Example: The kube-apiserver operator reads the `tlsSecurityProfile` field and passes the groups to the kube-apiserver via command-line flags or configuration files
+- Component operators watch this object and regenerate configuration when it
+  changes
+- Example: The kube-apiserver operator reads the `tlsSecurityProfile` field and
+  passes the groups to the kube-apiserver via command-line flags or
+  configuration files
 
 **2. Kubelet Configuration**
-- Kubelet TLS configuration is managed through `kubeletconfig.machineconfiguration.openshift.io`
+
+- Kubelet TLS configuration is managed through
+  `kubeletconfig.machineconfiguration.openshift.io`
 - Administrators can set a TLS profile (including groups) at this level:
+
   ```yaml
   apiVersion: machineconfiguration.openshift.io/v1
   kind: KubeletConfig
@@ -140,13 +170,19 @@ Different OpenShift components consume TLS configuration from different sources 
         - X25519MLKEM768
         - X25519
   ```
+
 - The Machine Config Operator (MCO) watches `KubeletConfig` objects
-- MCO renders this configuration into kubelet configuration files on nodes via MachineConfigs
+- MCO renders this configuration into kubelet configuration files on nodes via
+  MachineConfigs
 - Kubelet reads the configuration from `/etc/kubernetes/kubelet.conf` or similar
 
 **3. Ingress Controller**
-- Ingress configuration is managed through `ingresscontroller.operator.openshift.io`
-- Administrators configure TLS profiles (including groups) on the IngressController object:
+
+- Ingress configuration is managed through
+  `ingresscontroller.operator.openshift.io`
+- Administrators configure TLS profiles (including groups) on the
+  IngressController object:
+
   ```yaml
   apiVersion: operator.openshift.io/v1
   kind: IngressController
@@ -160,9 +196,12 @@ Different OpenShift components consume TLS configuration from different sources 
         groups:
         - X25519MLKEM768
   ```
+
 - The Ingress Operator watches IngressController objects
-- The operator configures the ingress router pods with the specified TLS settings
-- Router pods (typically HAProxy or similar) apply these settings to their TLS listeners
+- The operator configures the ingress router pods with the specified TLS
+  settings
+- Router pods (typically HAProxy or similar) apply these settings to their TLS
+  listeners
 
 **4. General Pattern for Operators**
 
@@ -176,8 +215,9 @@ For operators managing components that need to respect TLS configuration:
 
 3. **Translate** to the component's native configuration format:
    - For Go components: Set `tls.Config.CurvePreferences`
-   - For OpenSSL-based components: Use `SSL_CTX_set1_groups_list()` or configuration directives
-   - For HAProxy: Use `curves` directive in configuration (HAProxy still uses the `curves` directive name)
+   - For OpenSSL-based components: Use `SSL_CTX_set1_groups_list()` or
+     configuration directives
+   - For HAProxy: Use `curves` directive in configuration
 
 4. **Apply** configuration by:
    - Regenerating configuration files
@@ -188,98 +228,106 @@ For operators managing components that need to respect TLS configuration:
 
 **Configuration Precedence**
 
-When multiple TLS configuration sources exist, components follow this precedence (highest to lowest priority):
-1. Component-specific configuration (e.g., `IngressController.spec.tlsSecurityProfile`)
-2. Category-level configuration (e.g., `KubeletConfig.spec.tlsSecurityProfile` for node components)
-3. Cluster-wide default (e.g., `apiserver.config.openshift.io/cluster` for API server components)
+When multiple TLS configuration sources exist, components follow this
+precedence:
 
-This precedence model allows for centralized defaults with selective overrides where needed.
+1. Component-specific configuration (e.g.,
+   `IngressController.spec.tlsSecurityProfile`)
+2. Category-level configuration (e.g.,
+   `KubeletConfig.spec.tlsSecurityProfile` for node components)
+3. Cluster-wide default (e.g., `apiserver.config.openshift.io/cluster` for API
+   server components)
+
+This precedence model allows for centralized defaults with selective overrides
+where needed.
 
 #### Default group configuration
-The [default openshift TLS profiles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-understanding_tls-security-profiles) (Old, Intermediate, Modern) do not currently specify any groups, instead relying on the underlying TLS implementation to select a sensible default. However, the default Mozilla TLS profiles (which OpenShift TLS profiles are based on) *do* specify groups. We are planning on specifically adding these groups to OpenShift's non-custom profiles in the future as a separately scoped action. This API change should expose the `groups` field first to allow components time to implement the consumption of these groups when set in custom profiles.
 
-#### Go crypto/tls Implementation Limitations
+The named TLS profiles (Old, Intermediate, Modern) are updated as part of this
+implementation to include default groups based on Go's `crypto/tls` default
+group preferences: `X25519`, `SecP256r1`, `SecP384r1`, and `X25519MLKEM768`.
+Note that the [Mozilla TLS Profiles](https://wiki.mozilla.org/Security/Server_Side_TLS)
+(version 5.7) do not include `X25519MLKEM768`; Go's defaults are used here to
+align with the runtime behavior of Go-based OpenShift components and to enable
+post-quantum hybrid key exchange where supported.
 
-Components using Go's `crypto/tls` library face specific limitations that affect group and cipher suite configuration:
-
-**TLS 1.3 Cipher Suite Configuration**
-
-In TLS 1.3, Go's `crypto/tls` does not allow cipher suite configuration ([golang/go#29349](https://github.com/golang/go/issues/29349)). The `Config.CipherSuites` field is ignored for TLS 1.3 connections, and Go uses a hardcoded set of cipher suites. This means:
-- Components using Go cannot honor custom cipher suite configurations when TLS 1.3 is used
-- Administrators configuring `minTLSVersion: VersionTLS13` with custom cipher suites will find the cipher suite configuration is not applied by Go-based components
-- This is a known limitation of the Go standard library and cannot be worked around by OpenShift components
-
-**Group Preferences Ordering**
-
-Starting in Go 1.24, the semantics of `CurvePreferences` are changing ([golang/go#69393](https://github.com/golang/go/issues/69393)):
-- `CurvePreferences` will no longer specify preference ordering
-- Instead, it will be a list of enabled key exchanges, with `crypto/tls` automatically determining priority and key share selection
-- This change is driven by Post-Quantum Cryptography requirements where the library needs to intelligently manage group selection (e.g., sending both ML-KEM768X25519 and X25519 key shares)
-
-**Implications for OpenShift Components**
-
-Go-based components (which represent a significant portion of OpenShift) will have these constraints:
-- When using TLS 1.3, configured cipher suites cannot be enforced
-- Group preference ordering may not be honored as specified by administrators
-- Components should document these limitations in their operator conditions or status messages
-- Administrators should be aware that Go-based components have reduced configurability compared to OpenSSL-based components
-
-These limitations should be considered when evaluating component compliance with TLS configuration requirements.
+**FIPS mode constraint:** `X25519` and `X25519MLKEM768` are not FIPS-approved.
+Components running in FIPS mode must omit these groups. The FIPS-approved
+post-quantum alternatives (`SecP256r1MLKEM768`, `SecP384r1MLKEM1024`) require
+Go 1.26+ and are not currently supported.
 
 #### Mismatching groups and ciphersuites
-There is a case where the administrator could incorrectly specify a set of ciphersuites
-that do not work with the configured groups. For example, using an RSA ciphersuite with an ECDHE group (such as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 with P-256). The default behavior of OpenSSL and Go crypto/tls (both used extensively in OpenShift) is to fail at **TLS handshake time**. The TLS server instance will start normally, but when TLS clients attempt to handshake with the TLS server, the handshake will fail with a `handshake failure`.
 
-To avoid this scenario, OpenShift should implement validation to prevent **known incompatible cipher-group combinations**. A validation layer will be added to check for compatible combinations of groups and ciphersuites. If a known invalid combination is detected, the configuration will be rejected, informing the user of the incompatibility immediately rather than failing at runtime.
+There is a case where the administrator could incorrectly specify a set of
+ciphersuites that do not work with each other. For example, using an RSA
+ciphersuite with an ECDHE group (such as `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+and `P-256`). The default behavior of OpenSSL as well as Go's crypto/tls (both
+used extensively in OpenShift) is to fail at **TLS handshake time**. The TLS
+server instance will start normally, but when TLS clients attempt to handshake
+with the TLS server, the handshake will fail with a `handshake failure`.
 
-**Note**: This validation only covers known incompatible cipher-group combinations, not validation of group names themselves. Group names (valid, invalid, or malformed) are accepted and passed to the underlying TLS implementation, which filters them as described in the "Handling unsupported groups in custom profiles" section below.
+To avoid this scenario, OpenShift should implement validation to prevent known
+invalid combinations. A validation layer will be added to check for compatible
+combinations of groups and ciphersuites. If a known invalid combination is
+detected, the configuration will be rejected, informing the user of the
+incompatibility immediately rather than failing at runtime.
 
 #### Handling unsupported groups in custom profiles
 
-Custom TLS profiles follow a "use at your own risk" model that allows administrators 
-with advanced cryptographic knowledge to configure specific parameters. This same 
-model applies to groups as it does to existing cipher suite configuration.
+Custom TLS profiles follow a "use at your own risk" model that allows
+administrators with advanced cryptographic knowledge to configure specific
+parameters. This same model applies to groups as it does to existing cipher
+suite configuration.
 
 **Configuration-time behavior:**
-TLS implementations (OpenSSL, Go crypto/tls, HAProxy) accept arbitrary group names and do not fail when configured with invalid, malformed, or unsupported groups. Instead, they silently filter out:
-- **Invalid group names**: Groups that are not recognized (e.g., typos like "X225519" instead of "X25519")
-- **Malformed identifiers**: Group strings that don't match expected naming patterns
-- **Unsupported groups**: Valid group names that the specific TLS library version doesn't support (e.g., PQC groups in older library versions)
-
-The TLS implementation will proceed with only the valid and supported groups from the configured list.
-
-**Important**: This behavior means administrators can configure group lists that result in **no valid groups** being available, which will cause TLS handshake failures and render components inoperable. Manually setting groups in custom TLS profiles incurs significant risk and requires careful testing. See the [Support Procedures](#support-procedures) section for troubleshooting guidance.
+TLS implementations (OpenSSL, Go crypto/tls) do not fail when configured with
+unsupported groups or ciphers. Instead, they silently filter out unsupported
+items and proceed with the valid ones.
 
 **Runtime behavior:**
-If no mutually supported groups remain after filtering, TLS handshakes will fail with errors like "no shared group". This is the expected and desired behavior—it ensures only supported cryptographic parameters are used.
+If no mutually supported groups (or ciphers) remain after filtering, TLS
+handshakes will fail with errors like "handshake failure" (for cipher suites)
+or "no shared group" (for groups). This is the expected and desired
+behavior — it ensures only supported cryptographic parameters are used.
 
-**API-level validation:**
-The `groups` field uses an enum to validate group names, ensuring that only well-formed, recognized group identifiers can be specified. This prevents typos and provides clear documentation of available options. The enum will need to be updated as new groups are standardized and support is requested, but this is a reasonable tradeoff for improved user experience.
+**Why not validate at API level:**
+Validating group support at the API level would require maintaining a
+comprehensive registry of:
 
-**Note:** Enum validation ensures group names are syntactically valid, but cannot guarantee that a specific group is supported by every component's underlying TLS implementation. Components will filter the configured groups to only those they support at runtime.
+- All TLS implementation libraries used across OpenShift components
+- Version-specific support matrices for each library
+- Continuous updates as libraries evolve
+
+This approach is infeasible and would create a maintenance burden that
+outweighs the benefit. Runtime failures provide clear, immediate feedback about
+incompatibilities.
 
 **Recommended approach:**
-- **Most users**: Use the predefined profiles (Old, Intermediate, Modern), which are 
-  tested and guaranteed to work across all OpenShift components. These profiles will 
-  be enhanced to include secure group configurations in future work.
-- **Advanced users**: Custom profiles are available for specific requirements (e.g., 
-  early PQC adoption, compliance mandates). Administrators using custom profiles should:
+
+- **Most users**: Use the predefined profiles (Old, Intermediate, Modern), which
+  are tested and guaranteed to work across all OpenShift components. These
+  profiles include secure default group configurations.
+- **Advanced users**: Custom profiles are available for specific requirements
+  (e.g., early PQC adoption, compliance mandates). Administrators using custom
+  profiles should:
   - Understand the cryptographic implications of their configuration
   - Test connectivity to critical services after applying changes
   - Use the tls-scanner tool to verify actual negotiated parameters
   - Monitor component logs for TLS handshake failures
 
-This approach is consistent with the existing [custom TLS profile documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles), 
-which warns: "Use caution when using a Custom profile, because invalid 
+This approach is consistent with the existing [custom TLS profile documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles),
+which warns: "Use caution when using a Custom profile, because invalid
 configurations can cause problems."
 
 ### Risks and Mitigations
 
-OpenShift components could forego utilizing the groups set in the API config. However, this is a risk
-that exists in the current TLS config flow. This change will require coordination with component owners
-to ensure compliance with the new TLS config field, particularly for custom profiles where administrators
-explicitly set groups. For the initial scope of this enhancement, this may only apply when a custom profile
-is used, but backing implementation for core components is considered a requirement for GA promotion.
+OpenShift components could forego utilizing the groups set in the API config.
+However, this is a risk that exists in the current TLS config flow. This change
+will require coordination with component owners to ensure compliance with the
+new TLS config field, particularly for custom profiles where administrators
+explicitly set groups. For the initial scope of this enhancement, this may only
+apply when a custom profile is used, but backing implementation for core
+components is considered a requirement for GA promotion.
 
 ### Drawbacks
 
@@ -295,33 +343,47 @@ N/A
 
 ## Test Plan
 
-Utilize the `oc edit` and `oc describe` commands to verify that the API config server is exposing the correct list of groups.
+Utilize the `oc edit` and `oc describe` commands to verify that the API config
+server is exposing the correct list of groups.
 
-Once components are onboarded to utilize these groups, the cluster will be scanned with the [tls-scanner tool](github.com/openshift/tls-scanner) to verify that TLS implementations within OpenShift expose these groups as supported. It should also be verified that the TLS implementations will fall back to a default group set when not specified.
+Once components are onboarded to utilize these groups, the cluster will be
+scanned with the [tls-scanner tool](github.com/openshift/tls-scanner) to verify
+that TLS implementations within OpenShift expose these groups as supported. It
+should also be verified that the TLS implementations will fallback to a default
+group set when not specified.
 
 ### Dev Preview -> Tech Preview
 
-- Ability to specify supported groups.
+- Ability to specify supported groups via the `TLSCurvePreferences` feature
+  gate.
 
 ### Tech Preview -> GA
 
-- **Backing implementation for core components to respect the `groups` field when set in custom profiles.** This is a GA blocker.
-- Verify the general support for these groups using the [tls-scanner](github.com/openshift/tls-scanner)
-- Ensure that key OpenShift components (ingress controller, API server, etc.) properly consume and apply the configured groups from custom TLS profiles
+- **Backing implementation for core components to respect the groups field when
+  set in custom profiles.** This is a GA blocker.
+- Verify the general support for these groups using the
+  [tls-scanner](github.com/openshift/tls-scanner)
+- Ensure that key OpenShift components (ingress controller, API server, etc.)
+  properly consume and apply the configured groups from custom TLS profiles
 
 ### Removing a deprecated feature
 
 N/A
 
-
 ## Upgrade / Downgrade Strategy
 
-In OpenShift versions where the TLS groups are not specified, components will not specify the set of groups to be used to their underlying TLS implementations. The TLS implementation should fall back to a sensible default set of groups when not set. This should be verified during the component onboarding work as outlined in the test plan.
-
+In OpenShift versions where the TLS groups are not specified, components will
+not specify the set of groups to be used to their underlying TLS
+implementations. The TLS implementation should fallback to a sensible default
+set of groups when not set. This should be verified during the component
+onboarding work as outlined in the test plan.
 
 ## Version Skew Strategy
 
-By default, TLS implementations (OpenSSL, Go, etc.) fall back to a sensible default when groups are not set. Currently, OpenShift components that do not set groups exhibit this behavior. This should be verified during component onboarding.
+By default, TLS implementations (openssl, golang, etc.) fallback to a sensible
+default when groups are not set. Currently, OpenShift components that do not set
+groups exhibit this behavior. This should be verified during component
+onboarding.
 
 ## Operational Aspects of API Extensions
 
@@ -332,6 +394,7 @@ N/A
 ### Verifying Configuration
 
 **Check configured groups:**
+
 ```bash
 # For IngressController
 oc get ingresscontroller default -n openshift-ingress-operator -o yaml | grep -A 10 tlsSecurityProfile
@@ -341,7 +404,9 @@ oc get apiserver cluster -o yaml | grep -A 10 tlsSecurityProfile
 ```
 
 **Test connectivity:**
-After applying a custom group configuration, test connectivity to critical services:
+After applying a custom group configuration, test connectivity to critical
+services:
+
 - OpenShift console access
 - API server connectivity (`oc` commands)
 - Application routes through ingress
@@ -350,6 +415,7 @@ After applying a custom group configuration, test connectivity to critical servi
 ### Troubleshooting
 
 **Symptoms of group misconfiguration:**
+
 - TLS handshake failures in component logs
 - "no shared group" errors
 - "handshake failure" errors
@@ -358,6 +424,7 @@ After applying a custom group configuration, test connectivity to critical servi
 **Identifying the problem:**
 
 1. **Check component logs for TLS errors:**
+
 ```bash
 # Ingress router logs
 oc logs -n openshift-ingress -l ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
@@ -367,26 +434,33 @@ oc logs -n openshift-kube-apiserver -l app=openshift-kube-apiserver
 ```
 
 Look for errors containing:
+
 - "tls: no supported group"
 - "tls: handshake failure"
 - "no shared group"
 
 2. **Verify component is using groups:**
-Use [tls-scanner](https://github.com/openshift/tls-scanner) to confirm which components are respecting the group configuration and which may not have implemented support yet.
+Use [tls-scanner](https://github.com/openshift/tls-scanner) to confirm which
+components are respecting the group configuration and which may not have
+implemented support yet.
 
 3. **Check for unsupported groups:**
-If components are using older TLS library versions, they may not support newer groups (e.g., post-quantum groups like ML-KEM). Review component documentation for supported group lists.
+If components are using older TLS library versions, they may not support newer
+groups (e.g., post-quantum groups like X25519MLKEM768). Review component
+documentation for supported group lists.
 
 ### Recovery Procedures
 
 **Quick recovery - revert to predefined profile:**
-If a custom group configuration is causing issues, immediately revert to a predefined profile:
+If a custom group configuration is causing issues, immediately revert to a
+predefined profile:
 
 ```bash
 oc edit ingresscontroller default -n openshift-ingress-operator
 ```
 
 Change from:
+
 ```yaml
 spec:
   tlsSecurityProfile:
@@ -398,6 +472,7 @@ spec:
 ```
 
 To:
+
 ```yaml
 spec:
   tlsSecurityProfile:
@@ -408,6 +483,7 @@ This will restore known-good group defaults.
 
 **Gradual recovery - adjust group list:**
 If only specific groups are causing problems:
+
 1. Keep the Custom profile
 2. Remove problematic groups from the list
 3. Ensure at least one widely-supported group remains (e.g., X25519, P-256)
@@ -415,13 +491,19 @@ If only specific groups are causing problems:
 
 **Full rollback:**
 If needed, restore the previous configuration:
+
 ```bash
 oc rollout undo ingresscontroller/default -n openshift-ingress-operator
 ```
 
 ### Prevention
 
-- **Always include fallback groups:** When configuring custom groups (especially experimental ones like PQC groups), always include widely-supported groups in the list as fallbacks
-- **Test in non-production first:** Apply custom group configurations to development/staging clusters before production
-- **Use predefined profiles when possible:** Most users should use Old/Intermediate/Modern profiles, which are tested across all components
-- **Monitor after changes:** Watch component logs for 15-30 minutes after applying group configuration changes
+- **Always include fallback groups:** When configuring custom groups (especially
+  experimental ones like PQC groups), always include widely-supported groups in
+  the list as fallbacks
+- **Test in non-production first:** Apply custom group configurations to
+  development/staging clusters before production
+- **Use predefined profiles when possible:** Most users should use
+  Old/Intermediate/Modern profiles, which are tested across all components
+- **Monitor after changes:** Watch component logs for 15-30 minutes after
+  applying group configuration changes

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -383,13 +383,15 @@ includes this update as part of the GA promotion work.
 
 #### Mismatching groups and ciphersuites
 
-There is a case where the administrator could incorrectly specify a set of
-ciphersuites that do not work with each other. For example, using an RSA
-ciphersuite with an ECDHE group (such as `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
-and `P-256`). The default behavior of OpenSSL as well as Go's crypto/tls (both
-used extensively in OpenShift) is to fail at **TLS handshake time**. The TLS
-server instance will start normally, but when TLS clients attempt to handshake
-with the TLS server, the handshake will fail with a `handshake failure`.
+There is a case where the administrator could incorrectly specify ciphersuites
+and groups that do not work with each other. For example, specifying only
+non-EC DHE cipher suites (e.g. `DHE-RSA-AES256-GCM-SHA384`) while listing only
+EC-based groups (e.g. `X25519`, `P-256`) — DHE key exchange does not use EC
+groups, so no shared key exchange method can be negotiated. The default behavior
+of OpenSSL as well as Go's crypto/tls (both used extensively in OpenShift) is
+to fail at **TLS handshake time**. The TLS server instance will start normally,
+but when TLS clients attempt to handshake with the TLS server, the handshake
+will fail with a `handshake failure`.
 
 To avoid this scenario, OpenShift should implement validation to prevent known
 invalid combinations. A validation layer will be added to check for compatible

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -266,6 +266,8 @@ based on their operational context:
     tlsSecurityProfile:
       type: Custom
       custom:
+        ciphers:
+        - ECDHE-ECDSA-AES128-GCM-SHA256
         minTLSVersion: VersionTLS13
         groups:
         - X25519MLKEM768
@@ -294,6 +296,9 @@ based on their operational context:
     tlsSecurityProfile:
       type: Custom
       custom:
+        ciphers:
+        - ECDHE-RSA-CHACHA20-POLY1305
+        minTLSVersion: VersionTLS13
         groups:
         - X25519MLKEM768
   ```
@@ -593,6 +598,9 @@ spec:
   tlsSecurityProfile:
     type: Custom
     custom:
+      ciphers:
+      - ECDHE-RSA-CHACHA20-POLY1305
+      minTLSVersion: VersionTLS13
       groups:
       - X25519MLKEM768
       - X25519

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -274,6 +274,11 @@ based on their operational context:
         - X25519
   ```
 
+  In the example above, the KubeletConfig configures the `tlsSecurityProfile`
+  to use TLS v1.3 only, with one cipher (`ECDHE-ECDSA-AES128-GCM-SHA256`), and
+  two supported groups (`X25519MLKEM768` and `X25519`) for key exchange.
+  `X25519MLKEM768` is preferred over `X25519` due to the ordering.
+
 - The Machine Config Operator (MCO) watches `KubeletConfig` objects
 - MCO renders this configuration into kubelet configuration files on nodes via
   MachineConfigs

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -134,6 +134,10 @@ N/A
 This change will affect the TLS profile of both single node and microshift
 deployments.
 
+#### OpenShift Kubernetes Engine
+
+N/A
+
 ### Implementation Details/Notes/Constraints
 
 #### Component Configuration Consumption
@@ -351,6 +355,8 @@ scanned with the [tls-scanner tool](github.com/openshift/tls-scanner) to verify
 that TLS implementations within OpenShift expose these groups as supported. It
 should also be verified that the TLS implementations will fallback to a default
 group set when not specified.
+
+## Graduation Criteria
 
 ### Dev Preview -> Tech Preview
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -161,13 +161,12 @@ section for the full list of configuration sources and their precedence.
   `DevPreviewNoUpgrade` and `TechPreviewNoUpgrade` tiers
 - The addition of this field should not affect existing API behaviour
 - **Component implementors do not need to check for the feature gate.** Because
-  the field is optional (`+optional`, `omitempty`), components need only inspect
-  the field's value when unmarshaling the TLS security profile. When the feature
-  gate is disabled the field will never be set, so components will continue
-  using the TLS implementation's defaults transparently. When the field is
-  present, components use the specified groups; when absent, they fall back to
-  defaults. This mirrors the approach used for `tlsAdherence` in
-  [openshift/api#2583](https://github.com/openshift/api/pull/2583).
+  the field is optional (`+optional`, `omitempty`), the field's presence is
+  sufficient signal. When the field is set, components use the specified groups;
+  when absent, they fall back to the TLS implementation's defaults. When the
+  feature gate is not enabled, the API server will not persist the field, so it
+  will never be set — components therefore continue behaving exactly as they do
+  today without any feature-gate awareness.
 
 ### Topology Considerations
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -85,19 +85,46 @@ section for details.
 
 ### Workflow Description
 
-Administrators will use the [existing custom TLS security profile flow](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/tls-security-profiles#tls-profiles-ingress-configuring_tls-security-profiles)
-for setting the supported groups.
+Administrators configure TLS groups cluster-wide via the `apiserver.config.openshift.io/cluster`
+object, which serves as the global default for all cluster components (subject to
+the `tlsAdherence` setting described in the
+[centralized TLS config enhancement](centralized-tls-config.md)):
 
-Specifically administrators will use
+```bash
+oc edit apiserver cluster
+```
 
-`oc edit IngressController default -n openshift-ingress-operator`
+```yaml
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  tlsSecurityProfile:
+    type: Custom
+    custom:
+      ciphers:
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      minTLSVersion: VersionTLS12
+      groups:
+      - X25519MLKEM768
+      - X25519
+```
 
-and edit the spec.tlsSecurityProfile field:
+Component-specific objects can be used to override the cluster-wide default
+for individual components. For example, to override the groups on the ingress
+controller only:
+
+```bash
+oc edit IngressController default -n openshift-ingress-operator
+```
 
 ```yaml
 apiVersion: operator.openshift.io/v1
 kind: IngressController
- ...
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
 spec:
   tlsSecurityProfile:
     type: Custom
@@ -107,8 +134,10 @@ spec:
       minTLSVersion: VersionTLS13
       groups:
       - X25519MLKEM768
- ...
 ```
+
+See the [Component Configuration Consumption](#component-configuration-consumption)
+section for the full list of configuration sources and their precedence.
 
 ### API Extensions
 
@@ -117,17 +146,65 @@ spec:
 - The field is gated behind the `TLSCurvePreferences` feature gate, enabled in
   `DevPreviewNoUpgrade` and `TechPreviewNoUpgrade` tiers
 - The addition of this field should not affect existing API behaviour
+- **Component implementors do not need to check for the feature gate.** Because
+  the field is optional (`+optional`, `omitempty`), components need only inspect
+  the field's value when unmarshaling the TLS security profile. When the feature
+  gate is disabled the field will never be set, so components will continue
+  using the TLS implementation's defaults transparently. When the field is
+  present, components use the specified groups; when absent, they fall back to
+  defaults. This mirrors the approach used for `tlsAdherence` in
+  [openshift/api#2583](https://github.com/openshift/api/pull/2583).
 
 ### Topology Considerations
 
 #### Hypershift / Hosted Control Planes
 
-Hypershift [does not currently consume custom TLS supported groups](https://github.com/openshift/hypershift/blob/6b0338c192c966a9c072bfc6af45202739e9e553/support/config/cipher.go#L30).
-However, this is planned in the future.
+For HyperShift deployments, the TLS security profile for hosted control plane
+components is determined by the **management cluster**, not the hosted cluster.
+Hosted cluster administrators should not control TLS groups for components
+running in the provider's domain.
+
+HyperShift's control-plane-operator (CPO) directly manages a set of control
+plane components that, in standalone clusters, are managed through the normal
+SLO/operand chain. These components fall into three categories, each requiring
+a different mechanism for consuming TLS group configuration:
+
+**Category 1 — HyperShift-aware SLOs:**
+
+In standalone clusters, these operators watch `apiserver.config.openshift.io/cluster`
+and configure their operands. In HyperShift, these SLOs are run directly by the
+CPO and have access to the management cluster's KAS. They should read the TLS
+profile (including `groups`) from the `HostedCluster` CR spec in the management
+KAS rather than from `apiserver.config.openshift.io/cluster` in the hosted
+cluster's KAS.
+
+**Category 2 — Operands of SLOs (most components):**
+
+In standalone clusters, these components are configured by their SLO via
+command-line flags or environment variables. In HyperShift, the CPO replaces
+the SLO's role and must directly set the TLS-related flags and environment
+variables on their pod specs, including any group configuration derived from
+the `HostedCluster` CR.
+
+**Category 3 — Self-configuring components:**
+
+In standalone clusters, these components watch `apiserver.config.openshift.io/cluster`
+and configure their own TLS servers directly. In HyperShift, such components
+may be watching the wrong config object (the hosted cluster's rather than the
+management cluster's). These components should accept CLI flags for TLS
+settings that take precedence over the watched config object. The CPO sets
+these flags when deploying the component.
+
+This categorization mirrors the approach described in the
+[centralized TLS config enhancement](centralized-tls-config.md#hypershift--hosted-control-planes).
 
 #### Standalone Clusters
 
-N/A
+This is the primary target for this enhancement. Standalone clusters benefit
+directly from the ability to configure TLS groups cluster-wide via
+`apiserver.config.openshift.io/cluster`. Operators that already watch this
+object for TLS profile changes will be updated to read the new `groups` field
+and pass it through to their respective components.
 
 #### Single-node Deployments or MicroShift
 
@@ -150,9 +227,16 @@ based on their operational context:
 - Read TLS configuration from `apiserver.config.openshift.io/cluster`
 - Component operators watch this object and regenerate configuration when it
   changes
-- Example: The kube-apiserver operator reads the `tlsSecurityProfile` field and
-  passes the groups to the kube-apiserver via command-line flags or
-  configuration files
+- When `tlsAdherence: StrictAllComponents` is set, all components must honor
+  the `groups` field from this object. When `tlsAdherence` is unset or
+  `LegacyAdheringComponentsOnly`, only components that already honor the
+  cluster-wide TLS profile are required to do so
+- Component implementors should use the `ShouldHonorClusterTLSProfile` helper
+  function from library-go (rather than checking `tlsAdherence` values
+  directly) to determine whether to apply the configured groups
+- Example: The kube-apiserver operator reads the `tlsSecurityProfile` field
+  (including `groups`) and passes the configuration to the kube-apiserver via
+  command-line flags or configuration files
 
 **2. Kubelet Configuration**
 
@@ -212,8 +296,14 @@ based on their operational context:
 For operators managing components that need to respect TLS configuration:
 
 1. **Watch** the appropriate configuration source:
-   - `apiserver.config.openshift.io/cluster` for control plane components
+   - `apiserver.config.openshift.io/cluster` — the cluster-wide default for all
+     components when `tlsAdherence: StrictAllComponents` is set, or for
+     legacy-adhering components when `tlsAdherence` is unset or
+     `LegacyAdheringComponentsOnly`
    - Component-specific operator CRs (IngressController, KubeletConfig, etc.)
+     when a per-component override is needed
+   - `HostedCluster` CR in the management KAS — for HyperShift-aware SLOs
+     running in HyperShift (Category 1 components)
 
 2. **Extract** the `tlsSecurityProfile` including the `groups` field
 
@@ -260,6 +350,14 @@ Components running in FIPS mode must omit these groups. The FIPS-approved
 post-quantum alternatives (`SecP256r1MLKEM768`, `SecP384r1MLKEM1024`) require
 Go 1.26+ and are not currently supported.
 
+**Library-go update:** To support these defaults, the `TLSProfiles` mapping in
+[library-go](https://github.com/openshift/library-go) will be updated to include
+the `groups` field for each named profile. Operators and components that
+currently use the library-go `TLSProfiles` mapping to build their `tls.Config`
+will automatically pick up the new group defaults after updating their
+library-go dependency. Component owners must ensure their library-go version
+includes this update as part of the GA promotion work.
+
 #### Mismatching groups and ciphersuites
 
 There is a case where the administrator could incorrectly specify a set of
@@ -274,7 +372,10 @@ To avoid this scenario, OpenShift should implement validation to prevent known
 invalid combinations. A validation layer will be added to check for compatible
 combinations of groups and ciphersuites. If a known invalid combination is
 detected, the configuration will be rejected, informing the user of the
-incompatibility immediately rather than failing at runtime.
+incompatibility immediately rather than failing at runtime. This validation
+will be implemented as CEL validation expressions on the CRD, consistent with
+the approach used for TLS 1.3 cipher validation described in the
+[centralized TLS config enhancement](centralized-tls-config.md).
 
 #### Handling unsupported groups in custom profiles
 
@@ -294,17 +395,24 @@ handshakes will fail with errors like "handshake failure" (for cipher suites)
 or "no shared group" (for groups). This is the expected and desired
 behavior — it ensures only supported cryptographic parameters are used.
 
-**Why not validate at API level:**
-Validating group support at the API level would require maintaining a
-comprehensive registry of:
+**API-level validation against the IANA registry:**
+Rather than foregoing all API-level validation, group names will be validated
+against the [IANA TLS Supported Groups registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8).
+This approach provides a meaningful improvement over completely unvalidated
+strings while avoiding the infeasible task of tracking per-library support
+matrices:
 
-- All TLS implementation libraries used across OpenShift components
-- Version-specific support matrices for each library
-- Continuous updates as libraries evolve
+- Group names not present in the IANA registry are rejected at the API level,
+  providing immediate feedback for clearly invalid values
+- Group names that are valid per the IANA registry but unsupported by a
+  specific component version still produce runtime errors — this is the
+  expected "use at your own risk" behavior for custom profiles
+- Automation (a periodic job or CI check) queries the IANA registry and updates
+  the CEL allowlist in the CRD to keep it current as new groups are
+  standardized
 
-This approach is infeasible and would create a maintenance burden that
-outweighs the benefit. Runtime failures provide clear, immediate feedback about
-incompatibilities.
+This is strictly an improvement over completely unvalidated strings and avoids
+the maintenance burden of a per-library, version-specific support matrix.
 
 **Recommended approach:**
 

--- a/enhancements/security/api-tls-curves-config.md
+++ b/enhancements/security/api-tls-curves-config.md
@@ -39,6 +39,11 @@ As an administrator, I want to explicitly set the supported TLS groups to ensure
 PQC readiness throughout OpenShift so that I can ensure the security of TLS
 communication in the era of quantum computing.
 
+As an administrator, I want to rely on default TLS groups and default TLS
+security profiles without explicitly configuring supported groups, so that my
+cluster continues to work securely out of the box without requiring manual TLS
+configuration.
+
 ### Goals
 
 To provide an interface that allows the setting of TLS groups to be used cluster
@@ -111,6 +116,11 @@ spec:
       - X25519
 ```
 
+In the example above, the APIServer configures the `tlsSecurityProfile` to use
+TLS v1.2 or higher, with one cipher (`ECDHE-ECDSA-AES128-GCM-SHA256`), and two
+supported groups (`X25519MLKEM768` and `X25519`) for key exchange.
+`X25519MLKEM768` is preferred over `X25519` due to the ordering.
+
 Component-specific objects can be used to override the cluster-wide default
 for individual components. For example, to override the groups on the ingress
 controller only:
@@ -135,6 +145,10 @@ spec:
       groups:
       - X25519MLKEM768
 ```
+
+In the example above, the Ingress Controller can restrict traffic to use TLS
+v1.3 only, with one cipher (`ECDHE-RSA-CHACHA20-POLY1305`), and one supported
+group (`X25519MLKEM768`) for key exchange.
 
 See the [Component Configuration Consumption](#component-configuration-consumption)
 section for the full list of configuration sources and their precedence.


### PR DESCRIPTION
Adds an enhancement request for the addition of a `curves` field in the TLS profile spec of the OpenShift API config.