### PR TITLE
MG-155: Proposal to add custom must-gather image option in MustGather Spec.

### DIFF
--- a/enhancements/support-log-gather/must-gather-custom-images.md
+++ b/enhancements/support-log-gather/must-gather-custom-images.md
@@ -17,7 +17,7 @@ tracking-link:
   - https://issues.redhat.com/browse/MG-155
 ---
 
-# Enhancement Proposal: Custom Must-Gather Images
+# Custom must-gather Images for Support Log Gather operator
 
 ## Release Signoff Checklist
 

--- a/enhancements/support-log-gather/must-gather-custom-images.md
+++ b/enhancements/support-log-gather/must-gather-custom-images.md
@@ -1,0 +1,251 @@
+---
+title: must-gather-custom-images
+authors:
+  - "@shivprakashmuley"
+reviewers:
+  - "@TrilokGeer"
+  - "@Prashanth684"
+approvers:
+  - "@TrilokGeer"
+  - "@Prashanth684"
+api-approvers:
+  - "@TrilokGeer"
+  - "@Prashanth684"
+creation-date: 2025-12-11
+last-updated: 2025-12-11
+tracking-link:
+  - https://issues.redhat.com/browse/MG-155
+
+---
+
+# Enhancement Proposal: Custom Must-Gather Images
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in `openshift-docs`
+
+## Summary
+
+This proposal outlines a plan to enhance the must-gather-operator to support the use of custom must-gather images. A new cluster-scoped Custom Resource, `MustGatherImage`, will be introduced to define a list of allowed custom images that cluster administrators can manage. The existing `MustGather` Custom Resource will be updated with an optional `mustGatherImage` field, allowing users to select an image from the allowed list when triggering a must-gather execution.
+
+## Motivation
+
+The default must-gather image provides a broad set of diagnostic data for the OpenShift platform. However, there are scenarios where users and support teams require more specialized data collection that is not included in the default image. This can include:
+
+-   Running diagnostic scripts for specific applications or layered products.
+
+-   Gathering information from third-party operators or custom infrastructure components.
+
+-   Using a pre-release or patched version of the must-gather tooling for debugging purposes without waiting for an official release.
+
+Currently, there is no secure or manageable way to use a custom must-gather image. This proposal aims to provide a secure and Kubernetes-native mechanism for this purpose, giving administrators clear control over which images are permitted to run with elevated privileges in their clusters.
+
+## Goals
+
+1.  Introduce a new `MustGatherImage` CRD to act as a centrally managed allowlist for custom must-gather images.
+
+2.  Modify the `MustGather` CRD to allow users to specify a custom image for the must-gather job.
+
+3.  Update the must-gather-operator to validate any specified custom image against the `MustGatherImage` allowlist.
+
+4.  If the custom image is valid, the operator will use it to run the must-gather job.
+
+5.  If the custom image is invalid or the allowlist does not exist, the `MustGather` resource will report a failure.
+
+6.  Ensure that if no custom image is specified, the operator continues to use the default must-gather image.
+
+## Non-Goals
+
+1.  This proposal does not cover the process of building, hosting, or distributing custom must-gather images.
+
+2.  It will not provide a mechanism for automatically updating or managing the lifecycle of the custom images themselves.
+
+3.  It will not alter the content or scripts within the default must-gather image.
+
+## Proposal
+
+### 1. API Changes
+
+#### 1.1 New `MustGatherImage` CRD
+
+A new cluster-scoped Custom Resource Definition `MustGatherImage` will be created. This resource will serve as the allowlist for all custom must-gather images that can be used in the cluster. Only privileged users (like cluster-admins) should have permission to create and modify this resource.
+
+**Example `MustGatherImage` manifest:**
+
+```yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: MustGatherImage
+metadata:
+  # The name is fixed to 'cluster' to provide a single, cluster-wide source of truth.
+  name: cluster
+spec:
+  images:
+  - quay.io/my-org/my-custom-must-gather:latest
+  - registry.example.com/team-a/debug-must-gather:v1.2
+```
+
+The Go definition for this CRD will be created in `must-gather-operator/api/v1alpha1/mustgatherimage_types.go`:
+
+```go
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster,shortName=mgi
+// +kubebuilder:subresource:status
+
+// MustGatherImage is the Schema for the mustgatherimages API.
+type MustGatherImage struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   MustGatherImageSpec   `json:"spec,omitempty"`
+	Status MustGatherImageStatus `json:"status,omitempty"`
+}
+
+// MustGatherImageSpec defines the desired state of MustGatherImage.
+type MustGatherImageSpec struct {
+	// Images is a list of fully qualified container image references that are
+	// allowed to be used as a custom must-gather image.
+	// +kubebuilder:validation:Required
+	// +listType=set
+	Images []string `json:"images"`
+}
+
+// MustGatherImageStatus defines the observed state of MustGatherImage.
+type MustGatherImageStatus struct{}
+
+// +kubebuilder:object:root=true
+
+// MustGatherImageList contains a list of MustGatherImage.
+type MustGatherImageList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []MustGatherImage `json:"items"`
+}
+```
+
+#### 1.2 `MustGather` CRD Modification
+
+The `MustGatherSpec` in `must-gather-operator/api/v1alpha1/mustgather_types.go` will be updated to include an optional `mustGatherImage` field. This is in addition to other existing and proposed fields like `storage` for PVC destination and `uploadTarget` for extensible artifact uploading.
+
+```go
+// MustGatherSpec defines the desired state of MustGather
+type MustGatherSpec struct {
+	// the service account to use to run the must gather job pod, defaults to default
+	// +optional
+	ServiceAccountRef corev1.LocalObjectReference `json:"serviceAccountRef,omitempty"`
+
+	// MustGatherImage allows specifying a custom must-gather image.
+	// The image must be listed in the 'cluster' MustGatherImage resource to be accepted.
+	// If not specified, the operator's default must-gather image will be used.
+	// +kubebuilder:validation:Optional
+	MustGatherImage string `json:"mustGatherImage,omitempty"`
+
+	// additionalConfig contains extra parameters used to customize the gather process,
+	// currently enabling audit logs is the only supported field.
+	// +optional
+	AdditionalConfig *AdditionalConfig `json:"additionalConfig,omitempty"`
+
+	// This represents the proxy configuration to be used. If left empty it will default to the cluster-level proxy configuration.
+	// +optional
+	ProxyConfig ProxySpec `json:"proxyConfig,omitempty"`
+
+	// A time limit for gather command to complete a floating point number with a suffix:
+	// "s" for seconds, "m" for minutes, "h" for hours, or "d" for days.
+	// Will default to no time limit.
+	// +optional
+	// +kubebuilder:validation:Format=duration
+	MustGatherTimeout metav1.Duration `json:"mustGatherTimeout,omitempty"`
+
+	// A flag to specify if resources (secret, job, pods) should be retained when the MustGather completes.
+	// If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
+	// +optional
+	// +kubebuilder:default:=false
+	RetainResourcesOnCompletion bool `json:"retainResourcesOnCompletion,omitempty"`
+
+	// uploadTarget sets the target config for uploading the collected must-gather tar.
+	// Uploading is disabled if this field is unset.
+	// +optional
+	UploadTarget *UploadTarget `json:"uploadTarget,omitempty"`
+
+	// storage represents the volume where collected must-gather tar
+	// is persisted. Persistent storage is disabled if this field is unset,
+	// an ephemeral volume will be used.
+	// +optional
+	Storage *StorageConfig `json:"storage,omitempty"`
+}
+```
+
+### 2. Operator Logic Changes
+
+The `MustGatherReconciler` in `controllers/mustgather/mustgather_controller.go` will be updated to handle the new logic.
+
+The image selection logic in the `getJobFromInstance` function will be modified as follows:
+
+1.  Check if `instance.Spec.MustGatherImage` is set.
+
+2.  **If it is not set**, the logic proceeds as it does today, using the default `OPERATOR_IMAGE`.
+
+3.  **If it is set**, the controller will:
+
+    a.  Fetch the `MustGatherImage` resource with the name `cluster`.
+
+    b.  If the `cluster` resource is not found, the reconciliation will fail, and the `MustGather` status will be updated with an error indicating the allowlist is not configured.
+
+    c.  If the resource is found, the controller will check if the image specified in `spec.mustGatherImage` is present in the `spec.images` list.
+
+    d.  If the image is **not** in the list, the reconciliation will fail, and the `MustGather` status will be updated with an `InvalidImage` error.
+
+    e.  If the image **is** in the list, the controller will use this image string when calling `getJobTemplate` to construct the must-gather job, overriding the default image.
+
+### 3. RBAC Changes
+
+The operator's ClusterRole will need to be updated in `deploy/` to grant `get`, `list`, and `watch` permissions on the `mustgatherimages` resource at the cluster scope.
+
+```yaml
+# deploy/02_must-gather-operator.ClusterRole.yaml
+# ... existing rules ...
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - mustgatherimages
+  verbs:
+  - get
+  - list
+  - watch
+```
+
+Additionally, a new `ClusterRole` will be beneficial for administrators to manage the allowlist.
+
+```yaml
+# deploy/new_must-gather-image-admin.ClusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: must-gather-image-admin
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - mustgatherimages
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+```
+
+## Alternatives Considered
+
+A `ConfigMap` could have been used to store the list of allowed images. However, a CRD was chosen because it provides a more robust, Kubernetes-native solution with schema validation, RBAC integration, and better discoverability. This approach aligns with the operator pattern of extending the Kubernetes API to manage application configuration and provides a clearer audit trail.

--- a/enhancements/support-log-gather/must-gather-custom-images.md
+++ b/enhancements/support-log-gather/must-gather-custom-images.md
@@ -30,7 +30,9 @@ tracking-link:
 
 ## Summary
 
-This proposal outlines a plan to enhance the must-gather-operator to support the use of custom must-gather images. A new cluster-scoped Custom Resource, `MustGatherImage`, will be introduced to define a list of allowed custom images that cluster administrators can manage. The existing `MustGather` Custom Resource will be updated with an optional `mustGatherImage` field, allowing users to select an image from the allowed list when triggering a must-gather execution.
+This proposal outlines a plan to enhance the must-gather-operator with a secure and reliable framework for using custom must-gather images. This is achieved by introducing a new cluster-scoped `MustGatherImage` Custom Resource (CR) that serves as a centrally managed registry of approved custom images and their required permissions.
+
+The design introduces two core concepts: a permission model based on references to pre-existing `Roles` or `ClusterRoles` (`RoleRef`), and an asynchronous image verification system. The operator will create ephemeral, single-use `ServiceAccounts` for each job, binding them only to the pre-approved roles. It will also continuously verify that images in the allowlist are pullable and report their status. This ensures that custom diagnostics are run with the principle of least privilege and are reliable.
 
 ## Motivation
 
@@ -40,12 +42,13 @@ The default must-gather image provides a broad set of diagnostic data for the Op
 -   Gathering information from third-party operators or custom infrastructure components.
 -   Using a pre-release or patched version of the must-gather tooling for debugging purposes without waiting for an official release.
 
-Currently, there is no secure or manageable way to use a custom must-gather image. This proposal aims to provide a secure and Kubernetes-native mechanism for this purpose, giving administrators clear control over which images are permitted to run with elevated privileges in their clusters.
+Currently, there is no secure or manageable way to use a custom image. This proposal aims to provide a secure and Kubernetes-native mechanism for this purpose, giving administrators clear control over which images are permitted to run with elevated privileges in their clusters.
 
 ### User Stories
 
-- As a cluster administrator, I want to define a list of approved custom must-gather images to ensure that only trusted images are used for diagnostics.
-- As a support engineer, I want to use a custom must-gather image with specialized tools to debug a specific issue without needing to modify the cluster's default must-gather image.
+- As a cluster administrator, I want to define a list of approved custom must-gather images and bind each one to a specific, narrowly-scoped `Role` or `ClusterRole` to ensure it runs with the principle of least privilege.
+- As a support engineer, I want to request a must-gather run using a pre-approved custom image, knowing that its permissions are strictly managed and its source is verified.
+- As an administrator, I want to see the status of all configured custom images to know ahead of time if an image is unpullable due to a typo or deletion from the registry.
 - As a developer, I want to test a new version of our product's diagnostic scripts by running it as a custom must-gather image in a development cluster.
 
 ### Goals
@@ -56,82 +59,89 @@ Currently, there is no secure or manageable way to use a custom must-gather imag
 - If the custom image is valid, the operator will use it to run the must-gather job.
 - If the custom image is invalid or the allowlist does not exist, the `MustGather` resource will report a failure.
 - Ensure that if no custom image is specified, the operator continues to use the default must-gather image.
+- Implement a secure, reference-based permission model (`RoleRef`) supporting both namespaced `Roles` and `ClusterRoles` to prevent privilege escalation.
+- Ensure each must-gather job runs with an ephemeral, single-purpose `ServiceAccount` to guarantee strict privilege and lifecycle isolation.
+- Introduce an asynchronous image verification mechanism to ensure all allowlisted images are valid and pullable.
+- Provide clear status and observability into the health of the custom image allowlist via the `MustGatherImage` status subresource.
 
 ### Non-Goals
 
 - This proposal does not cover the process of building, hosting, or distributing custom must-gather images.
-- It will not provide a mechanism for automatically updating or managing the lifecycle of the custom images themselves.
+- It will not provide a mechanism for automatically updating or managing the lifecycle of the custom images themselves beyond status reporting.
 - It will not alter the content or scripts within the default must-gather image.
 
 ## Proposal
 
 ### Workflow Description
 
-1.  A cluster administrator defines a `MustGatherImage` resource named `cluster`, which contains a list of approved custom must-gather image URLs.
-2.  A user creates a `MustGather` resource and specifies an image from the allowlist in the `spec.mustGatherImage` field.
-3.  The must-gather-operator reconciles the `MustGather` resource.
-4.  The operator fetches the `MustGatherImage` resource named `cluster`.
-5.  It validates that the image specified in the `MustGather` resource is present in the `MustGatherImage` resource's list.
-6.  If the image is valid, the operator creates a must-gather job using the custom image.
-7.  If the image is not valid, or if the `MustGatherImage` resource does not exist, the operator updates the `MustGather` resource's status with an error and does not create the job.
+The workflow is divided into two main parts: the one-time administrative setup and the recurring user request flow.
+
+**Part 1: Administrative Configuration**
+
+1.  **Create Roles:** A cluster-admin first creates the `Roles` (for namespaced diagnostics) or `ClusterRoles` (for cluster-wide diagnostics) that contain the minimal permissions required for a specific diagnostic task.
+2.  **Define Allowlist:** The admin creates a single `MustGatherImage` resource named `cluster`. In its spec, they define a list of "security contracts," where each entry pairs a custom image URL with a `roleRef` pointing to one of the pre-created roles.
+3.  **Automatic Verification:** The must-gather-operator detects the `MustGatherImage` resource and begins an asynchronous loop. It continuously checks each image in the list to ensure it is pullable, updating the `status` subresource of the `MustGatherImage` CR with `Verified` or `Failed` for each image.
+
+**Part 2: User Request and Operator Execution**
+
+1.  **User Request:** A user creates a `MustGather` CR in a specific namespace, setting the `spec.mustGatherImage` field to an image from the admin's allowlist.
+2.  **Operator Validation:** The operator validates the request by checking the `MustGatherImage.status` to ensure the requested image is marked as `Verified`.
+3.  **Secure Execution:** If valid, the operator creates an ephemeral `ServiceAccount` and binds it to the corresponding `Role` or `ClusterRole`. It then creates the Kubernetes `Job` using this temporary ServiceAccount and the specified image.
+4.  **Cleanup:** Once the job completes, the operator deletes the job and all associated ephemeral resources (`ServiceAccount`, `RoleBinding`/`ClusterRoleBinding`).
 
 ### API Extensions
 
-#### New `MustGatherImage` CRD
-
-A new cluster-scoped Custom Resource Definition `MustGatherImage` will be created. This resource will serve as the allowlist for all custom must-gather images that can be used in the cluster. Only privileged users (like cluster-admins) should have permission to create and modify this resource.
-
-**Example `MustGatherImage` manifest:**
-
-```yaml
-apiVersion: operator.openshift.io/v1alpha1
-kind: MustGatherImage
-metadata:
-  # The name is fixed to 'cluster' to provide a single, cluster-wide source of truth.
-  name: cluster
-spec:
-  images:
-  - quay.io/my-org/my-custom-must-gather:latest
-  - registry.example.com/team-a/debug-must-gather:v1.2
-```
-
-The Go definition for this CRD will be created in `must-gather-operator/api/v1alpha1/mustgatherimage_types.go`:
+#### `MustGatherImage` CRD
 
 ```go
 package v1alpha1
 
 import (
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=mgi
 // +kubebuilder:subresource:status
-
-// MustGatherImage is the Schema for the mustgatherimages API.
 type MustGatherImage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
 	Spec   MustGatherImageSpec   `json:"spec,omitempty"`
 	Status MustGatherImageStatus `json:"status,omitempty"`
 }
 
-// MustGatherImageSpec defines the desired state of MustGatherImage.
 type MustGatherImageSpec struct {
-	// Images is a list of fully qualified container image references that are
-	// allowed to be used as a custom must-gather image.
-	// +kubebuilder:validation:Required
-	// +listType=set
-	Images []string `json:"images"`
+	// +listType=map
+	// +listMapKey=image
+	Images []CustomMustGatherImage `json:"images"`
 }
 
-// MustGatherImageStatus defines the observed state of MustGatherImage.
-type MustGatherImageStatus struct{}
+type CustomMustGatherImage struct {
+	// +kubebuilder:validation:Required
+	Image string `json:"image"`
+	// +kubebuilder:validation:Required
+	RoleRef rbacv1.RoleRef `json:"roleRef"`
+}
+
+type MustGatherImageStatus struct {
+	// +optional
+	// +listType=map
+	// +listMapKey=image
+	VerifiedImages []ImageVerificationStatus `json:"verifiedImages,omitempty"`
+}
+
+type ImageVerificationStatus struct {
+	// +kubebuilder:validation:Required
+	Image string `json:"image"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Verified;Failed;Pending
+	State string `json:"state"`
+	// +optional
+	Reason string `json:"reason,omitempty"`
+}
 
 // +kubebuilder:object:root=true
-
-// MustGatherImageList contains a list of MustGatherImage.
 type MustGatherImageList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -141,62 +151,22 @@ type MustGatherImageList struct {
 
 #### `MustGather` CRD Modification
 
-The `MustGatherSpec` in `must-gather-operator/api/v1alpha1/mustgather_types.go` will be updated to include an optional `mustGatherImage` field. This is in addition to other existing and proposed fields like `storage` for PVC destination and `uploadTarget` for extensible artifact uploading.
-
 ```go
-// MustGatherSpec defines the desired state of MustGather
 type MustGatherSpec struct {
-	// the service account to use to run the must gather job pod, defaults to default
-	// +optional
-	ServiceAccountRef corev1.LocalObjectReference `json:"serviceAccountRef,omitempty"`
-
-	// MustGatherImage allows specifying a custom must-gather image.
-	// The image must be listed in the 'cluster' MustGatherImage resource to be accepted.
-	// If not specified, the operator's default must-gather image will be used.
+	// ... existing fields ...
 	// +kubebuilder:validation:Optional
 	MustGatherImage string `json:"mustGatherImage,omitempty"`
-
-	// additionalConfig contains extra parameters used to customize the gather process,
-	// currently enabling audit logs is the only supported field.
-	// +optional
-	AdditionalConfig *AdditionalConfig `json:"additionalConfig,omitempty"`
-
-	// This represents the proxy configuration to be used. If left empty it will default to the cluster-level proxy configuration.
-	// +optional
-	ProxyConfig ProxySpec `json:"proxyConfig,omitempty"`
-
-	// A time limit for gather command to complete a floating point number with a suffix:
-	// "s" for seconds, "m" for minutes, "h" for hours, or "d" for days.
-	// Will default to no time limit.
-	// +optional
-	// +kubebuilder:validation:Format=duration
-	MustGatherTimeout metav1.Duration `json:"mustGatherTimeout,omitempty"`
-
-	// A flag to specify if resources (secret, job, pods) should be retained when the MustGather completes.
-	// If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
-	// +optional
-	// +kubebuilder:default:=false
-	RetainResourcesOnCompletion bool `json:"retainResourcesOnCompletion,omitempty"`
-
-	// uploadTarget sets the target config for uploading the collected must-gather tar.
-	// Uploading is disabled if this field is unset.
-	// +optional
-	UploadTarget *UploadTarget `json:"uploadTarget,omitempty"`
-
-	// storage represents the volume where collected must-gather tar
-	// is persisted. Persistent storage is disabled if this field is unset,
-	// an ephemeral volume will be used.
-	// +optional
-	Storage *StorageConfig `json:"storage,omitempty"`
+	// ... existing fields ...
 }
 ```
 
 ### Topology Considerations
 
-This enhancement does not introduce any unique topological considerations. The must-gather-operator and the custom must-gather images are expected to run on any supported OpenShift topology.
+This enhancement does not introduce any unique topological considerations and is expected to function identically across all supported OpenShift topologies.
 
 #### Hypershift / Hosted Control Planes
 
+No unique considerations. The operator runs in the guest cluster and performs all its functions there.
 
 #### Standalone Clusters
 
@@ -204,32 +174,38 @@ This enhancement does not introduce any unique topological considerations. The m
 #### Single-node Deployments or MicroShift
 
 
+
 ### Implementation Details/Notes/Constraints
 
--   The `MustGatherImage` resource will be named `cluster` to ensure a single source of truth for the allowlist.
--   The operator will require RBAC permissions to `get`, `list`, and `watch` the `mustgatherimages` resource at the cluster scope.
--   The operator's logic will be updated to fetch the `MustGatherImage` resource and validate the custom image specified in the `MustGather` CR.
--   If the `MustGatherImage` resource is not found, or if the specified image is not in the allowlist, the `MustGather` resource's status will be updated with an appropriate error condition.
+-   The `MustGatherImage` resource must be named `cluster` to serve as the single source of truth.
+-   The operator will require cluster-level RBAC to `get/list/watch` `MustGatherImage` resources and to create `ClusterRoleBindings`.
+-   The image verification loop will utilize the cluster's global pull secret to authenticate to private container registries.
+-   Failures during the process (e.g., image not verified, role not found) will be reported as conditions in the `MustGather` resource's status.
 
 ### Risks and Mitigations
 
--   **Risk:** A misconfigured `MustGatherImage` resource could prevent all must-gather runs that use custom images.
-    -   **Mitigation:** The operator will provide clear status conditions and events on the `MustGather` resource to indicate the reason for failure. Documentation will emphasize the importance of correctly configuring the `MustGatherImage` resource.
+-   **Risk:** Operator has excessive permissions to create arbitrary roles.
+    -   **Mitigation:** The `RoleRef` model prevents this. The operator only creates `RoleBindings` to roles pre-approved by an admin.
+-   **Risk:** A privileged `ServiceAccount` is left behind after a job.
+    -   **Mitigation:** The `ServiceAccount` is ephemeral and garbage collected by the operator upon job completion.
+-   **Risk:** An administrator misconfigures an image URL or a role.
+    -   **Mitigation:** Image pull errors are made visible by the async verification status. Role binding errors are reported on the `MustGather` CR.
 
 ### Drawbacks
 
--   This enhancement introduces a new CRD that cluster administrators must manage.
--   Users must be aware of the `MustGatherImage` resource and the allowed images when creating a `MustGather` resource with a custom image.
+-   The feature introduces additional complexity for cluster administrators, who are now responsible for creating and managing roles and the `MustGatherImage` allowlist.
 
 ## Test Plan
 
 -   **Unit Tests:**
-    -   Test the validation logic for the `MustGatherImage` CRD.
-    -   Test the operator's logic for fetching the `MustGatherImage` resource and validating the custom image.
+    -   Test the reconciler logic for the `MustGatherImage` resource, including the image verification loop.
+    -   Test the `MustGather` reconciler logic for validating a custom image request and creating ephemeral resources (`ServiceAccount`, bindings, `Job`).
 -   **E2E Tests:**
-    -   Test the successful creation of a must-gather job with a custom image from the allowlist.
-    -   Test the failure of a must-gather job with a custom image that is not in the allowlist.
-    -   Test the failure of a must-gather job when the `MustGatherImage` resource does not exist and if the custom-image is specified, otherwise run must-gather job with default image.
+    -   Verify the full workflow for a valid custom image with a `ClusterRole`.
+    -   Verify the full workflow for a valid custom image with a namespaced `Role`.
+    -   Verify that a request for an unlisted image fails with an appropriate status condition.
+    -   Verify that a request for a listed but unpullable (failed verification) image fails.
+    -   Verify that after a job completes, the ephemeral `ServiceAccount` and bindings are deleted.
 
 ## Graduation Criteria
 
@@ -237,11 +213,12 @@ This enhancement does not introduce any unique topological considerations. The m
 
 -   Ability to utilize the enhancement end-to-end.
 -   End-user documentation and API stability.
--   Sufficient test coverage.
+-   Sufficient test coverage (unit and E2E).
+-   Gather feedback from early adopters.
 
 ### Tech Preview -> GA
 
--   More testing, including upgrade and scale scenarios.
+-   More extensive testing, including upgrade and scale scenarios.
 -   Sufficient time for user feedback and adoption.
 -   User-facing documentation created in [openshift-docs](https://github.com/openshift/openshift-docs/).
 
@@ -251,21 +228,72 @@ Not applicable.
 
 ## Upgrade / Downgrade Strategy
 
--   This change is backward compatible. Existing `MustGather` resources that do not have the `mustGatherImage` field will continue to work as before.
--   On downgrade, the `mustGatherImage` field will be ignored by older operators.
+-   **Upgrade:** This is a backward-compatible change. Existing `MustGather` resources without the `mustGatherImage` field will continue to function as before. The new `MustGatherImage` CRD will be created upon upgrade.
+-   **Downgrade:** On downgrade, the `MustGatherImage` CRD will remain, but the older operator will not be aware of it. Any `MustGather` resource that specifies a `mustGatherImage` will be ignored by the older operator and will likely fail validation if the field is not recognized.
 
 ## Version Skew Strategy
 
-This enhancement does not introduce any version skew concerns. The change is self-contained within the must-gather-operator and its CRDs.
+This enhancement does not introduce any version skew concerns. The logic is self-contained within the must-gather-operator and its CRDs.
 
 ## Operational Aspects of API Extensions
 
-The `MustGatherImage` CRD is the main API extension. The operator will manage its lifecycle. Failure to find the `MustGatherImage` resource or an invalid image will be surfaced as status conditions on the `MustGather` resource.
+The primary API extension is the `MustGatherImage` CRD. Its operational status is exposed via its `status` subresource. Cluster administrators are responsible for its lifecycle. Failure modes, such as an unpullable image, are surfaced directly in this status, making the system's configuration health easily observable.
 
 ## Support Procedures
 
-If a `must-gather` run with a custom image fails, support personnel should first inspect the `MustGather` resource's status and events to check for image-related errors (e.g., `InvalidImage`, `AllowlistNotConfigured`). If the image is valid, standard `must-gather` debugging procedures apply.
+If a `must-gather` run with a custom image fails, support personnel should first inspect the `MustGather` resource's status and events to check for errors. If the error is related to image verification or permissions, they should then inspect the `MustGatherImage` resource (`oc get mustgatherimage cluster -o yaml`) to verify its configuration and status.
 
 ## Alternatives (Not Implemented)
 
-A `ConfigMap` could have been used to store the list of allowed images. However, a CRD was chosen because it provides a more robust, Kubernetes-native solution with schema validation, RBAC integration, and better discoverability. This approach aligns with the operator pattern of extending the Kubernetes API to manage application configuration and provides a clearer audit trail.
+An alternative design was considered where the operator could be given permissions to create `Roles` dynamically. This was rejected because it would require the operator itself to possess dangerously broad permissions, violating the principle of least privilege. The `RoleRef` model ensures the operator remains a low-privilege component.
+
+### Examples
+
+#### Example 1: Administrator Configuration (`MustGatherImage`)
+
+This example shows a cluster administrator configuring the `cluster` allowlist with two custom images. The first image is for cluster-wide network diagnostics and is bound to a `ClusterRole`. The second is for application-specific diagnostics and is bound to a namespaced `Role`.
+
+```yaml
+# /deploy/examples/must-gather-image-allowlist.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: MustGatherImage
+metadata:
+  # The name is fixed to 'cluster' to provide a single, cluster-wide source of truth.
+  name: cluster
+spec:
+  images:
+  - image: quay.io/my-org/network-debug-tools:v1.2
+    roleRef:
+      apiGroup: rbac.authorization.k-8s.io
+      kind: ClusterRole
+      name: custom-must-gather-network-role # Admin must pre-create this ClusterRole
+  - image: registry.example.com/team-a/app-diagnostics:latest
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: team-a-diagnostics-role # Admin must pre-create this Role in relevant app namespace(s)
+```
+
+#### Example 2: User Request (`MustGather`)
+
+This example shows a user in the `team-a-namespace` namespace requesting a must-gather run using the pre-approved application-specific diagnostic image.
+
+```yaml
+# /deploy/examples/must-gather-with-custom-image.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: my-app-diagnostics-run
+  namespace: team-a-namespace # The namespace where the Role "team-a-diagnostics-role" exists
+spec:
+  # Requesting the custom image for app diagnostics.
+  # The operator will validate this against the 'cluster' MustGatherImage resource.
+  mustGatherImage: registry.example.com/team-a/app-diagnostics:latest
+
+  # Other spec fields, like storage, remain available.
+  storage:
+    type: PersistentVolume
+    persistentVolume:
+      claim:
+        name: my-diagnostics-pvc
+```

--- a/enhancements/support-log-gather/must-gather-custom-images.md
+++ b/enhancements/support-log-gather/must-gather-custom-images.md
@@ -36,11 +36,7 @@ The design introduces two core concepts: a permission model based on references 
 
 ## Motivation
 
-The default must-gather image provides a broad set of diagnostic data for the OpenShift platform. However, there are scenarios where users and support teams require more specialized data collection that is not included in the default image. This can include:
-
--   Running diagnostic scripts for specific applications or layered products.
--   Gathering information from third-party operators or custom infrastructure components.
--   Using a pre-release or patched version of the must-gather tooling for debugging purposes without waiting for an official release.
+The default must-gather image provides a broad set of diagnostic data for the OpenShift platform. However, there are scenarios where users and support teams require more specialized data collection that is not included in the default image.
 
 Currently, there is no secure or manageable way to use a custom image. This proposal aims to provide a secure and Kubernetes-native mechanism for this purpose, giving administrators clear control over which images are permitted to run with elevated privileges in their clusters.
 

--- a/enhancements/support-log-gather/must-gather-custom-images.md
+++ b/enhancements/support-log-gather/must-gather-custom-images.md
@@ -15,7 +15,6 @@ creation-date: 2025-12-11
 last-updated: 2025-12-11
 tracking-link:
   - https://issues.redhat.com/browse/MG-155
-
 ---
 
 # Enhancement Proposal: Custom Must-Gather Images
@@ -30,128 +29,69 @@ tracking-link:
 
 ## Summary
 
-This proposal outlines a plan to enhance the must-gather-operator with a secure and reliable framework for using custom must-gather images. This is achieved by introducing a new cluster-scoped `MustGatherImage` Custom Resource (CR) that serves as a centrally managed registry of approved custom images and their required permissions.
+This proposal outlines a plan to enhance the must-gather-operator to support custom must-gather images by leveraging native OpenShift `ImageStream` resources. This is achieved by requiring administrators to create `ImageStream`s in the must-gather-operator's own namespace, which then serves as a centrally managed allowlist of approved custom images.
 
-The design introduces two core concepts: a permission model based on references to pre-existing `Roles` or `ClusterRoles` (`RoleRef`), and an asynchronous image verification system. The operator will create ephemeral, single-use `ServiceAccounts` for each job, binding them only to the pre-approved roles. It will also continuously verify that images in the allowlist are pullable and report their status. This ensures that custom diagnostics are run with the principle of least privilege and are reliable.
+To enable this, the `MustGather` CRD will be extended with a new `imageStreamTag` field. The operator's role is limited to validating the requested image from the allowlist and using the user-provided `ServiceAccount` to run the must-gather job. The administrator remains fully responsible for all RBAC management.
 
 ## Motivation
 
-The default must-gather image provides a broad set of diagnostic data for the OpenShift platform. However, there are scenarios where users and support teams require more specialized data collection that is not included in the default image.
-
-Currently, there is no secure or manageable way to use a custom image. This proposal aims to provide a secure and Kubernetes-native mechanism for this purpose, giving administrators clear control over which images are permitted to run with elevated privileges in their clusters.
+The default must-gather image provides a broad set of diagnostic data. However, users often require specialized data collection not included in the default image for specific applications or third-party components. This proposal aims to provide a native OpenShift mechanism for using custom images for this purpose.
 
 ### User Stories
 
-- As a cluster administrator, I want to define a list of approved custom must-gather images and bind each one to a specific, narrowly-scoped `Role` or `ClusterRole` to ensure it runs with the principle of least privilege.
-- As a support engineer, I want to request a must-gather run using a pre-approved custom image, knowing that its permissions are strictly managed and its source is verified.
-- As an administrator, I want to see the status of all configured custom images to know ahead of time if an image is unpullable due to a typo or deletion from the registry.
-- As a developer, I want to test a new version of our product's diagnostic scripts by running it as a custom must-gather image in a development cluster.
+- As a cluster administrator, I want to define a list of approved custom must-gather images by creating `ImageStream`s in the operator's namespace.
+- As a cluster administrator, I want to create and manage a set of long-lived `ServiceAccounts` with specific `Roles` or `ClusterRoles` for different diagnostic purposes.
+- As a support engineer, I want to run a must-gather job using a pre-approved custom image by specifying an `ImageStreamTag` and the appropriate, pre-configured `serviceAccountName` for my task.
+- As an administrator, I want to leverage the `ImageStreamTag` import status to know if an allowlisted image has become unpullable.
 
 ### Goals
 
-- Introduce a new `MustGatherImage` CRD to act as a centrally managed allowlist for custom must-gather images.
-- Modify the `MustGather` CRD to allow users to specify a custom image for the must-gather job.
-- Update the must-gather-operator to validate any specified custom image against the `MustGatherImage` allowlist.
-- If the custom image is valid, the operator will use it to run the must-gather job.
-- If the custom image is invalid or the allowlist does not exist, the `MustGather` resource will report a failure.
+- Utilize the OpenShift `ImageStream` resource as a centrally managed allowlist for custom must-gather images.
+- Add a new `imageStreamTag` field to the `MustGather` CRD.
+- Update the must-gather-operator to validate any specified `imageStreamTag` against the allowlisted `ImageStream`s.
+- Leverage the built-in import status of an `ImageStreamTag` to asynchronously verify that an image is valid and pullable.
+- The operator will use the user-provided `serviceAccountName` directly to run the must-gather job.
+- If the `ImageStreamTag` is invalid or the import has failed, the `MustGather` resource will report a failure.
 - Ensure that if no custom image is specified, the operator continues to use the default must-gather image.
-- Implement a secure, reference-based permission model (`RoleRef`) supporting both namespaced `Roles` and `ClusterRoles` to prevent privilege escalation.
-- Ensure each must-gather job runs with an ephemeral, single-purpose `ServiceAccount` to guarantee strict privilege and lifecycle isolation.
-- Introduce an asynchronous image verification mechanism to ensure all allowlisted images are valid and pullable.
-- Provide clear status and observability into the health of the custom image allowlist via the `MustGatherImage` status subresource.
 
 ### Non-Goals
 
 - This proposal does not cover the process of building, hosting, or distributing custom must-gather images.
-- It will not provide a mechanism for automatically updating or managing the lifecycle of the custom images themselves beyond status reporting.
-- It will not alter the content or scripts within the default must-gather image.
+- The operator will not create, manage, or validate any RBAC resources (`Roles`, `ClusterRoles`, `ServiceAccounts`, or bindings). This is the administrator's responsibility.
 
 ## Proposal
 
 ### Workflow Description
 
-The workflow is divided into two main parts: the one-time administrative setup and the recurring user request flow.
+The workflow is divided into two main parts: the administrative setup and the user request flow.
 
 **Part 1: Administrative Configuration**
 
-1.  **Create Roles:** A cluster-admin first creates the `Roles` (for namespaced diagnostics) or `ClusterRoles` (for cluster-wide diagnostics) that contain the minimal permissions required for a specific diagnostic task.
-2.  **Define Allowlist:** The admin creates a single `MustGatherImage` resource named `cluster`. In its spec, they define a list of "security contracts," where each entry pairs a custom image URL with a `roleRef` pointing to one of the pre-created roles.
-3.  **Automatic Verification:** The must-gather-operator detects the `MustGatherImage` resource and begins an asynchronous loop. It continuously checks each image in the list to ensure it is pullable, updating the `status` subresource of the `MustGatherImage` CR with `Verified` or `Failed` for each image.
+1.  **Create Roles:** A cluster-admin creates the `Roles` or `ClusterRoles` that contain the permissions required for various diagnostic tasks.
+2.  **Create ServiceAccounts and Bindings:** The admin creates long-lived `ServiceAccount`s and binds each one to the appropriate role using a `RoleBinding` or `ClusterRoleBinding`.
+3.  **Define Allowlist via `ImageStream`:** The admin creates `ImageStream`s in operator's namespace, where each `ImageStreamTag` points to an allowed custom image URL.
+4.  **Automatic Verification:** OpenShift's native image import mechanism periodically attempts to import the tag, updating the `ImageStreamTag` status, which the operator monitors to verify image pullability.
 
 **Part 2: User Request and Operator Execution**
 
-1.  **User Request:** A user creates a `MustGather` CR in a specific namespace, setting the `spec.mustGatherImage` field to an image from the admin's allowlist.
-2.  **Operator Validation:** The operator validates the request by checking the `MustGatherImage.status` to ensure the requested image is marked as `Verified`.
-3.  **Secure Execution:** If valid, the operator creates an ephemeral `ServiceAccount` and binds it to the corresponding `Role` or `ClusterRole`. It then creates the Kubernetes `Job` using this temporary ServiceAccount and the specified image.
-4.  **Cleanup:** Once the job completes, the operator deletes the job and all associated ephemeral resources (`ServiceAccount`, `RoleBinding`/`ClusterRoleBinding`).
+1.  **User Request:** A user creates a `MustGather` CR, setting the new `spec.imageStreamTag` field to an allowed tag.
+2.  **Operator Validation:** The operator validates that the requested `ImageStreamTag` exists and its import status is successful.
+3.  **Execution:** If the image is valid, the operator creates the Kubernetes `Job`, specifying the user-provided `serviceAccountName` in the pod spec. The job runs with the permissions granted to that `ServiceAccount`.
+4.  **Cleanup:** Once the job completes, the operator deletes the job. The `ServiceAccount` and its associated RBAC resources remain.
 
 ### API Extensions
 
-#### `MustGatherImage` CRD
-
-```go
-package v1alpha1
-
-import (
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-// +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster,shortName=mgi
-// +kubebuilder:subresource:status
-type MustGatherImage struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec   MustGatherImageSpec   `json:"spec,omitempty"`
-	Status MustGatherImageStatus `json:"status,omitempty"`
-}
-
-type MustGatherImageSpec struct {
-	// +listType=map
-	// +listMapKey=image
-	Images []CustomMustGatherImage `json:"images"`
-}
-
-type CustomMustGatherImage struct {
-	// +kubebuilder:validation:Required
-	Image string `json:"image"`
-	// +kubebuilder:validation:Required
-	RoleRef rbacv1.RoleRef `json:"roleRef"`
-}
-
-type MustGatherImageStatus struct {
-	// +optional
-	// +listType=map
-	// +listMapKey=image
-	VerifiedImages []ImageVerificationStatus `json:"verifiedImages,omitempty"`
-}
-
-type ImageVerificationStatus struct {
-	// +kubebuilder:validation:Required
-	Image string `json:"image"`
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Verified;Failed;Pending
-	State string `json:"state"`
-	// +optional
-	Reason string `json:"reason,omitempty"`
-}
-
-// +kubebuilder:object:root=true
-type MustGatherImageList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []MustGatherImage `json:"items"`
-}
-```
-
 #### `MustGather` CRD Modification
+
+The `MustGather` spec will be modified to include the new `imageStreamTag` field.
 
 ```go
 type MustGatherSpec struct {
 	// ... existing fields ...
 	// +kubebuilder:validation:Optional
-	MustGatherImage string `json:"mustGatherImage,omitempty"`
+	// ImageStreamTag is the new field to specify a custom image from the allowlist.
+	ImageStreamTag string `json:"imageStreamTag,omitempty"`
+
 	// ... existing fields ...
 }
 ```
@@ -162,7 +102,7 @@ This enhancement does not introduce any unique topological considerations and is
 
 #### Hypershift / Hosted Control Planes
 
-No unique considerations. The operator runs in the guest cluster and performs all its functions there.
+No unique considerations.
 
 #### Standalone Clusters
 
@@ -173,38 +113,34 @@ No unique considerations. The operator runs in the guest cluster and performs al
 #### Single-node Deployments or MicroShift
 
 
-
 ### Implementation Details/Notes/Constraints
 
--   The `MustGatherImage` resource must be named `cluster` to serve as the single source of truth.
--   The operator will require cluster-level RBAC to `get/list/watch` `MustGatherImage` resources and to create `ClusterRoleBindings`.
--   The image verification loop will utilize the cluster's global pull secret to authenticate to private container registries.
--   Failures during the process (e.g., image not verified, role not found) will be reported as conditions in the `MustGather` resource's status.
+-   All `ImageStream`s for the allowlist must be created in operator's namespace.
+-   The administrator is responsible for communicating to users which `serviceAccountName` to use for a given diagnostic task.
 
 ### Risks and Mitigations
 
--   **Risk:** Operator has excessive permissions to create arbitrary roles.
-    -   **Mitigation:** The `RoleRef` model prevents this. The operator only creates `RoleBindings` to roles pre-approved by an admin.
--   **Risk:** A privileged `ServiceAccount` is left behind after a job.
-    -   **Mitigation:** The `ServiceAccount` is ephemeral and garbage collected by the operator upon job completion.
--   **Risk:** An administrator misconfigures an image URL or a role.
-    -   **Mitigation:** Image pull errors are made visible by the async verification status. Role binding errors are reported on the `MustGather` CR.
+-   **Risk:** A user specifies an incorrect `ServiceAccount`, either gaining insufficient permissions (job fails) or excessive permissions (security risk).
+    -   **Mitigation:** This design relies on administrative controls and clear documentation. The user running `must-gather` is expected to have the permissions to *use* the specified `ServiceAccount`.
+-   **Risk:** Long-lived, privileged `ServiceAccount`s increase the cluster's attack surface.
+    -   **Mitigation:** Administrators must follow security best practices, granting only the minimal required permissions to each `ServiceAccount`.
+-   **Risk:** An administrator misconfigures an image URL.
+    -   **Mitigation:** The `ImageStreamTag` import status will fail, making the error visible. The operator will reject `MustGather` requests for failed tags.
 
 ### Drawbacks
 
--   The feature introduces additional complexity for cluster administrators, who are now responsible for creating and managing roles and the `MustGatherImage` allowlist.
+-   This approach requires the administrator to create, manage, and document RBAC resources.
+-   It requires the end-user to have knowledge of the underlying permission model (`ServiceAccount` names).
+-   The lack of an automated link between an image and its required permissions can lead to user error when selecting a `ServiceAccount`.
 
 ## Test Plan
 
 -   **Unit Tests:**
-    -   Test the reconciler logic for the `MustGatherImage` resource, including the image verification loop.
-    -   Test the `MustGather` reconciler logic for validating a custom image request and creating ephemeral resources (`ServiceAccount`, bindings, `Job`).
+    -   Test the `MustGather` reconciler logic for finding `ImageStream`s and checking their import status.
 -   **E2E Tests:**
-    -   Verify the full workflow for a valid custom image with a `ClusterRole`.
-    -   Verify the full workflow for a valid custom image with a namespaced `Role`.
-    -   Verify that a request for an unlisted image fails with an appropriate status condition.
-    -   Verify that a request for a listed but unpullable (failed verification) image fails.
-    -   Verify that after a job completes, the ephemeral `ServiceAccount` and bindings are deleted.
+    -   Verify the full workflow: admin creates RBAC and `ImageStream`, then a user creates a `MustGather` specifying both, and the job succeeds.
+    -   Verify failure mode: request for a non-existent `ImageStreamTag`.
+    -   Verify failure mode: `ImageStream` exists but the image tag import has failed.
 
 ## Graduation Criteria
 
@@ -227,69 +163,95 @@ Not applicable.
 
 ## Upgrade / Downgrade Strategy
 
--   **Upgrade:** This is a backward-compatible change. Existing `MustGather` resources without the `mustGatherImage` field will continue to function as before. The new `MustGatherImage` CRD will be created upon upgrade.
--   **Downgrade:** On downgrade, the `MustGatherImage` CRD will remain, but the older operator will not be aware of it. Any `MustGather` resource that specifies a `mustGatherImage` will be ignored by the older operator and will likely fail validation if the field is not recognized.
+-   **Upgrade:** This is a backward-compatible change. Existing `MustGather` resources will continue to function as before.
+-   **Downgrade:** On downgrade, the older operator will not understand the `imageStreamTag` field, and any `MustGather` resource that specifies it will fail validation.
 
 ## Version Skew Strategy
 
-This enhancement does not introduce any version skew concerns. The logic is self-contained within the must-gather-operator and its CRDs.
+This enhancement does not introduce any version skew concerns.
 
 ## Operational Aspects of API Extensions
 
-The primary API extension is the `MustGatherImage` CRD. Its operational status is exposed via its `status` subresource. Cluster administrators are responsible for its lifecycle. Failure modes, such as an unpullable image, are surfaced directly in this status, making the system's configuration health easily observable.
+Administrators will manage a set of `ImageStream` resources in the operator's namespace. The operational status of the allowlist is exposed via the native `status` subresource of each `ImageStreamTag`. Administrators are responsible for creating these resources and ensuring their `importPolicy` is correctly configured to point to a valid internal or external image source. Monitoring the status of these `ImageStream`s is the primary way to observe the health of the custom image configuration.
 
 ## Support Procedures
 
-If a `must-gather` run with a custom image fails, support personnel should first inspect the `MustGather` resource's status and events to check for errors. If the error is related to image verification or permissions, they should then inspect the `MustGatherImage` resource (`oc get mustgatherimage cluster -o yaml`) to verify its configuration and status.
+If a `must-gather` run fails, support personnel should inspect the `MustGather` status. If the error is related to the image, they should check the `ImageStream`. If it's a permissions error, they must check the `ServiceAccount` and its associated `RoleBindings`.
 
 ## Alternatives (Not Implemented)
 
-An alternative design was considered where the operator could be given permissions to create `Roles` dynamically. This was rejected because it would require the operator itself to possess dangerously broad permissions, violating the principle of least privilege. The `RoleRef` model ensures the operator remains a low-privilege component.
+A design using a dedicated `MustGatherImage` CRD with an automated, ephemeral `ServiceAccount` model was considered. This would provide a more integrated and secure link between an image and its permissions, but adds more complexity to the operator. The current approach was chosen to maximize simplicity in the operator's logic.
 
 ### Examples
 
-#### Example 1: Administrator Configuration (`MustGatherImage`)
+#### Example 1: Administrator Configuration
 
-This example shows a cluster administrator configuring the `cluster` allowlist with two custom images. The first image is for cluster-wide network diagnostics and is bound to a `ClusterRole`. The second is for application-specific diagnostics and is bound to a namespaced `Role`.
+The admin must create all required resources: the `Role`, the `ServiceAccount`, the `RoleBinding`, and the `ImageStream`.
 
 ```yaml
-# /deploy/examples/must-gather-image-allowlist.yaml
-apiVersion: operator.openshift.io/v1alpha1
-kind: MustGatherImage
+# /deploy/examples/admin-full-setup.yaml
+
+# 1. The Role with required permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  # The name is fixed to 'cluster' to provide a single, cluster-wide source of truth.
-  name: cluster
+  name: custom-must-gather-network-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+# 2. The long-lived ServiceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: must-gather-network-sa
+  namespace: openshift-must-gather-operator
+---
+# 3. The binding to link the Role and ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: must-gather-network-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-must-gather-network-role
+subjects:
+- kind: ServiceAccount
+  name: must-gather-network-sa
+  namespace: openshift-must-gather-operator
+---
+# 4. The ImageStream to allowlist the image
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: network-debug-tools
+  namespace: must-gather-operator
 spec:
-  images:
-  - image: quay.io/my-org/network-debug-tools:v1.2
-    roleRef:
-      apiGroup: rbac.authorization.k-8s.io
-      kind: ClusterRole
-      name: custom-must-gather-network-role # Admin must pre-create this ClusterRole
-  - image: registry.example.com/team-a/app-diagnostics:latest
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: team-a-diagnostics-role # Admin must pre-create this Role in relevant app namespace(s)
+  tags:
+  - name: 'v1.2'
+    from:
+      kind: DockerImage
+      name: 'quay.io/my-org/network-debug-tools:v1.2'
 ```
 
 #### Example 2: User Request (`MustGather`)
 
-This example shows a user in the `team-a-namespace` namespace requesting a must-gather run using the pre-approved application-specific diagnostic image.
+The user specifies the new `imageStreamTag` and, optionally, the existing `serviceAccountName` field.
 
 ```yaml
-# /deploy/examples/must-gather-with-custom-image.yaml
+# /deploy/examples/must-gather-with-imagestream-and-sa.yaml
 apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
-  name: my-app-diagnostics-run
-  namespace: team-a-namespace # The namespace where the Role "team-a-diagnostics-role" exists
+  name: my-network-diagnostics-run
+  namespace: team-a-namespace
 spec:
-  # Requesting the custom image for app diagnostics.
-  # The operator will validate this against the 'cluster' MustGatherImage resource.
-  mustGatherImage: registry.example.com/team-a/app-diagnostics:latest
-
-  # Other spec fields, like storage, remain available.
+  # Reference to the allowed image via the new field
+  imageStreamTag: "network-debug-tools:v1.2"
+  # Reference to the pre-configured ServiceAccount via the existing field
+  serviceAccountName: "must-gather-network-sa"
   storage:
     type: PersistentVolume
     persistentVolume:

--- a/enhancements/support-log-gather/must-gather-custom-images.md
+++ b/enhancements/support-log-gather/must-gather-custom-images.md
@@ -167,6 +167,9 @@ No unique considerations. The operator runs in the guest cluster and performs al
 #### Standalone Clusters
 
 
+#### OpenShift Kubernetes Engine
+
+
 #### Single-node Deployments or MicroShift
 
 


### PR DESCRIPTION
This PR introduces an enhancement proposal to support the use of custom must-gather images with the must-gather-operator. This feature allows cluster administrators to define an allowlist of trusted images that can be used for diagnostic data collection, providing a secure and flexible way to gather specialized information.

**Summary:**

The proposal introduces below API changes:
A  `ImageStream`: This operator namespace-scoped resource acts as an allowlist for custom must-gather images. Cluster administrators can manage this resource to control which images are permitted to run in the cluster.
An update to the `MustGather CRD`: The MustGather CRD is extended with an optional mustGatherImage field 
and `imageStreamRef` field. When creating a MustGather resource, users can specify an image from the `imagestream` to be used for the data collection job.
The must-gather-operator's logic is updated to validate the mustGatherImage against the ImageStreams in the operator namespace. If the image is valid, the operator will use it to run the must-gather job. If the image is not in the imagestreams, or if the imagestream is not configured, the MustGather resource's status will be updated with an error. If no custom image is specified, the operator will use the default must-gather image, ensuring backward compatibility.

**User-Facing Changes:**

Cluster administrators can now create and manage a `ImageStream` resource to control the use of custom must-gather images.
Users can specify a custom must-gather image in the `MustGather CR` with `imageStreamRef`.

**JIRA tracker:**
https://issues.redhat.com/browse/MG-155