### PR TITLE
OPNET-679: Block external access to coredns

### DIFF
--- a/enhancements/network/block-external-access-to-coredns.md
+++ b/enhancements/network/block-external-access-to-coredns.md
@@ -1,0 +1,873 @@
+---
+title: block-external-access-to-coredns
+authors:
+  - "@emy"
+reviewers:
+  - "@cybertron"
+approvers:
+  - TBD
+api-approvers:
+  - TBD
+creation-date: 2026-03-25
+last-updated: 2026-03-30
+status: provisional
+tracking-link:
+  - https://redhat.atlassian.net/browse/OPNET-679
+---
+
+# Block External Access to CoreDNS
+
+## Summary
+
+This enhancement proposes to block external access to CoreDNS pods running
+in OpenShift clusters by implementing NetworkPolicies that restrict DNS
+queries to originate only from within the cluster. The feature follows a
+secure-by-default approach: when the BlockExternalDNSAccess feature gate
+is enabled, external access is automatically blocked unless administrators
+explicitly configure the DNS Operator to allow it.
+
+This security hardening measure prevents unauthorized external entities
+from querying cluster DNS, mitigates DNS amplification/reflection attacks,
+and reduces the risk of data exfiltration through DNS reconnaissance.
+
+## Motivation
+
+OpenShift clusters run CoreDNS to provide DNS resolution for cluster
+workloads. By default, if CoreDNS pods are exposed externally (either
+through misconfigurations or network topology), they can be accessed by
+external entities outside the cluster.
+
+**This creates the following risks:**
+
+    Unauthorized reconnaissance: External actors can query cluster DNS to discover
+    internal service names, namespaces, and cluster topology
+    
+    DNS amplification attacks: CoreDNS can be exploited as a vector for DDoS attacks by sending spoofed
+    DNS queries that generate larger responses
+    
+    Data exfiltration: Sensitive cluster information can leak through DNS query responses to external parties
+    
+    Compliance violations: Many security frameworks and regulatory requirements mandate that internal DNS servers
+    should not be accessible from external networks
+
+### User Stories
+
+* As a **cluster administrator**, I want to prevent external access to CoreDNS
+  so that I can reduce the attack surface of my OpenShift cluster and
+  comply with security policies that require DNS isolation.
+
+* As a **security engineer**, I want to ensure that DNS queries to CoreDNS can
+  only originate from within the cluster so that I can prevent DNS-based
+  reconnaissance and amplification attacks targeting my infrastructure.
+
+* As a **platform team member** managing multi-tenant OpenShift environments,
+  I want to enforce DNS access control at the platform level so that I can
+  provide security hardening by default without requiring individual tenant
+  configuration.
+
+* As a **cluster administrator**, I want the system to be monitored and
+  remediated at scale so that any configuration drift or policy violations
+  related to CoreDNS access control are automatically detected and
+  corrected.
+
+### Goals
+
+* Provide secure-by-default protection: block external access to CoreDNS
+  automatically when the feature gate is enabled
+* Prevent external entities from querying CoreDNS pods by default
+* Provide security hardening against DNS-based attacks (amplification,
+  reflection, reconnaissance)
+* Reduce the risk of data exfiltration through DNS queries
+* Ensure DNS queries can only originate from pods and nodes within the
+  cluster (unless explicitly allowed)
+* Make the protection configurable through the DNS Operator API to allow
+  external access when required
+
+### Non-Goals
+
+* Blocking DNS queries between namespaces within the cluster (internal DNS
+  segmentation)
+* Implementing DNS query rate limiting or throttling
+* Modifying CoreDNS configuration or plugins beyond access control
+
+## Proposal
+
+This enhancement proposes to add a new field to the DNS Operator CRD that
+controls external access to CoreDNS. When the feature gate is enabled
+(initially DevPreviewNoUpgrade), the DNS Operator will block external
+access by default using NetworkPolicies that restrict DNS traffic to the
+CoreDNS pods to only accept connections from sources within the cluster
+network. This provides a secure-by-default approach that requires
+administrators to explicitly opt-in to allow external access if needed.
+
+The implementation will:
+1. Add a new API field to the DNS Operator CRD for configuring external
+   access blocking
+2. Update the DNS Operator to watch for this configuration and create
+   appropriate NetworkPolicies
+3. Create NetworkPolicies that allow DNS traffic (UDP/TCP port 53) only
+   from cluster CIDR ranges (pod network and service network)
+4. Ensure the NetworkPolicies are applied to all CoreDNS pods in the
+   openshift-dns namespace
+5. Monitor and reconcile NetworkPolicies to prevent configuration drift
+
+### Workflow Description
+
+**cluster administrator** is a human user responsible for managing cluster
+security and configuration.
+
+**DNS operator** is the OpenShift component responsible for managing
+CoreDNS deployment and configuration.
+
+**NetworkPolicy controller** is the CNI-specific component that enforces
+NetworkPolicies.
+
+1. The cluster administrator enables the DevPreviewNoUpgrade feature set
+   on the cluster to activate the BlockExternalDNSAccess feature gate.
+
+2. When the feature gate is enabled, the DNS operator automatically
+   applies the secure-by-default behavior. External access to CoreDNS is
+   blocked via NetworkPolicies even if the `externalAccessPolicy` field
+   is not explicitly set (defaults to empty string which means "Deny").
+
+   Optionally, the administrator can explicitly set the policy in the DNS
+   custom resource:
+   ```yaml
+   apiVersion: operator.openshift.io/v1
+   kind: DNS
+   metadata:
+     name: default
+   spec:
+     externalAccessPolicy: Deny
+   ```
+
+3. The DNS operator observes the feature gate is enabled and validates
+   the configuration.
+
+4. The DNS operator creates NetworkPolicy resources in the openshift-dns
+   namespace that:
+   - Allow ingress DNS traffic (UDP/TCP port 53) from the cluster's pod
+     CIDR
+   - Allow ingress DNS traffic (UDP/TCP port 53) from the cluster's
+     service CIDR
+   - Allow ingress DNS traffic from the node network (for host network
+     pods and nodes)
+   - Deny all other ingress traffic to CoreDNS pods
+
+5. The NetworkPolicy controller (part of the CNI plugin) enforces the
+   policies on CoreDNS pods.
+
+6. The DNS operator continuously reconciles the NetworkPolicies to ensure
+   they remain in place and correctly configured.
+
+7. Any DNS queries from external sources are blocked by the NetworkPolicy,
+   while internal cluster workloads continue to resolve DNS normally.
+
+```mermaid
+sequenceDiagram
+    participant Admin as Cluster Administrator
+    participant API as Kubernetes API
+    participant DNSOp as DNS Operator
+    participant NP as NetworkPolicy Controller
+    participant CoreDNS as CoreDNS Pods
+
+    Admin->>API: Enable BlockExternalDNSAccess feature gate
+    API->>DNSOp: Feature gate enabled event
+    DNSOp->>DNSOp: Detect feature gate enabled
+    DNSOp->>DNSOp: Apply secure-by-default (empty = Deny)
+    DNSOp->>API: Create NetworkPolicy
+    API->>NP: Apply NetworkPolicy
+    NP->>CoreDNS: Enforce ingress rules
+    Note over CoreDNS: Only cluster traffic allowed (default)
+    DNSOp->>DNSOp: Reconcile periodically
+    DNSOp->>API: Verify NetworkPolicy exists
+```
+
+#### Variation: Allowing External Access
+
+If a cluster administrator needs to allow external access to CoreDNS
+(e.g., for external monitoring systems or specific network requirements):
+
+1. The administrator updates the DNS resource to explicitly allow external
+   access:
+   ```yaml
+   apiVersion: operator.openshift.io/v1
+   kind: DNS
+   metadata:
+     name: default
+   spec:
+     externalAccessPolicy: Allow
+   ```
+2. The DNS operator observes the "Allow" value and removes any existing
+   NetworkPolicies from the openshift-dns namespace
+3. CoreDNS access uses the default cluster network configuration, allowing
+   external queries
+
+#### Variation: Explicitly Blocking External Access
+
+If a cluster administrator wants to explicitly document their choice to
+block external access (the default secure behavior):
+
+1. The administrator sets the DNS resource with an explicit "Deny" value:
+   ```yaml
+   apiVersion: operator.openshift.io/v1
+   kind: DNS
+   metadata:
+     name: default
+   spec:
+     externalAccessPolicy: Deny
+   ```
+2. The DNS operator creates NetworkPolicies to block external access
+3. This has the same behavior as the default (empty string), but
+   explicitly documents the administrator's intent to block external
+   access
+
+### API Extensions
+
+This enhancement adds a new field to the existing DNS Operator CRD
+(`operator.openshift.io/v1`, kind `DNS`):
+
+```go
+// DNSSpec is the specification of the desired behavior of the DNS.
+type DNSSpec struct {
+    // ... existing fields ...
+
+    // externalAccessPolicy defines the policy for external access to
+    // CoreDNS pods. This field controls whether NetworkPolicies are
+    // created to restrict DNS queries from sources outside the cluster.
+    //
+    // When the BlockExternalDNSAccess feature gate is enabled, this
+    // enhancement follows a secure-by-default approach: external access
+    // is blocked by default unless explicitly allowed.
+    //
+    // Valid values are:
+    //
+    // - "" (empty string): External access to CoreDNS is blocked via
+    //   NetworkPolicies. Only DNS queries originating from within the
+    //   cluster (pod network, service network, and node network) are
+    //   permitted. External sources will be unable to query CoreDNS.
+    //   This is the default secure behavior when the field is omitted.
+    //
+    // - "Allow": Explicitly allows external access to CoreDNS. No
+    //   NetworkPolicies are applied by the DNS operator for access
+    //   control. CoreDNS access uses the default cluster network
+    //   configuration. Use this value when external access to CoreDNS
+    //   is required (e.g., for external monitoring systems).
+    //
+    // - "Deny": Explicitly blocks all external access to CoreDNS via
+    //   NetworkPolicies. Only DNS queries originating from within the
+    //   cluster (pod network, service network, and node network) are
+    //   permitted. This value has the same behavior as the empty string
+    //   but allows administrators to explicitly document their intent to
+    //   block external access.
+    //
+    // Future values may include policies for allowlisting specific external
+    // sources or custom access control configurations.
+    //
+    // This field requires the BlockExternalDNSAccess feature gate to be
+    // enabled.
+    //
+    // +optional
+    // +openshift:enable:FeatureGate=BlockExternalDNSAccess
+    ExternalAccessPolicy string `json:"externalAccessPolicy,omitempty"`
+}
+```
+
+This enhancement modifies the behavior of the DNS Operator to create and
+manage NetworkPolicy resources targeting CoreDNS pods in the openshift-dns
+namespace.
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+In Hypershift deployments, CoreDNS runs in the hosted cluster (guest
+cluster), not in the management cluster. The NetworkPolicies created by
+this enhancement will apply to the CoreDNS pods in the hosted cluster's
+data plane.
+
+This enhancement is fully applicable to Hypershift deployments. The DNS
+operator running in the management cluster will manage the NetworkPolicies
+in the hosted cluster just as it manages other DNS configurations.
+
+#### Standalone Clusters
+
+This enhancement is primarily designed for standalone clusters where
+CoreDNS runs in the cluster's openshift-dns namespace. It provides direct
+security hardening for these deployments.
+
+#### Single-node Deployments or MicroShift
+
+For Single-Node OpenShift (SNO) deployments, this enhancement provides the
+same security benefits. The resource overhead of NetworkPolicies is
+minimal and should not impact SNO resource consumption significantly.
+
+For MicroShift, DNS is typically handled differently and CoreDNS may be
+managed outside the DNS operator. This enhancement may not apply directly
+to MicroShift unless CoreDNS is managed via the DNS operator in that
+environment.
+
+<!-- TODO: Validate MicroShift applicability and DNS management approach -->
+
+#### OpenShift Kubernetes Engine
+
+This enhancement applies to OKE deployments as they include the DNS
+operator and CoreDNS components. The security hardening provided is
+beneficial for OKE clusters as well.
+
+### Implementation Details/Notes/Constraints
+
+The implementation requires changes to the following components:
+
+1. **openshift/api**: Add the `ExternalAccessPolicy` field to the DNS CRD
+   with the appropriate feature gate marker
+   (`+openshift:enable:FeatureGate=BlockExternalDNSAccess`)
+
+2. **openshift/cluster-dns-operator**: Update the DNS operator to:
+   - Read the feature gate state using the feature gate accessor pattern
+   - When the BlockExternalDNSAccess feature gate is enabled, apply
+     secure-by-default behavior
+   - Watch the DNS resource for the `externalAccessPolicy` field
+   - Create NetworkPolicy resources when:
+     - The feature gate is enabled AND the field is empty/unset (default)
+     - The field is explicitly set to "Deny"
+   - Delete NetworkPolicy resources when the field is set to "Allow"
+   - Reconcile NetworkPolicies to ensure they are not modified or deleted
+
+3. **NetworkPolicy specification**: The NetworkPolicies will:
+   - Target CoreDNS pods using label selectors (e.g., `dns.operator.
+     openshift.io/daemonset-dns=default`)
+   - Allow ingress on UDP and TCP port 53 from:
+     - Cluster pod CIDR (obtained from Network CR)
+     - Cluster service CIDR (obtained from Network CR)
+     - Node network (obtained from cluster network configuration)
+   - Use a deny-by-default approach (no egress restrictions needed for
+     this feature)
+
+4. **Feature gate creation**: A new feature gate `BlockExternalDNSAccess`
+   must be added to https://github.com/openshift/api/blob/master/features/
+   features.go with:
+   - Initial feature set: DevPreviewNoUpgrade
+   - Jira component: Networking / DNS
+   - Enhancement PR link (this enhancement)
+   - Contact person and owning product (ocpSpecific)
+
+**Constraints and considerations**:
+
+- The implementation depends on the CNI plugin supporting NetworkPolicies
+  (OVN-Kubernetes, Calico, etc.). Clusters using CNI plugins that do not
+  support NetworkPolicies will not be able to use this feature.
+- Getting accurate cluster CIDR ranges requires querying the Network CR
+  and cluster configuration, which may vary by platform and installation
+  type.
+- The NetworkPolicies must be kept in sync with any changes to cluster
+  network configuration (e.g., if additional pod or service CIDRs are
+  added).
+
+### Risks and Mitigations
+
+**Risk**: Enabling the feature gate automatically blocks external access by
+default, which could disrupt existing workflows or external monitoring
+systems that rely on querying CoreDNS from outside the cluster.
+
+**Mitigation**:
+- Comprehensive documentation warning administrators about the
+  secure-by-default behavior when enabling the feature gate
+- Provide clear instructions on how to set `externalAccessPolicy: Allow`
+  before enabling the feature gate if external access is required
+- Start with DevPreviewNoUpgrade to gather feedback from early adopters
+  about any disruption scenarios
+- Include prominent warnings in release notes and feature gate
+  documentation
+
+**Risk**: NetworkPolicies may inadvertently block legitimate DNS traffic if
+cluster CIDR ranges are incorrectly identified or if there are edge cases
+in network topology.
+
+**Mitigation**: Extensive testing across different platforms and network
+configurations. Provide clear documentation on how to verify the feature
+is working correctly and how to allow external access if issues arise.
+Start with DevPreviewNoUpgrade to gather feedback before promoting to Tech
+Preview or GA.
+
+**Risk**: CNI plugins that do not support NetworkPolicies will silently
+fail to enforce the blocking, creating a false sense of security.
+
+**Mitigation**: The DNS operator should detect if NetworkPolicy support is
+available in the cluster (by checking CNI capabilities) and report a
+degraded status with a clear message if NetworkPolicies cannot be enforced.
+
+**Risk**: Changes to cluster network configuration during cluster lifecycle
+may cause NetworkPolicies to become outdated (e.g., new CIDR ranges added).
+
+**Mitigation**: The DNS operator should watch the Network CR and
+automatically update NetworkPolicies when cluster network configuration
+changes.
+
+**Risk**: External monitoring or health check systems that need to query
+CoreDNS will be blocked by default when the feature gate is enabled.
+
+**Mitigation**: Document this limitation clearly and prominently. Provide
+guidance on alternative approaches for external monitoring (e.g.,
+monitoring through cluster API or using internal monitoring agents). Make
+it easy to set `externalAccessPolicy: Allow` for clusters that require
+external access. Consider adding configuration to allow specific external
+IPs if needed in future iterations.
+
+### Drawbacks
+
+- The secure-by-default approach means that enabling the feature gate will
+  immediately block external access, which could disrupt existing workflows
+  or external monitoring systems that rely on querying CoreDNS from outside
+  the cluster without warning
+- This feature adds complexity to the DNS operator with additional
+  reconciliation logic for NetworkPolicies
+- NetworkPolicies introduce additional resource overhead (minimal, but
+  non-zero)
+- Organizations with external DNS monitoring or testing tools will need to
+  explicitly set `externalAccessPolicy: Allow` to maintain their existing
+  workflows
+- The feature is CNI-dependent and will not work on clusters with CNI
+  plugins that don't support NetworkPolicies
+
+## Alternatives (Not Implemented)
+
+### Alternative 1: Configure CoreDNS ACL Plugin
+
+Instead of NetworkPolicies, configure CoreDNS with an ACL plugin to reject
+queries from external sources based on source IP.
+
+**Pros**:
+- Does not depend on CNI NetworkPolicy support
+- Can provide more granular control (e.g., query-based filtering)
+
+**Cons**:
+- Requires modifying CoreDNS configuration which adds complexity
+- Less standard approach compared to NetworkPolicies
+- Performance overhead of checking ACLs for every query
+- ACL configuration needs to be maintained and synchronized with cluster
+  network changes
+
+**Reason not selected**: NetworkPolicies are a more Kubernetes-native
+approach and are enforced at the network layer before traffic reaches
+CoreDNS, providing better performance and security.
+
+### Alternative 2: Firewall Rules at Node Level
+
+Use node-level firewall rules (iptables/nftables) to block external access
+to CoreDNS service IPs.
+
+**Pros**:
+- Works regardless of CNI plugin capabilities
+- Can be enforced at node level with high performance
+
+**Cons**:
+- Requires managing firewall rules on every node
+- More complex to implement across different node operating systems and
+  firewall implementations
+- Harder to manage lifecycle (what happens during node upgrades, reboots,
+  etc.)
+
+**Reason not selected**: NetworkPolicies provide a cleaner abstraction and
+are managed declaratively through Kubernetes resources, making them easier
+to maintain and reason about.
+
+### Alternative 3: Do Not Expose CoreDNS Externally
+
+Simply document that CoreDNS should not be exposed externally and leave it
+to cluster administrators to ensure proper network configuration.
+
+**Pros**:
+- No code changes required
+- Maximum flexibility for administrators
+
+**Cons**:
+- Relies on manual configuration which is error-prone
+- Does not provide defense-in-depth
+- No enforcement mechanism
+
+**Reason not selected**: This enhancement provides defense-in-depth and
+enforces security best practices by default, reducing the risk of
+misconfiguration.
+
+## Open Questions
+
+1. Should we provide configuration to allow specific external IP ranges
+   (e.g., for monitoring systems) in addition to the "Allow" and "Deny"
+   options?
+
+2. Should we add observability metrics to track blocked DNS queries from
+   external sources?
+
+3. For future iterations, should we consider DNS query rate limiting as
+   an additional security layer?
+
+4. Is the secure-by-default approach (blocking external access when the
+   feature gate is enabled) the right choice, or should administrators be
+   required to explicitly opt-in to blocking? The current design prioritizes
+   security but may cause disruption for clusters with external dependencies
+   on CoreDNS.
+
+## Test Plan
+
+The test plan will include:
+
+1. **Unit tests**:
+   - DNS operator logic for creating/updating/deleting NetworkPolicies
+   - Feature gate detection and handling
+   - Validation of DNS CR with blockExternalAccess field
+
+2. **Integration tests**:
+   - Verify NetworkPolicies are created when blockExternalAccess is
+     enabled
+   - Verify NetworkPolicies are removed when blockExternalAccess is
+     disabled
+   - Verify NetworkPolicies allow internal cluster DNS traffic
+   - Verify NetworkPolicies block external DNS traffic (simulate external
+     query)
+
+3. **E2E tests** (in openshift/origin):
+   - All tests must include the following labels:
+     - `[OCPFeatureGate:BlockExternalDNSAccess]` - feature gate label
+     - `[Jira:"Networking / DNS"]` - component label
+     - `[Suite:openshift/network]` - test suite label (if applicable)
+     - Additional labels as needed: `[Serial]`, `[Slow]`, `[Disruptive]`
+   - Test that internal pods can resolve DNS after enabling the feature
+   - Test that external entities cannot query CoreDNS (requires test
+     infrastructure to simulate external access)
+   - Test across different CNI plugins (OVN-Kubernetes, others if
+     supported)
+   - Test upgrade scenarios where the feature is enabled before upgrade
+   - Test that the feature gracefully handles CNI plugins without
+     NetworkPolicy support
+
+For detailed test labeling conventions, see dev-guide/test-conventions.md.
+
+## Graduation Criteria
+
+This enhancement follows the standard OpenShift feature graduation path:
+DevPreviewNoUpgrade -> TechPreviewNoUpgrade -> Default (GA).
+
+### Dev Preview -> Tech Preview
+
+**Testing**:
+- Minimum 5 e2e tests implemented in openshift/origin with
+  `[OCPFeatureGate:BlockExternalDNSAccess]` label covering:
+  - Internal DNS resolution continues to work with feature enabled
+    (default secure behavior)
+  - External DNS queries are blocked when `externalAccessPolicy` is
+    empty/unset or set to "Deny"
+  - External DNS queries succeed when `externalAccessPolicy` is set to
+    "Allow"
+  - NetworkPolicies are created and managed correctly by DNS operator
+  - Upgrade scenario with feature enabled
+- Tests run successfully on at least AWS and one other platform (e.g.,
+  Azure or GCP)
+- Unit and integration tests for DNS operator NetworkPolicy management
+  logic
+- Test coverage for CNI plugins that don't support NetworkPolicies
+  (operator should degrade gracefully)
+
+**Documentation**:
+- End user documentation explaining:
+  - The secure-by-default behavior when feature gate is enabled
+  - How to explicitly allow external access using `externalAccessPolicy:
+    Allow`
+  - Limitations and CNI plugin requirements
+  - How to verify the feature is working correctly
+  - Troubleshooting steps
+- Enhancement proposal updated with implementation details and lessons
+  learned from Dev Preview
+
+**Operational Requirements**:
+- DNS operator exposes metrics for NetworkPolicy creation/reconciliation
+- DNS operator reports degraded status when CNI doesn't support
+  NetworkPolicies
+- No major bugs or regressions reported in Dev Preview
+- Validation that NetworkPolicies correctly identify cluster CIDRs across
+  different network configurations and platforms
+
+**Feedback**:
+- Gathered feedback from at least 3 early adopter clusters
+- Documented any workflows that were disrupted by the secure-by-default
+  behavior
+- Validated that `externalAccessPolicy: Allow` successfully addresses use
+  cases requiring external access
+
+**API Stability**:
+- The `externalAccessPolicy` field API is stable and no breaking changes
+  are anticipated
+- API has been reviewed and approved by API reviewers
+
+### Tech Preview -> GA
+
+**Testing Requirements** (per dev-guide/feature-zero-to-hero.md):
+
+- **Test quantity**: Minimum 5 tests with
+  `[OCPFeatureGate:BlockExternalDNSAccess]` label
+- **Test frequency**: All tests run at least 7 times per week
+- **Platform coverage**: All tests run at least 14 times on each supported
+  platform:
+  - AWS (HA, amd64, default network)
+  - AWS (Single, amd64, default network)
+  - Azure (HA, amd64, default network)
+  - GCP (HA, amd64, default network)
+  - vSphere (HA, amd64, default network)
+  - Baremetal (HA, amd64, IPv4)
+  - Baremetal (HA, amd64, IPv6 - disconnected)
+  - Baremetal (HA, amd64, Dual stack)
+- **Pass rate**: 95% or higher pass rate across all test runs
+- **Test duration**: Tests have been running for at least 14 days before
+  branch cut
+- **Test variants**: Tests run in both `TechPreviewNoUpgrade` and `Default`
+  job variants (skipped in Default until promoted)
+
+**Comprehensive Testing**:
+- Upgrade testing:
+  - Upgrade from version without feature to version with feature
+    (validates no disruption when feature gate is disabled)
+  - Upgrade with feature gate enabled and `externalAccessPolicy` set to
+    "Allow" (validates external access remains functional)
+  - Upgrade with feature gate enabled and default secure behavior
+    (validates NetworkPolicies persist and reconcile)
+- Downgrade testing:
+  - Downgrade with feature enabled (validates NetworkPolicies can be
+    manually cleaned up)
+  - Documentation for manual cleanup steps if needed
+- Scale testing:
+  - Feature works correctly in clusters with custom/additional pod and
+    service CIDRs
+  - NetworkPolicy updates when cluster network configuration changes
+- Version skew testing:
+  - DNS operator at N+1, CoreDNS at N
+  - CNI upgrade scenarios
+
+**Documentation**:
+- User-facing documentation in openshift-docs including:
+  - Configuration guide
+  - Security implications and best practices
+  - Troubleshooting guide
+  - Migration guide for clusters with external DNS dependencies
+- Release notes documenting the secure-by-default behavior
+- CNI compatibility matrix clearly documented
+
+**Operational Maturity**:
+- Metrics for monitoring:
+  - NetworkPolicy creation/update/deletion events
+  - DNS operator condition status related to this feature
+  - Optionally: metrics for blocked external DNS queries (if feasible)
+- Alerts defined for:
+  - DNS operator degraded when NetworkPolicy support is unavailable
+  - NetworkPolicy creation failures
+- Performance validation:
+  - DNS query latency impact measured (should be negligible)
+  - NetworkPolicy reconciliation overhead is acceptable
+
+**User Feedback**:
+- Positive feedback from Tech Preview users
+- No major usability issues reported
+- Documented common use cases and their solutions
+- Validation that the secure-by-default approach is acceptable to users
+
+**Security and API Review**:
+- Security review completed and signed off
+- API review completed and approved (if any API changes from Tech Preview)
+- Confirmation that the feature provides meaningful security hardening
+
+**Platform Compatibility**:
+- Feature works correctly with all supported CNI plugins:
+  - OVN-Kubernetes (primary)
+  - Others if applicable
+- Graceful degradation documented and tested for CNI plugins without
+  NetworkPolicy support
+- Feature tested on all supported topologies:
+  - Standalone clusters
+  - Hypershift/Hosted Control Planes
+  - Single-Node OpenShift (SNO)
+  - OKE (if applicable)
+
+**Production Readiness**:
+- No critical or high-severity bugs open
+- Support procedures documented and validated
+- Runbooks created for common support scenarios
+- Monitoring and alerting validated in production-like environments
+
+## Upgrade / Downgrade Strategy
+
+**Upgrades**:
+
+When upgrading from a version without this feature to a version with this
+feature:
+- The feature gate will be disabled by default (Dev Preview)
+- Existing clusters will see no change in DNS behavior unless
+  administrators explicitly enable the BlockExternalDNSAccess feature gate
+- **IMPORTANT**: Once the feature gate is enabled, the secure-by-default
+  behavior activates immediately. External access to CoreDNS will be
+  blocked automatically via NetworkPolicies unless administrators
+  explicitly set `externalAccessPolicy: Allow` in the DNS CR
+- Administrators who need external CoreDNS access must proactively set
+  `externalAccessPolicy: Allow` before or immediately after enabling the
+  feature gate to avoid service disruption
+
+When upgrading with the feature already enabled:
+- The DNS operator will continue to maintain the NetworkPolicies
+- The feature should remain functional during the upgrade
+- If the NetworkPolicies are temporarily deleted during upgrade, the DNS
+  operator will recreate them during reconciliation
+- The secure-by-default behavior persists across upgrades
+
+**Downgrades**:
+
+When downgrading from a version with this feature to a version without it:
+- The NetworkPolicies created by the DNS operator will remain in the
+  cluster (Kubernetes does not delete resources during downgrades)
+- Administrators should manually delete the NetworkPolicies if they want
+  to restore the previous behavior
+- Documentation will include steps to clean up NetworkPolicies after
+  downgrade
+
+If downgrading with the feature enabled causes issues:
+- The DNS CR may contain the `blockExternalAccess` field that the older
+  DNS operator doesn't understand
+- The older DNS operator will ignore unknown fields, so this should not
+  cause errors
+- The NetworkPolicies will persist but will not be managed (no
+  reconciliation)
+
+## Version Skew Strategy
+
+During an upgrade where the DNS operator is updated but other components
+are still at older versions:
+- The DNS operator creates NetworkPolicies that target CoreDNS pods
+- CoreDNS pods themselves do not need to be aware of this feature
+- The CNI plugin (OVN-Kubernetes) enforces NetworkPolicies and should
+  handle them correctly regardless of version
+
+If the CoreDNS version changes during an upgrade:
+- The NetworkPolicies use label selectors, not version-specific targeting
+- As long as CoreDNS pods maintain the same labels, NetworkPolicies will
+  continue to apply
+
+If the CNI plugin is upgraded during cluster upgrade:
+- NetworkPolicy enforcement is handled by the CNI
+- Temporary loss of NetworkPolicy enforcement during CNI upgrade is
+  acceptable (brief window)
+- DNS operator will verify NetworkPolicies exist after CNI upgrade
+
+## Operational Aspects of API Extensions
+
+This enhancement modifies the DNS CRD (`operator.openshift.io/v1`, kind
+`DNS`) by adding a new optional field `blockExternalAccess`. This is an
+additive change that does not modify existing behavior when the field is
+not set.
+
+**SLIs for monitoring DNS operator health**:
+- Existing DNS operator condition `Degraded=False` should remain false
+- Existing DNS operator condition `Available=True` should remain true
+- DNS operator logs will include messages about NetworkPolicy creation,
+  updates, and reconciliation
+
+**Impact on existing SLIs**:
+- Minimal impact on API throughput as the DNS CR is infrequently updated
+- No impact on pod scheduling or other cluster operations
+- NetworkPolicy creation/updates are rare events (only when DNS CR changes
+  or during reconciliation)
+- DNS query performance should not be impacted (NetworkPolicies are
+  evaluated at network layer before reaching CoreDNS)
+
+**Measurement**:
+- Performance testing will be conducted during Tech Preview to measure any
+  DNS query latency impact
+- Testing will be performed by the networking QE team as part of standard
+  regression testing
+
+**Failure modes**:
+- **NetworkPolicy creation fails**: DNS operator will report Degraded
+  condition with a message indicating NetworkPolicy creation failure. DNS
+  resolution continues to work normally, but external access is not
+  blocked.
+- **CNI does not support NetworkPolicies**: DNS operator should detect
+  this and report Degraded condition with message "NetworkPolicy support
+  not available in cluster CNI". Feature cannot be enabled.
+- **NetworkPolicy is deleted by user**: DNS operator reconciliation will
+  recreate it within the reconciliation interval (typically 5-10 minutes).
+
+**Impact on cluster health**:
+- NetworkPolicy failures do not impact DNS resolution functionality
+- Cluster operations continue normally even if this feature fails
+- No impact on kube-controller-manager or other core components
+
+**Teams involved in escalations**:
+- Primary: Networking team (DNS component)
+- Secondary: CNI team (OVN-Kubernetes) for NetworkPolicy enforcement issues
+
+## Support Procedures
+
+**Detecting failure modes**:
+
+1. **Feature gate is enabled but NetworkPolicies are not created**:
+   - Symptom: `oc get networkpolicies -n openshift-dns` shows no policies
+     related to CoreDNS access control, even though the feature gate is
+     enabled and `externalAccessPolicy` is empty or "Deny"
+   - Check DNS operator logs: `oc logs -n openshift-dns-operator deployment/
+     dns-operator`
+   - Look for errors mentioning NetworkPolicy creation
+   - Check DNS operator conditions: `oc get dns.operator.openshift.io/
+     default -o yaml` and examine status conditions
+
+2. **External access is still possible despite feature gate being enabled**:
+   - Symptom: External DNS queries to CoreDNS succeed even though the
+     feature gate is enabled and `externalAccessPolicy` is not set to
+     "Allow"
+   - Verify NetworkPolicies exist and are correctly configured
+   - Check if CNI supports NetworkPolicies: `oc get network.config.
+     openshift.io/cluster -o yaml` and examine networkType
+   - Verify CNI is enforcing policies (CNI-specific debugging)
+
+3. **Internal DNS resolution fails after enabling feature gate**:
+   - Symptom: Pods cannot resolve DNS after enabling the
+     BlockExternalDNSAccess feature gate
+   - Check NetworkPolicy rules to ensure cluster CIDRs are correctly
+     specified
+   - Verify pod and service CIDRs: `oc get network.config.openshift.io/
+     cluster -o yaml`
+   - Check NetworkPolicy logs/events in CNI plugin
+
+4. **External monitoring stops working after enabling feature gate**:
+   - Symptom: External monitoring systems can no longer query CoreDNS
+     after enabling the BlockExternalDNSAccess feature gate
+   - This is expected behavior due to secure-by-default
+   - Solution: Set `externalAccessPolicy: Allow` if external access is
+     required
+
+**Allowing external access**:
+
+To allow external access to CoreDNS (disabling the default blocking):
+1. Update the DNS CR: `oc edit dns.operator.openshift.io/default` and
+   set `externalAccessPolicy: Allow`
+2. Verify NetworkPolicies are removed: `oc get networkpolicies -n
+   openshift-dns`
+3. External DNS queries should now succeed
+
+**Consequences of allowing external access**:
+- External entities can query CoreDNS (if network topology permits)
+- Security posture is reduced - cluster DNS becomes accessible from
+  outside the cluster
+- Increased risk of DNS-based reconnaissance and amplification attacks
+- No impact on existing workloads or cluster health
+- No data loss or configuration loss
+
+**Graceful failure and recovery**:
+- If the DNS operator crashes while managing NetworkPolicies, the
+  NetworkPolicies remain in place (enforced by CNI)
+- When the DNS operator restarts, it will reconcile and recreate any
+  missing NetworkPolicies
+- If NetworkPolicies are manually deleted, the DNS operator will recreate
+  them during the next reconciliation cycle
+- Internal DNS resolution is never impacted by this feature's failure
+  (fail-open for internal traffic)
+
+## Infrastructure Needed
+
+No additional infrastructure is required for this enhancement. Testing will
+leverage existing OpenShift CI infrastructure and e2e test frameworks.

--- a/enhancements/network/block-external-access-to-coredns.md
+++ b/enhancements/network/block-external-access-to-coredns.md
@@ -78,6 +78,9 @@ the cluster.
   reduce the attack surface of my OpenShift cluster and comply with
   security policies that require DNS isolation.
 
+* As a **cluster administrator**, I want to deploy proof-of-concept (POC)
+  clusters without sitewide DNS changes.
+
 * As a **security engineer**, I want to ensure that DNS queries to the
   on-prem CoreDNS instances can only originate from within the cluster
   nodes or internal networks so that I can prevent DNS-based reconnaissance
@@ -131,7 +134,7 @@ the cluster.
 
 This enhancement proposes to block external access to CoreDNS running on
 bare metal nodes by default. When the BlockExternalDNSAccess feature gate
-is enabled (initially DevPreviewNoUpgrade), external access is blocked by
+is enabled (initially Tech Preview), external access is blocked by
 default. This provides a secure-by-default approach that requires
 administrators to explicitly opt-in to allow external access if needed for
 specific use cases (e.g., external monitoring).
@@ -174,27 +177,6 @@ metal node. This could be implemented via:
   nodes)
 - Node Firewall Operator may not be available in all environments
 
-### Approach 2: CoreDNS ACL Plugin
-
-Configure on-prem CoreDNS with an ACL (Access Control List) plugin or
-similar mechanism to reject DNS queries from external sources based on
-source IP addresses.
-
-**Pros**:
-- Application-level control that's easier to reason about
-- Centrally managed through CoreDNS configuration
-- No dependency on node-level firewall mechanisms
-- Easier to debug (CoreDNS logs show rejected queries)
-- More portable across different platforms and OS versions
-
-**Cons**:
-- Traffic still reaches CoreDNS process (not blocked at network layer)
-- Performance overhead of checking ACLs for every DNS query
-- Requires modifying CoreDNS configuration which adds complexity
-- ACL configuration needs to be maintained and synchronized with cluster
-  network changes
-- Potential vulnerabilities in CoreDNS could be exploited before ACL check
-
 ### Proposed Implementation Path
 
 This enhancement proposes starting with **Approach 1 (Node-Level Firewall
@@ -230,7 +212,7 @@ steps:
    - Use cluster-level annotations or labels
    - MCO-based configuration override mechanism
 
-Alternative Approach 2 (CoreDNS ACL) remains a viable fallback if
+The alternative approach 1 (CoreDNS ACL) remains a viable fallback if
 node-level firewall management proves too complex or problematic.
 
 ### Workflow Description
@@ -247,7 +229,7 @@ metal nodes.
 
 #### Workflow: Enabling External Access Blocking (Default Secure Behavior)
 
-1. The cluster administrator enables the DevPreviewNoUpgrade feature set
+1. The cluster administrator enables the Tech Preview feature set
    on the cluster to activate the BlockExternalDNSAccess feature gate.
 
 2. When the feature gate is enabled, the system automatically applies the
@@ -380,7 +362,7 @@ The implementation requires the following components and changes:
 1. **Feature gate creation**: A new feature gate `BlockExternalDNSAccess`
    must be added to https://github.com/openshift/api/blob/master/features/
    features.go with:
-   - Initial feature set: DevPreviewNoUpgrade
+   - Initial feature set: Tech Preview
    - Jira component: Networking / DNS (or potentially Baremetal)
    - Contact person (bnemec)
 
@@ -435,7 +417,7 @@ systems that rely on querying on-prem CoreDNS from outside the cluster.
   secure-by-default behavior when enabling the feature gate
 - Provide clear instructions on how to disable the feature gate or apply
   override configuration (if available) if external access is required
-- Start with DevPreviewNoUpgrade to gather feedback from early adopters
+- Start with Tech Preview to gather feedback from early adopters
   about any disruption scenarios
 - Include prominent warnings in release notes and feature gate
   documentation
@@ -448,8 +430,7 @@ cases in network topology or node IP address changes.
 configurations (IPv4, IPv6, dual stack). Provide clear documentation on how
 to verify firewall rules are working correctly and how to debug DNS access
 issues. Include instructions on checking firewall rules via SSH to nodes.
-Start with DevPreviewNoUpgrade to gather feedback before promoting to Tech
-Preview or GA.
+Start with Tech Preview to gather feedback before promoting to GA.
 
 **Risk**: Firewall rule deployment via MachineConfig may cause node reboots
 on bare metal nodes, potentially disrupting workloads during initial
@@ -504,9 +485,30 @@ allow specific external IPs if needed in future iterations.
 - MachineConfig deployment may cause node reboots, impacting workload
   availability during initial feature enablement
 
-## Alternatives (Not Implemented)
+## Alternatives
 
-### Alternative 1: Use NetworkPolicies
+### Alternative 1: CoreDNS ACL Plugin
+
+Configure on-prem CoreDNS with an ACL (Access Control List) plugin or
+similar mechanism to reject DNS queries from external sources based on
+source IP addresses.
+
+**Pros**:
+- Application-level control that's easier to reason about
+- Centrally managed through CoreDNS configuration
+- No dependency on node-level firewall mechanisms
+- Easier to debug (CoreDNS logs show rejected queries)
+- More portable across different platforms and OS versions
+
+**Cons**:
+- Traffic still reaches CoreDNS process (not blocked at network layer)
+- Performance overhead of checking ACLs for every DNS query
+- Requires modifying CoreDNS configuration which adds complexity
+- ACL configuration needs to be maintained and synchronized with cluster
+  network changes
+- Potential vulnerabilities in CoreDNS could be exploited before ACL check
+
+### Alternative 2: Use NetworkPolicies (Not viable)
 
 Use Kubernetes NetworkPolicies to block external access to CoreDNS.
 
@@ -528,7 +530,7 @@ Use Kubernetes NetworkPolicies to block external access to CoreDNS.
 CoreDNS running on the host network. NetworkPolicies only control traffic
 to pods, not to host-network services.
 
-### Alternative 2: Do Not Expose On-Premises CoreDNS Externally
+### Alternative 3: Do Not Expose On-Premises CoreDNS Externally (Not viable)
 
 Simply document that on-prem CoreDNS should not be exposed externally
 and leave it to cluster administrators to ensure proper network
@@ -621,7 +623,7 @@ For detailed test labeling conventions, see dev-guide/test-conventions.md.
 ## Graduation Criteria
 
 This enhancement follows the standard OpenShift feature graduation path:
-DevPreviewNoUpgrade -> TechPreviewNoUpgrade -> Default (GA).
+TechPreviewNoUpgrade -> Default (GA).
 
 ### Dev Preview -> Tech Preview
 

--- a/enhancements/network/block-external-access-to-coredns.md
+++ b/enhancements/network/block-external-access-to-coredns.md
@@ -9,7 +9,7 @@ approvers:
 api-approvers:
   - TBD
 creation-date: 2026-03-25
-last-updated: 2026-03-30
+last-updated: 2026-03-31
 status: provisional
 tracking-link:
   - https://redhat.atlassian.net/browse/OPNET-679
@@ -19,527 +19,602 @@ tracking-link:
 
 ## Summary
 
-This enhancement proposes to block external access to CoreDNS pods running
-in OpenShift clusters by implementing NetworkPolicies that restrict DNS
-queries to originate only from within the cluster. The feature follows a
-secure-by-default approach: when the BlockExternalDNSAccess feature gate
-is enabled, external access is automatically blocked unless administrators
-explicitly configure the DNS Operator to allow it.
+This enhancement proposes to block external access to CoreDNS instances
+running on bare metal OpenShift cluster nodes. On bare metal deployments,
+CoreDNS runs on the host network namespace to provide DNS resolution for
+the host operating system. These instances can be exposed to external
+networks depending on the network topology and firewall configuration. The
+feature follows a secure-by-default approach: when the
+BlockExternalDNSAccess feature gate is enabled, external access is
+automatically blocked unless explicitly allowed.
+
+This enhancement is **specific to bare metal nodes** and does NOT involve
+the cluster DNS Operator. It explores two implementation
+approaches:
+1. **Node-level firewall rules** using the Node Firewall Operator or
+   MachineConfig
+2. **CoreDNS ACL plugin** to reject queries from external sources at the
+   application level via CoreDNS configuration
 
 This security hardening measure prevents unauthorized external entities
-from querying cluster DNS, mitigates DNS amplification/reflection attacks,
+from querying on-prem DNS, mitigates DNS amplification/reflection attacks,
 and reduces the risk of data exfiltration through DNS reconnaissance.
 
 ## Motivation
 
-OpenShift clusters run CoreDNS to provide DNS resolution for cluster
-workloads. By default, if CoreDNS pods are exposed externally (either
-through misconfigurations or network topology), they can be accessed by
-external entities outside the cluster.
+On **bare metal OpenShift deployments**, CoreDNS instances run on each
+node in the host network namespace to provide DNS resolution for the host
+operating system and node-level services. Unlike cloud deployments where
+network access is typically restricted by cloud provider security groups,
+bare metal nodes may have direct network exposure. These on-prem CoreDNS
+instances listen on the node's network interfaces (typically port 53
+UDP/TCP). Depending on the network topology and firewall configuration,
+these CoreDNS instances may be accessible from external networks outside
+the cluster.
 
 **This creates the following risks:**
 
-    Unauthorized reconnaissance: External actors can query cluster DNS to discover
-    internal service names, namespaces, and cluster topology
-    
-    DNS amplification attacks: CoreDNS can be exploited as a vector for DDoS attacks by sending spoofed
-    DNS queries that generate larger responses
-    
-    Data exfiltration: Sensitive cluster information can leak through DNS query responses to external parties
-    
-    Compliance violations: Many security frameworks and regulatory requirements mandate that internal DNS servers
-    should not be accessible from external networks
+    Unauthorized reconnaissance: External actors can query on-prem DNS
+    to discover internal host names, services, and network topology
+
+    DNS amplification attacks: CoreDNS can be exploited as a vector for
+    DDoS attacks by sending spoofed DNS queries that generate larger
+    responses
+
+    Data exfiltration: Sensitive infrastructure information can leak
+    through DNS query responses to external parties
+
+    Compliance violations: Many security frameworks and regulatory
+    requirements mandate that internal DNS servers should not be
+    accessible from external networks
+
+    Host compromise: Vulnerabilities in CoreDNS could be exploited by
+    external attackers if the service is exposed
 
 ### User Stories
 
-* As a **cluster administrator**, I want to prevent external access to CoreDNS
-  so that I can reduce the attack surface of my OpenShift cluster and
-  comply with security policies that require DNS isolation.
+* As a **cluster administrator**, I want to prevent external access to the
+  on-prem CoreDNS instances running on my cluster nodes so that I can
+  reduce the attack surface of my OpenShift cluster and comply with
+  security policies that require DNS isolation.
 
-* As a **security engineer**, I want to ensure that DNS queries to CoreDNS can
-  only originate from within the cluster so that I can prevent DNS-based
-  reconnaissance and amplification attacks targeting my infrastructure.
+* As a **security engineer**, I want to ensure that DNS queries to the
+  on-prem CoreDNS instances can only originate from within the cluster
+  nodes or internal networks so that I can prevent DNS-based reconnaissance
+  and amplification attacks targeting my infrastructure.
 
-* As a **platform team member** managing multi-tenant OpenShift environments,
-  I want to enforce DNS access control at the platform level so that I can
-  provide security hardening by default without requiring individual tenant
-  configuration.
+* As a **platform team member** managing multi-tenant OpenShift
+  environments, I want to enforce DNS access control for on-prem
+  CoreDNS at the platform level so that I can provide security hardening by
+  default without requiring individual tenant or node-level configuration.
 
 * As a **cluster administrator**, I want the system to be monitored and
-  remediated at scale so that any configuration drift or policy violations
-  related to CoreDNS access control are automatically detected and
-  corrected.
+  remediated at scale so that any configuration drift or firewall rule
+  violations related to on-prem CoreDNS access control are
+  automatically detected and corrected.
 
 ### Goals
 
-* Provide secure-by-default protection: block external access to CoreDNS
-  automatically when the feature gate is enabled
-* Prevent external entities from querying CoreDNS pods by default
+* Provide secure-by-default protection for **bare metal deployments**:
+  block external access to on-prem CoreDNS instances running on bare metal
+  nodes automatically when the feature gate is enabled
+* Prevent external entities from querying on-prem CoreDNS instances on
+  bare metal nodes by default
 * Provide security hardening against DNS-based attacks (amplification,
-  reflection, reconnaissance)
-* Reduce the risk of data exfiltration through DNS queries
-* Ensure DNS queries can only originate from pods and nodes within the
-  cluster (unless explicitly allowed)
-* Make the protection configurable through the DNS Operator API to allow
-  external access when required
+  reflection, reconnaissance) targeting host-level CoreDNS on bare metal
+  infrastructure
+* Reduce the risk of data exfiltration through DNS queries to on-prem
+  CoreDNS on bare metal nodes
+* Ensure DNS queries to on-prem CoreDNS can only originate from localhost
+  or other cluster nodes (unless explicitly allowed)
+* Determine how to make this configurable (if needed) to allow external
+  access when required (e.g., for monitoring) without involving the DNS
+  Operator
+* Determine the most appropriate implementation approach (node firewall vs
+  CoreDNS ACL) based on operational considerations, performance, and
+  maintainability for bare metal deployments
 
 ### Non-Goals
 
-* Blocking DNS queries between namespaces within the cluster (internal DNS
-  segmentation)
+* Blocking access to the cluster DNS service (the in-cluster CoreDNS pods
+  used by workloads managed by the DNS Operator) - this enhancement
+  specifically targets on-prem CoreDNS running on bare metal host network
+* Modifying the DNS Operator or its CRDs - this enhancement does not
+  involve the cluster DNS Operator
+* Applying to cloud deployments (AWS, Azure, GCP, etc.) - this enhancement
+  is specific to bare metal infrastructure
+* Blocking DNS queries between bare metal nodes within the cluster
 * Implementing DNS query rate limiting or throttling
-* Modifying CoreDNS configuration or plugins beyond access control
+* Replacing or removing on-prem CoreDNS from bare metal nodes
 
 ## Proposal
 
-This enhancement proposes to add a new field to the DNS Operator CRD that
-controls external access to CoreDNS. When the feature gate is enabled
-(initially DevPreviewNoUpgrade), the DNS Operator will block external
-access by default using NetworkPolicies that restrict DNS traffic to the
-CoreDNS pods to only accept connections from sources within the cluster
-network. This provides a secure-by-default approach that requires
-administrators to explicitly opt-in to allow external access if needed.
+This enhancement proposes to block external access to CoreDNS running on
+bare metal nodes by default. When the BlockExternalDNSAccess feature gate
+is enabled (initially DevPreviewNoUpgrade), external access is blocked by
+default. This provides a secure-by-default approach that requires
+administrators to explicitly opt-in to allow external access if needed for
+specific use cases (e.g., external monitoring).
 
-The implementation will:
-1. Add a new API field to the DNS Operator CRD for configuring external
-   access blocking
-2. Update the DNS Operator to watch for this configuration and create
-   appropriate NetworkPolicies
-3. Create NetworkPolicies that allow DNS traffic (UDP/TCP port 53) only
-   from cluster CIDR ranges (pod network and service network)
-4. Ensure the NetworkPolicies are applied to all CoreDNS pods in the
-   openshift-dns namespace
-5. Monitor and reconcile NetworkPolicies to prevent configuration drift
+Since on-prem CoreDNS runs on the host network namespace on bare metal
+nodes (not as pods in the cluster), Kubernetes NetworkPolicies cannot be
+used to restrict access. Additionally, this enhancement does NOT involve
+the cluster DNS Operator, as the DNS Operator manages the in-cluster
+CoreDNS service used by workloads, not the on-prem CoreDNS on bare metal
+nodes.
+
+This enhancement explores two viable implementation approaches for bare
+metal deployments:
+
+### Approach 1: Node-Level Firewall Rules
+
+Use node-level firewall mechanisms (nftables) to block external
+access to the CoreDNS service port (typically UDP/TCP 53) on each bare
+metal node. This could be implemented via:
+
+- **Node Firewall Operator**: Leverage existing Node Firewall Operator
+  (if available) to deploy and manage firewall rules across all
+  bare metal nodes
+- **Machine Config Operator (MCO)**: Use MCO to configure firewall rules
+  via MachineConfig resources targeting bare metal machine pools
+
+**Pros**:
+- Blocks traffic at the network layer before it reaches CoreDNS (defense
+  in depth)
+- Works regardless of CoreDNS configuration or plugins
+- Provides OS-level enforcement that's harder to bypass
+- Can be applied consistently across all nodes
+
+**Cons**:
+- Requires managing firewall state on every node
+- More complex to implement and maintain across different node OS versions
+- Potential conflicts with other firewall rules managed by different
+  operators
+- Harder to debug when issues occur (need to check firewall state on
+  nodes)
+- Node Firewall Operator may not be available in all environments
+
+### Approach 2: CoreDNS ACL Plugin
+
+Configure on-prem CoreDNS with an ACL (Access Control List) plugin or
+similar mechanism to reject DNS queries from external sources based on
+source IP addresses.
+
+**Pros**:
+- Application-level control that's easier to reason about
+- Centrally managed through CoreDNS configuration
+- No dependency on node-level firewall mechanisms
+- Easier to debug (CoreDNS logs show rejected queries)
+- More portable across different platforms and OS versions
+
+**Cons**:
+- Traffic still reaches CoreDNS process (not blocked at network layer)
+- Performance overhead of checking ACLs for every DNS query
+- Requires modifying CoreDNS configuration which adds complexity
+- ACL configuration needs to be maintained and synchronized with cluster
+  network changes
+- Potential vulnerabilities in CoreDNS could be exploited before ACL check
+
+### Proposed Implementation Path
+
+This enhancement proposes starting with **Approach 1 (Node-Level Firewall
+Rules)** as the initial implementation, with the following high-level
+steps:
+
+1. Create MachineConfig resources (or NodeFirewallConfiguration resources
+   if using Node Firewall Operator) that deploy firewall rules to bare
+   metal nodes
+2. Firewall rules will:
+   - Allow DNS queries from localhost (127.0.0.1, ::1)
+   - Allow DNS queries from other cluster nodes (node IPs within cluster
+     CIDR)
+   - Deny all other DNS queries from external sources
+3. Apply these configurations via one of the following methods:
+   - MCO MachineConfig targeting bare metal machine pools
+   - Node Firewall Operator NodeFirewallConfiguration resources
+4. Configuration will be enabled when the BlockExternalDNSAccess feature
+   gate is enabled
+
+**Open Questions**:
+1. The exact mechanism for deploying firewall rules (Node Firewall
+   Operator vs MCO) needs to be determined based on:
+   - Availability and maturity of Node Firewall Operator
+   - Complexity and maintainability of each approach
+   - Performance impact and resource overhead
+   - Compatibility with RHCOS and different node operating systems
+
+2. How to make this configurable if administrators need to allow external
+   access? Options:
+   - Feature gate controls default behavior only (no per-cluster config)
+   - Introduce a new CR/ConfigMap separate from DNS Operator
+   - Use cluster-level annotations or labels
+   - MCO-based configuration override mechanism
+
+Alternative Approach 2 (CoreDNS ACL) remains a viable fallback if
+node-level firewall management proves too complex or problematic.
 
 ### Workflow Description
 
-**cluster administrator** is a human user responsible for managing cluster
+**cluster administrator** is a user responsible for managing cluster
 security and configuration.
 
-**DNS operator** is the OpenShift component responsible for managing
-CoreDNS deployment and configuration.
+**Bare metal node** is an OpenShift cluster node running CoreDNS on the
+host network for host-level DNS resolution.
 
-**NetworkPolicy controller** is the CNI-specific component that enforces
-NetworkPolicies.
+**MCO (Machine Config Operator)** or **Node Firewall Operator** is the
+component responsible for deploying and enforcing firewall rules on bare
+metal nodes.
+
+#### Workflow: Enabling External Access Blocking (Default Secure Behavior)
 
 1. The cluster administrator enables the DevPreviewNoUpgrade feature set
    on the cluster to activate the BlockExternalDNSAccess feature gate.
 
-2. When the feature gate is enabled, the DNS operator automatically
-   applies the secure-by-default behavior. External access to CoreDNS is
-   blocked via NetworkPolicies even if the `externalAccessPolicy` field
-   is not explicitly set (defaults to empty string which means "Deny").
+2. When the feature gate is enabled, the system automatically applies the
+   secure-by-default behavior. A MachineConfig (or
+   NodeFirewallConfiguration) is deployed that configures firewall rules
+   on bare metal nodes to block external access to on-prem CoreDNS.
 
-   Optionally, the administrator can explicitly set the policy in the DNS
-   custom resource:
-   ```yaml
-   apiVersion: operator.openshift.io/v1
-   kind: DNS
-   metadata:
-     name: default
-   spec:
-     externalAccessPolicy: Deny
-   ```
+3. The MCO (or Node Firewall Operator) deploys the firewall configuration
+   to all bare metal nodes.
 
-3. The DNS operator observes the feature gate is enabled and validates
-   the configuration.
+4. Firewall rules are applied on each bare metal node that:
+   - Allow DNS traffic (UDP/TCP port 53) from localhost (127.0.0.1, ::1)
+   - Allow DNS traffic (UDP/TCP port 53) from other cluster node IPs
+     (within cluster node CIDR)
+   - Deny all other DNS traffic from external sources to port 53
 
-4. The DNS operator creates NetworkPolicy resources in the openshift-dns
-   namespace that:
-   - Allow ingress DNS traffic (UDP/TCP port 53) from the cluster's pod
-     CIDR
-   - Allow ingress DNS traffic (UDP/TCP port 53) from the cluster's
-     service CIDR
-   - Allow ingress DNS traffic from the node network (for host network
-     pods and nodes)
-   - Deny all other ingress traffic to CoreDNS pods
+5. The firewall mechanism (nftables) on each node
+   enforces the rules.
 
-5. The NetworkPolicy controller (part of the CNI plugin) enforces the
-   policies on CoreDNS pods.
+6. Any DNS queries to on-prem CoreDNS from external sources are blocked by
+   the node firewall, while internal node-to-node and localhost DNS
+   queries continue to work normally.
 
-6. The DNS operator continuously reconciles the NetworkPolicies to ensure
-   they remain in place and correctly configured.
-
-7. Any DNS queries from external sources are blocked by the NetworkPolicy,
-   while internal cluster workloads continue to resolve DNS normally.
+7. If a bare metal node is rebooted, the MCO ensures the firewall
+   configuration persists and is reapplied.
 
 ```mermaid
 sequenceDiagram
     participant Admin as Cluster Administrator
-    participant API as Kubernetes API
-    participant DNSOp as DNS Operator
-    participant NP as NetworkPolicy Controller
-    participant CoreDNS as CoreDNS Pods
+    participant FG as Feature Gate
+    participant MCO as MCO/Node Firewall Operator
+    participant Node as Bare Metal Nodes
 
-    Admin->>API: Enable BlockExternalDNSAccess feature gate
-    API->>DNSOp: Feature gate enabled event
-    DNSOp->>DNSOp: Detect feature gate enabled
-    DNSOp->>DNSOp: Apply secure-by-default (empty = Deny)
-    DNSOp->>API: Create NetworkPolicy
-    API->>NP: Apply NetworkPolicy
-    NP->>CoreDNS: Enforce ingress rules
-    Note over CoreDNS: Only cluster traffic allowed (default)
-    DNSOp->>DNSOp: Reconcile periodically
-    DNSOp->>API: Verify NetworkPolicy exists
+    Admin->>FG: Enable BlockExternalDNSAccess feature gate
+    FG->>MCO: Feature gate enabled
+    MCO->>MCO: Create MachineConfig with firewall rules
+    MCO->>Node: Deploy firewall configuration
+    Node->>Node: Apply nftables rules
+    Note over Node: Block external DNS traffic Allow localhost + node IPs
+    MCO->>Node: Reconcile on reboot/config drift
 ```
 
 #### Variation: Allowing External Access
 
-If a cluster administrator needs to allow external access to CoreDNS
-(e.g., for external monitoring systems or specific network requirements):
+If a cluster administrator needs to allow external access to on-prem
+CoreDNS on bare metal nodes (e.g., for external monitoring systems or
+specific network requirements):
 
-1. The administrator updates the DNS resource to explicitly allow external
-   access:
-   ```yaml
-   apiVersion: operator.openshift.io/v1
-   kind: DNS
-   metadata:
-     name: default
-   spec:
-     externalAccessPolicy: Allow
-   ```
-2. The DNS operator observes the "Allow" value and removes any existing
-   NetworkPolicies from the openshift-dns namespace
-3. CoreDNS access uses the default cluster network configuration, allowing
-   external queries
+**Option 1: Disable the feature gate** (if external access is needed
+cluster-wide):
+1. The administrator disables the BlockExternalDNSAccess feature gate
+2. The MachineConfig with firewall rules is removed
+3. On-prem CoreDNS becomes accessible from external networks
 
-#### Variation: Explicitly Blocking External Access
+**Option 2: Override via custom configuration** (if per-cluster control is
+implemented):
+1. The administrator creates a custom configuration resource (exact
+   mechanism TBD - see Open Questions) that overrides the default blocking
+   behavior
+2. The MCO/Node Firewall Operator removes firewall rules based on the
+   override configuration
+3. On-prem CoreDNS becomes accessible from external networks (subject to
+   other network controls like hardware firewalls, network ACLs, etc.)
 
-If a cluster administrator wants to explicitly document their choice to
-block external access (the default secure behavior):
-
-1. The administrator sets the DNS resource with an explicit "Deny" value:
-   ```yaml
-   apiVersion: operator.openshift.io/v1
-   kind: DNS
-   metadata:
-     name: default
-   spec:
-     externalAccessPolicy: Deny
-   ```
-2. The DNS operator creates NetworkPolicies to block external access
-3. This has the same behavior as the default (empty string), but
-   explicitly documents the administrator's intent to block external
-   access
+**Note**: The exact mechanism for per-cluster configuration override is an
+open question that needs to be resolved during implementation design.
 
 ### API Extensions
 
-This enhancement adds a new field to the existing DNS Operator CRD
-(`operator.openshift.io/v1`, kind `DNS`):
+This enhancement proposes a new API field.
+The implementation is controlled by a new
+BlockExternalDNSAccess feature gate and deployed 
+with one of the following methods:
 
-```go
-// DNSSpec is the specification of the desired behavior of the DNS.
-type DNSSpec struct {
-    // ... existing fields ...
+- **MachineConfig resources** (if using MCO approach)
+- **NodeFirewallConfiguration resources** (if using Node Firewall Operator
+  approach)
 
-    // externalAccessPolicy defines the policy for external access to
-    // CoreDNS pods. This field controls whether NetworkPolicies are
-    // created to restrict DNS queries from sources outside the cluster.
-    //
-    // When the BlockExternalDNSAccess feature gate is enabled, this
-    // enhancement follows a secure-by-default approach: external access
-    // is blocked by default unless explicitly allowed.
-    //
-    // Valid values are:
-    //
-    // - "" (empty string): External access to CoreDNS is blocked via
-    //   NetworkPolicies. Only DNS queries originating from within the
-    //   cluster (pod network, service network, and node network) are
-    //   permitted. External sources will be unable to query CoreDNS.
-    //   This is the default secure behavior when the field is omitted.
-    //
-    // - "Allow": Explicitly allows external access to CoreDNS. No
-    //   NetworkPolicies are applied by the DNS operator for access
-    //   control. CoreDNS access uses the default cluster network
-    //   configuration. Use this value when external access to CoreDNS
-    //   is required (e.g., for external monitoring systems).
-    //
-    // - "Deny": Explicitly blocks all external access to CoreDNS via
-    //   NetworkPolicies. Only DNS queries originating from within the
-    //   cluster (pod network, service network, and node network) are
-    //   permitted. This value has the same behavior as the empty string
-    //   but allows administrators to explicitly document their intent to
-    //   block external access.
-    //
-    // Future values may include policies for allowlisting specific external
-    // sources or custom access control configurations.
-    //
-    // This field requires the BlockExternalDNSAccess feature gate to be
-    // enabled.
-    //
-    // +optional
-    // +openshift:enable:FeatureGate=BlockExternalDNSAccess
-    ExternalAccessPolicy string `json:"externalAccessPolicy,omitempty"`
-}
-```
-
-This enhancement modifies the behavior of the DNS Operator to create and
-manage NetworkPolicy resources targeting CoreDNS pods in the openshift-dns
-namespace.
+**Open Question**: If per-cluster configuration is needed (to allow
+administrators to override the default blocking behavior without disabling
+the feature gate entirely), the new API field is required. Options include:
+1. A new CRD specifically for on-prem CoreDNS access control (e.g.,
+   `BaremetalDNSAccessPolicy`)
+2. A field in an existing CRD like DNS
+3. A ConfigMap-based configuration
+4. Annotations on MachineConfigPool resources
 
 ### Topology Considerations
 
+This enhancement is **specific to bare metal OpenShift deployments** where
+CoreDNS runs on the host network namespace for node-level DNS resolution.
+
 #### Hypershift / Hosted Control Planes
 
-In Hypershift deployments, CoreDNS runs in the hosted cluster (guest
-cluster), not in the management cluster. The NetworkPolicies created by
-this enhancement will apply to the CoreDNS pods in the hosted cluster's
-data plane.
+**Not Applicable**: Hypershift deployments typically run on cloud
+infrastructure (AWS, Azure, GCP) where network security is managed via
+cloud provider security groups and network ACLs. On-prem CoreDNS on host
+network is not a typical deployment pattern for Hypershift.
 
-This enhancement is fully applicable to Hypershift deployments. The DNS
-operator running in the management cluster will manage the NetworkPolicies
-in the hosted cluster just as it manages other DNS configurations.
+If Hypershift is deployed on bare metal infrastructure, the same firewall
+rules would apply to the bare metal worker nodes in the hosted cluster.
 
 #### Standalone Clusters
 
-This enhancement is primarily designed for standalone clusters where
-CoreDNS runs in the cluster's openshift-dns namespace. It provides direct
-security hardening for these deployments.
+**Applicable to bare metal standalone clusters only**: This enhancement
+applies to standalone OpenShift clusters deployed on bare metal
+infrastructure where nodes run CoreDNS on the host network for host-level
+DNS resolution.
 
 #### Single-node Deployments or MicroShift
 
-For Single-Node OpenShift (SNO) deployments, this enhancement provides the
-same security benefits. The resource overhead of NetworkPolicies is
-minimal and should not impact SNO resource consumption significantly.
+**Single-Node OpenShift (SNO) on bare metal**: If SNO is deployed on bare
+metal infrastructure, this enhancement applies and provides security
+hardening for the on-prem CoreDNS instance running on the single node.
 
-For MicroShift, DNS is typically handled differently and CoreDNS may be
-managed outside the DNS operator. This enhancement may not apply directly
-to MicroShift unless CoreDNS is managed via the DNS operator in that
-environment.
-
-<!-- TODO: Validate MicroShift applicability and DNS management approach -->
+**MicroShift**: DNS architecture in MicroShift may differ from standard
+OpenShift. Applicability needs to be validated based on whether MicroShift
+runs CoreDNS on the host network namespace.
 
 #### OpenShift Kubernetes Engine
 
-This enhancement applies to OKE deployments as they include the DNS
-operator and CoreDNS components. The security hardening provided is
-beneficial for OKE clusters as well.
+**OKE on bare metal only**: This enhancement applies to OKE deployments
+only if they are running on bare metal infrastructure. Cloud-based OKE
+deployments use cloud provider network security controls.
 
 ### Implementation Details/Notes/Constraints
 
-The implementation requires changes to the following components:
+The implementation requires the following components and changes:
 
-1. **openshift/api**: Add the `ExternalAccessPolicy` field to the DNS CRD
-   with the appropriate feature gate marker
-   (`+openshift:enable:FeatureGate=BlockExternalDNSAccess`)
-
-2. **openshift/cluster-dns-operator**: Update the DNS operator to:
-   - Read the feature gate state using the feature gate accessor pattern
-   - When the BlockExternalDNSAccess feature gate is enabled, apply
-     secure-by-default behavior
-   - Watch the DNS resource for the `externalAccessPolicy` field
-   - Create NetworkPolicy resources when:
-     - The feature gate is enabled AND the field is empty/unset (default)
-     - The field is explicitly set to "Deny"
-   - Delete NetworkPolicy resources when the field is set to "Allow"
-   - Reconcile NetworkPolicies to ensure they are not modified or deleted
-
-3. **NetworkPolicy specification**: The NetworkPolicies will:
-   - Target CoreDNS pods using label selectors (e.g., `dns.operator.
-     openshift.io/daemonset-dns=default`)
-   - Allow ingress on UDP and TCP port 53 from:
-     - Cluster pod CIDR (obtained from Network CR)
-     - Cluster service CIDR (obtained from Network CR)
-     - Node network (obtained from cluster network configuration)
-   - Use a deny-by-default approach (no egress restrictions needed for
-     this feature)
-
-4. **Feature gate creation**: A new feature gate `BlockExternalDNSAccess`
+1. **Feature gate creation**: A new feature gate `BlockExternalDNSAccess`
    must be added to https://github.com/openshift/api/blob/master/features/
    features.go with:
    - Initial feature set: DevPreviewNoUpgrade
-   - Jira component: Networking / DNS
-   - Enhancement PR link (this enhancement)
-   - Contact person and owning product (ocpSpecific)
+   - Jira component: Networking / DNS (or potentially Baremetal)
+   - Contact person (bnemec)
+
+2. **Implementation approach** (one of the following):
+
+   **Option A: Machine Config Operator (MCO) approach**:
+   - Create MachineConfig resources that deploy firewall rules to bare
+     metal nodes
+   - MachineConfig will configure nftables rules directly
+   - Target bare metal machine pools specifically
+   - Firewall rules will:
+     - Allow DNS (UDP/TCP port 53) from localhost (127.0.0.1, ::1)
+     - Allow DNS from other cluster node IPs (determine dynamically or via
+       static CIDR configuration)
+     - Deny all other DNS traffic to port 53
+
+   **Option B: Node Firewall Operator approach (if available)**:
+   - Create NodeFirewallConfiguration resources
+   - Leverage Node Firewall Operator to manage firewall rules
+   - Simpler declarative API compared to MachineConfig
+   - Requires Node Firewall Operator to be available and mature
+
+3. **Configuration mechanism** (if per-cluster override is needed):
+   - Determine how administrators can override the default blocking
+     behavior
+   - Options: new CRD, ConfigMap, annotations, or feature gate
+     disable-only
+   - See Open Questions for decision points
 
 **Constraints and considerations**:
 
-- The implementation depends on the CNI plugin supporting NetworkPolicies
-  (OVN-Kubernetes, Calico, etc.). Clusters using CNI plugins that do not
-  support NetworkPolicies will not be able to use this feature.
-- Getting accurate cluster CIDR ranges requires querying the Network CR
-  and cluster configuration, which may vary by platform and installation
-  type.
-- The NetworkPolicies must be kept in sync with any changes to cluster
-  network configuration (e.g., if additional pod or service CIDRs are
-  added).
+- This feature applies **only to bare metal deployments**. Cloud
+  deployments (AWS, Azure, GCP, etc.) are excluded.
+- The implementation must correctly identify cluster node IPs to allow
+  inter-node DNS queries while blocking external access.
+- Firewall rules must persist across node reboots.
+- MCO-managed configurations may cause node reboots when applied, which
+  needs to be documented.
+- The exact firewall mechanism (nftables) may
+  depend on the RHCOS version and node configuration.
+- Node Firewall Operator availability and maturity needs to be validated
+  for target OpenShift versions.
 
 ### Risks and Mitigations
 
 **Risk**: Enabling the feature gate automatically blocks external access by
 default, which could disrupt existing workflows or external monitoring
-systems that rely on querying CoreDNS from outside the cluster.
+systems that rely on querying on-prem CoreDNS from outside the cluster.
 
 **Mitigation**:
 - Comprehensive documentation warning administrators about the
   secure-by-default behavior when enabling the feature gate
-- Provide clear instructions on how to set `externalAccessPolicy: Allow`
-  before enabling the feature gate if external access is required
+- Provide clear instructions on how to disable the feature gate or apply
+  override configuration (if available) if external access is required
 - Start with DevPreviewNoUpgrade to gather feedback from early adopters
   about any disruption scenarios
 - Include prominent warnings in release notes and feature gate
   documentation
 
-**Risk**: NetworkPolicies may inadvertently block legitimate DNS traffic if
-cluster CIDR ranges are incorrectly identified or if there are edge cases
-in network topology.
+**Risk**: Firewall rules may inadvertently block legitimate DNS traffic if
+cluster node IP ranges are incorrectly identified or if there are edge
+cases in network topology or node IP address changes.
 
-**Mitigation**: Extensive testing across different platforms and network
-configurations. Provide clear documentation on how to verify the feature
-is working correctly and how to allow external access if issues arise.
+**Mitigation**: Extensive testing across different bare metal network
+configurations (IPv4, IPv6, dual stack). Provide clear documentation on how
+to verify firewall rules are working correctly and how to debug DNS access
+issues. Include instructions on checking firewall rules via SSH to nodes.
 Start with DevPreviewNoUpgrade to gather feedback before promoting to Tech
 Preview or GA.
 
-**Risk**: CNI plugins that do not support NetworkPolicies will silently
-fail to enforce the blocking, creating a false sense of security.
+**Risk**: Firewall rule deployment via MachineConfig may cause node reboots
+on bare metal nodes, potentially disrupting workloads during initial
+deployment or configuration changes.
 
-**Mitigation**: The DNS operator should detect if NetworkPolicy support is
-available in the cluster (by checking CNI capabilities) and report a
-degraded status with a clear message if NetworkPolicies cannot be enforced.
+**Mitigation**: Document the potential for node reboots clearly. Provide
+guidance on using maintenance windows when enabling the feature gate.
+Consider using Node Firewall Operator (if available) which may avoid node
+reboots for firewall rule changes.
 
-**Risk**: Changes to cluster network configuration during cluster lifecycle
-may cause NetworkPolicies to become outdated (e.g., new CIDR ranges added).
+**Risk**: Changes to cluster node IP addresses during cluster lifecycle
+(e.g., node replacement, network reconfiguration) may cause firewall rules
+to become outdated, blocking legitimate inter-node DNS traffic.
 
-**Mitigation**: The DNS operator should watch the Network CR and
-automatically update NetworkPolicies when cluster network configuration
-changes.
+**Mitigation**: The MCO or Node Firewall Operator should reconcile firewall
+rules when node network configuration changes. Provide monitoring and
+alerting to detect when inter-node DNS queries are blocked. Document
+troubleshooting procedures for verifying and updating node IP allowlists in
+firewall rules.
 
 **Risk**: External monitoring or health check systems that need to query
-CoreDNS will be blocked by default when the feature gate is enabled.
+on-prem CoreDNS will be blocked by default when the feature gate is
+enabled.
 
 **Mitigation**: Document this limitation clearly and prominently. Provide
 guidance on alternative approaches for external monitoring (e.g.,
 monitoring through cluster API or using internal monitoring agents). Make
-it easy to set `externalAccessPolicy: Allow` for clusters that require
-external access. Consider adding configuration to allow specific external
-IPs if needed in future iterations.
+it easy to disable the feature gate or apply override configuration for
+clusters that require external access. Consider adding configuration to
+allow specific external IPs if needed in future iterations.
 
 ### Drawbacks
 
 - The secure-by-default approach means that enabling the feature gate will
   immediately block external access, which could disrupt existing workflows
-  or external monitoring systems that rely on querying CoreDNS from outside
-  the cluster without warning
-- This feature adds complexity to the DNS operator with additional
-  reconciliation logic for NetworkPolicies
-- NetworkPolicies introduce additional resource overhead (minimal, but
-  non-zero)
+  or external monitoring systems that rely on querying on-prem CoreDNS
+  from outside the cluster without warning
+- This feature adds complexity to bare metal node configuration management
+  with additional logic for managing node-level firewall rules or CoreDNS
+  configuration
+- Node-level firewall rules introduce additional complexity in node
+  configuration management and potential conflicts with other operators
+  managing firewall state
 - Organizations with external DNS monitoring or testing tools will need to
-  explicitly set `externalAccessPolicy: Allow` to maintain their existing
-  workflows
-- The feature is CNI-dependent and will not work on clusters with CNI
-  plugins that don't support NetworkPolicies
+  disable the feature gate or apply override configuration to maintain
+  their existing workflows
+- The implementation approach (node firewall vs CoreDNS ACL) has trade-offs
+  and requires careful evaluation before finalizing the design
+- Debugging firewall-related issues on nodes requires SSH access and
+  knowledge of node-level firewall mechanisms (nftables), which is more
+  complex than debugging Kubernetes-native resources
+- MachineConfig deployment may cause node reboots, impacting workload
+  availability during initial feature enablement
 
 ## Alternatives (Not Implemented)
 
-### Alternative 1: Configure CoreDNS ACL Plugin
+### Alternative 1: Use NetworkPolicies
 
-Instead of NetworkPolicies, configure CoreDNS with an ACL plugin to reject
-queries from external sources based on source IP.
+Use Kubernetes NetworkPolicies to block external access to CoreDNS.
 
 **Pros**:
-- Does not depend on CNI NetworkPolicy support
-- Can provide more granular control (e.g., query-based filtering)
+- Kubernetes-native approach
+- Declarative resource management
+- Well-understood by cluster administrators
+- No node-level changes required
 
 **Cons**:
-- Requires modifying CoreDNS configuration which adds complexity
-- Less standard approach compared to NetworkPolicies
-- Performance overhead of checking ACLs for every query
-- ACL configuration needs to be maintained and synchronized with cluster
-  network changes
+- **Does not work for on-prem CoreDNS**: NetworkPolicies apply to pod
+  traffic only, not to processes running on the host network namespace.
+  Since on-prem CoreDNS runs on the host network, NetworkPolicies
+  cannot be used to restrict access to it.
+- Would only work if targeting the in-cluster CoreDNS pods (not the scope
+  of this enhancement)
 
-**Reason not selected**: NetworkPolicies are a more Kubernetes-native
-approach and are enforced at the network layer before traffic reaches
-CoreDNS, providing better performance and security.
+**Reason not selected**: This alternative does not apply to on-prem
+CoreDNS running on the host network. NetworkPolicies only control traffic
+to pods, not to host-network services.
 
-### Alternative 2: Firewall Rules at Node Level
+### Alternative 2: Do Not Expose On-Premises CoreDNS Externally
 
-Use node-level firewall rules (iptables/nftables) to block external access
-to CoreDNS service IPs.
-
-**Pros**:
-- Works regardless of CNI plugin capabilities
-- Can be enforced at node level with high performance
-
-**Cons**:
-- Requires managing firewall rules on every node
-- More complex to implement across different node operating systems and
-  firewall implementations
-- Harder to manage lifecycle (what happens during node upgrades, reboots,
-  etc.)
-
-**Reason not selected**: NetworkPolicies provide a cleaner abstraction and
-are managed declaratively through Kubernetes resources, making them easier
-to maintain and reason about.
-
-### Alternative 3: Do Not Expose CoreDNS Externally
-
-Simply document that CoreDNS should not be exposed externally and leave it
-to cluster administrators to ensure proper network configuration.
+Simply document that on-prem CoreDNS should not be exposed externally
+and leave it to cluster administrators to ensure proper network
+configuration (e.g., via cloud security groups, hardware firewalls).
 
 **Pros**:
-- No code changes required
+- No code changes required in OpenShift
 - Maximum flexibility for administrators
+- Leverages existing infrastructure security controls
 
 **Cons**:
 - Relies on manual configuration which is error-prone
-- Does not provide defense-in-depth
-- No enforcement mechanism
+- Does not provide defense-in-depth at the cluster level
+- No enforcement mechanism within OpenShift
+- Inconsistent security posture across different deployment environments
 
 **Reason not selected**: This enhancement provides defense-in-depth and
-enforces security best practices by default, reducing the risk of
-misconfiguration.
+enforces security best practices by default at the OpenShift cluster level,
+reducing the risk of misconfiguration and providing consistent security
+across all deployment environments.
 
 ## Open Questions
 
-1. Should we provide configuration to allow specific external IP ranges
+1. Which implementation approach should we use?
+   - **Option A**: Node-level firewall rules (Node Firewall Operator, MCO,
+     or direct nftables management)
+   - **Option B**: CoreDNS ACL plugin configuration
+   - Decision criteria: availability of Node Firewall Operator, complexity,
+     maintainability, performance, security depth, platform compatibility
+   - **Recommendation needed** to finalize the approach
+
+2. If using node-level firewall rules, which mechanism should deploy them?
+   - Node Firewall Operator (if available and mature)
+   - Machine Config Operator (MachineConfig resources)
+   - Direct management by DNS operator (most complex, least desirable)
+
+3. Should we provide configuration to allow specific external IP ranges
    (e.g., for monitoring systems) in addition to the "Allow" and "Deny"
    options?
 
-2. Should we add observability metrics to track blocked DNS queries from
-   external sources?
+4. Should we add observability metrics to track blocked DNS queries from
+   external sources? (This may be more feasible with CoreDNS ACL than with
+   firewall rules)
 
-3. For future iterations, should we consider DNS query rate limiting as
+5. For future iterations, should we consider DNS query rate limiting as
    an additional security layer?
 
-4. Is the secure-by-default approach (blocking external access when the
+6. Is the secure-by-default approach (blocking external access when the
    feature gate is enabled) the right choice, or should administrators be
    required to explicitly opt-in to blocking? The current design prioritizes
    security but may cause disruption for clusters with external dependencies
-   on CoreDNS.
+   on on-prem CoreDNS.
 
 ## Test Plan
 
 The test plan will include:
 
 1. **Unit tests**:
-   - DNS operator logic for creating/updating/deleting NetworkPolicies
+   - Logic for creating/updating/deleting MachineConfig or
+     NodeFirewallConfiguration resources
    - Feature gate detection and handling
-   - Validation of DNS CR with blockExternalAccess field
+   - Firewall rule generation logic
 
 2. **Integration tests**:
-   - Verify NetworkPolicies are created when blockExternalAccess is
-     enabled
-   - Verify NetworkPolicies are removed when blockExternalAccess is
-     disabled
-   - Verify NetworkPolicies allow internal cluster DNS traffic
-   - Verify NetworkPolicies block external DNS traffic (simulate external
-     query)
+   - Verify firewall rules are deployed when the feature gate is enabled
+   - Verify firewall rules are removed when the feature gate is disabled
+   - Verify firewall rules allow localhost DNS traffic
+   - Verify firewall rules allow inter-node DNS traffic
+   - Verify firewall rules block external DNS traffic
 
-3. **E2E tests** (in openshift/origin):
+3. **E2E tests** (in openshift/origin or openshift-tests-extension):
    - All tests must include the following labels:
      - `[OCPFeatureGate:BlockExternalDNSAccess]` - feature gate label
-     - `[Jira:"Networking / DNS"]` - component label
-     - `[Suite:openshift/network]` - test suite label (if applicable)
+     - `[Jira:"Networking / DNS"]` or `[Jira:"Baremetal"]` - component
+       label
+     - `[Suite:openshift/baremetal]` - test suite label (if applicable)
      - Additional labels as needed: `[Serial]`, `[Slow]`, `[Disruptive]`
-   - Test that internal pods can resolve DNS after enabling the feature
-   - Test that external entities cannot query CoreDNS (requires test
-     infrastructure to simulate external access)
-   - Test across different CNI plugins (OVN-Kubernetes, others if
-     supported)
+   - Test that localhost can resolve DNS after enabling the feature
+   - Test that nodes can query each other's CoreDNS after enabling the
+     feature
+   - Test that external entities cannot query on-prem CoreDNS (requires
+     test infrastructure to simulate external access)
+   - Test on bare metal platforms only
    - Test upgrade scenarios where the feature is enabled before upgrade
-   - Test that the feature gracefully handles CNI plugins without
-     NetworkPolicy support
+   - Test that MachineConfig or NodeFirewallConfiguration is correctly
+     applied and persists across node reboots
 
 For detailed test labeling conventions, see dev-guide/test-conventions.md.
 
@@ -559,14 +634,7 @@ DevPreviewNoUpgrade -> TechPreviewNoUpgrade -> Default (GA).
     empty/unset or set to "Deny"
   - External DNS queries succeed when `externalAccessPolicy` is set to
     "Allow"
-  - NetworkPolicies are created and managed correctly by DNS operator
   - Upgrade scenario with feature enabled
-- Tests run successfully on at least AWS and one other platform (e.g.,
-  Azure or GCP)
-- Unit and integration tests for DNS operator NetworkPolicy management
-  logic
-- Test coverage for CNI plugins that don't support NetworkPolicies
-  (operator should degrade gracefully)
 
 **Documentation**:
 - End user documentation explaining:
@@ -580,24 +648,19 @@ DevPreviewNoUpgrade -> TechPreviewNoUpgrade -> Default (GA).
   learned from Dev Preview
 
 **Operational Requirements**:
-- DNS operator exposes metrics for NetworkPolicy creation/reconciliation
-- DNS operator reports degraded status when CNI doesn't support
-  NetworkPolicies
 - No major bugs or regressions reported in Dev Preview
-- Validation that NetworkPolicies correctly identify cluster CIDRs across
-  different network configurations and platforms
 
 **Feedback**:
-- Gathered feedback from at least 3 early adopter clusters
+- Gathered feedback from at least 3 early adopter bare metal clusters
 - Documented any workflows that were disrupted by the secure-by-default
   behavior
-- Validated that `externalAccessPolicy: Allow` successfully addresses use
-  cases requiring external access
+- Validated that disabling the feature gate or override configuration
+  successfully addresses use cases requiring external access
 
-**API Stability**:
-- The `externalAccessPolicy` field API is stable and no breaking changes
-  are anticipated
-- API has been reviewed and approved by API reviewers
+**API Stability** (if applicable):
+- Any new API field/CRD is stable and no breaking changes are anticipated
+- API has been reviewed and approved by API reviewers (if new API is
+  introduced)
 
 ### Tech Preview -> GA
 
@@ -607,84 +670,73 @@ DevPreviewNoUpgrade -> TechPreviewNoUpgrade -> Default (GA).
   `[OCPFeatureGate:BlockExternalDNSAccess]` label
 - **Test frequency**: All tests run at least 7 times per week
 - **Platform coverage**: All tests run at least 14 times on each supported
-  platform:
-  - AWS (HA, amd64, default network)
-  - AWS (Single, amd64, default network)
-  - Azure (HA, amd64, default network)
-  - GCP (HA, amd64, default network)
-  - vSphere (HA, amd64, default network)
+  **bare metal platform**:
   - Baremetal (HA, amd64, IPv4)
   - Baremetal (HA, amd64, IPv6 - disconnected)
   - Baremetal (HA, amd64, Dual stack)
+  - Baremetal (Single-node/SNO, amd64) if applicable
 - **Pass rate**: 95% or higher pass rate across all test runs
 - **Test duration**: Tests have been running for at least 14 days before
   branch cut
 - **Test variants**: Tests run in both `TechPreviewNoUpgrade` and `Default`
   job variants (skipped in Default until promoted)
+- **Note**: This feature is bare metal only, so tests will only run on bare
+  metal platforms
 
 **Comprehensive Testing**:
 - Upgrade testing:
-  - Upgrade from version without feature to version with feature
-    (validates no disruption when feature gate is disabled)
-  - Upgrade with feature gate enabled and `externalAccessPolicy` set to
-    "Allow" (validates external access remains functional)
-  - Upgrade with feature gate enabled and default secure behavior
-    (validates NetworkPolicies persist and reconcile)
+  - Upgrade from version without feature to version with feature on bare
+    metal (validates no disruption when feature gate is disabled)
+  - Upgrade with feature gate enabled (validates firewall rules persist
+    and external access remains blocked)
+  - Upgrade with feature gate enabled and override configuration allowing
+    external access (if applicable)
 - Downgrade testing:
-  - Downgrade with feature enabled (validates NetworkPolicies can be
-    manually cleaned up)
-  - Documentation for manual cleanup steps if needed
+  - Downgrade with feature enabled on bare metal
+  - Documentation for manual cleanup steps if needed (removing
+    MachineConfig or NodeFirewallConfiguration)
+- Node reboot testing:
+  - Verify firewall rules persist across node reboots
+  - Verify MCO reapplies configuration after reboot
 - Scale testing:
-  - Feature works correctly in clusters with custom/additional pod and
-    service CIDRs
-  - NetworkPolicy updates when cluster network configuration changes
-- Version skew testing:
-  - DNS operator at N+1, CoreDNS at N
-  - CNI upgrade scenarios
+  - Feature works correctly when nodes are added/removed from cluster
+  - Firewall rules are correctly applied to new bare metal nodes
 
 **Documentation**:
 - User-facing documentation in openshift-docs including:
-  - Configuration guide
+  - Configuration guide for bare metal deployments
   - Security implications and best practices
-  - Troubleshooting guide
-  - Migration guide for clusters with external DNS dependencies
-- Release notes documenting the secure-by-default behavior
-- CNI compatibility matrix clearly documented
+  - Troubleshooting guide (how to check firewall rules on nodes)
+  - Migration guide for bare metal clusters with external DNS dependencies
+- Release notes documenting the secure-by-default behavior for bare metal
+- Bare metal platform requirements clearly documented
 
 **Operational Maturity**:
-- Metrics for monitoring:
-  - NetworkPolicy creation/update/deletion events
-  - DNS operator condition status related to this feature
-  - Optionally: metrics for blocked external DNS queries (if feasible)
-- Alerts defined for:
-  - DNS operator degraded when NetworkPolicy support is unavailable
-  - NetworkPolicy creation failures
+- Optionally: metrics for blocked external DNS queries (if feasible)
 - Performance validation:
-  - DNS query latency impact measured (should be negligible)
-  - NetworkPolicy reconciliation overhead is acceptable
+  - DNS query latency impact measured on bare metal nodes (should be
+    negligible)
+  - Firewall rule performance impact measured
 
 **User Feedback**:
-- Positive feedback from Tech Preview users
+- Positive feedback from Tech Preview users on bare metal
 - No major usability issues reported
-- Documented common use cases and their solutions
-- Validation that the secure-by-default approach is acceptable to users
+- Documented common use cases and their solutions for bare metal
+- Validation that the secure-by-default approach is acceptable to bare
+  metal users
 
 **Security and API Review**:
 - Security review completed and signed off
-- API review completed and approved (if any API changes from Tech Preview)
-- Confirmation that the feature provides meaningful security hardening
+- API review completed and approved (if new API is introduced)
+- Confirmation that the feature provides meaningful security hardening for
+  bare metal deployments
 
 **Platform Compatibility**:
-- Feature works correctly with all supported CNI plugins:
-  - OVN-Kubernetes (primary)
-  - Others if applicable
-- Graceful degradation documented and tested for CNI plugins without
-  NetworkPolicy support
-- Feature tested on all supported topologies:
-  - Standalone clusters
-  - Hypershift/Hosted Control Planes
-  - Single-Node OpenShift (SNO)
-  - OKE (if applicable)
+- Feature works correctly on all supported bare metal configurations:
+  - IPv4, IPv6, and Dual stack networking
+  - HA and SNO topologies
+- Feature tested on bare metal platforms only (not applicable to cloud
+  deployments)
 
 **Production Readiness**:
 - No critical or high-severity bugs open
@@ -697,175 +749,186 @@ DevPreviewNoUpgrade -> TechPreviewNoUpgrade -> Default (GA).
 **Upgrades**:
 
 When upgrading from a version without this feature to a version with this
-feature:
+feature on bare metal:
 - The feature gate will be disabled by default (Dev Preview)
-- Existing clusters will see no change in DNS behavior unless
+- Existing bare metal clusters will see no change in DNS behavior unless
   administrators explicitly enable the BlockExternalDNSAccess feature gate
 - **IMPORTANT**: Once the feature gate is enabled, the secure-by-default
-  behavior activates immediately. External access to CoreDNS will be
-  blocked automatically via NetworkPolicies unless administrators
-  explicitly set `externalAccessPolicy: Allow` in the DNS CR
-- Administrators who need external CoreDNS access must proactively set
-  `externalAccessPolicy: Allow` before or immediately after enabling the
-  feature gate to avoid service disruption
+  behavior activates immediately. External access to on-prem CoreDNS on
+  bare metal nodes will be blocked automatically via firewall rules
+- Administrators who need external CoreDNS access must proactively disable
+  the feature gate or apply override configuration (if available) before
+  or immediately after enabling to avoid service disruption
+- MachineConfig deployment may cause node reboots on bare metal nodes
 
 When upgrading with the feature already enabled:
-- The DNS operator will continue to maintain the NetworkPolicies
+- Firewall rules will persist during the upgrade
 - The feature should remain functional during the upgrade
-- If the NetworkPolicies are temporarily deleted during upgrade, the DNS
-  operator will recreate them during reconciliation
 - The secure-by-default behavior persists across upgrades
+- MachineConfig or NodeFirewallConfiguration resources are reconciled by
+  MCO/Node Firewall Operator
 
 **Downgrades**:
 
-When downgrading from a version with this feature to a version without it:
-- The NetworkPolicies created by the DNS operator will remain in the
-  cluster (Kubernetes does not delete resources during downgrades)
-- Administrators should manually delete the NetworkPolicies if they want
-  to restore the previous behavior
-- Documentation will include steps to clean up NetworkPolicies after
-  downgrade
-
-If downgrading with the feature enabled causes issues:
-- The DNS CR may contain the `blockExternalAccess` field that the older
-  DNS operator doesn't understand
-- The older DNS operator will ignore unknown fields, so this should not
-  cause errors
-- The NetworkPolicies will persist but will not be managed (no
-  reconciliation)
+When downgrading from a version with this feature to a version without it
+on bare metal:
+- MachineConfig or NodeFirewallConfiguration resources may remain in the
+  cluster
+- Firewall rules may persist on nodes even after downgrade
+- Documentation will include steps to manually clean up:
+  - Remove MachineConfig resources related to this feature
+  - Remove NodeFirewallConfiguration resources (if applicable)
+  - Optionally manually remove firewall rules from nodes
 
 ## Version Skew Strategy
 
-During an upgrade where the DNS operator is updated but other components
-are still at older versions:
-- The DNS operator creates NetworkPolicies that target CoreDNS pods
-- CoreDNS pods themselves do not need to be aware of this feature
-- The CNI plugin (OVN-Kubernetes) enforces NetworkPolicies and should
-  handle them correctly regardless of version
+This feature is implemented via MachineConfig or NodeFirewallConfiguration
+resources and does not have significant version skew concerns:
 
-If the CoreDNS version changes during an upgrade:
-- The NetworkPolicies use label selectors, not version-specific targeting
-- As long as CoreDNS pods maintain the same labels, NetworkPolicies will
-  continue to apply
+During an upgrade on bare metal:
+- MachineConfig resources are managed by MCO, which handles version skew
+- NodeFirewallConfiguration resources are managed by Node Firewall
+  Operator
+- Firewall rules are applied at the node level and persist regardless of
+  cluster component versions
+- On-prem CoreDNS does not need to be aware of this feature
 
-If the CNI plugin is upgraded during cluster upgrade:
-- NetworkPolicy enforcement is handled by the CNI
-- Temporary loss of NetworkPolicy enforcement during CNI upgrade is
-  acceptable (brief window)
-- DNS operator will verify NetworkPolicies exist after CNI upgrade
+If nodes are upgraded at different times:
+- Each node's firewall rules are managed independently by MCO or Node
+  Firewall Operator
+- Nodes at different versions can coexist - each enforces its own firewall
+  rules
+- No coordination required between nodes for this feature
+
+If MCO or Node Firewall Operator is upgraded:
+- Existing firewall rules persist on nodes
+- The upgraded operator continues to reconcile the MachineConfig or
+  NodeFirewallConfiguration resources
+- No disruption to DNS access control during operator upgrades
 
 ## Operational Aspects of API Extensions
 
-This enhancement modifies the DNS CRD (`operator.openshift.io/v1`, kind
-`DNS`) by adding a new optional field `blockExternalAccess`. This is an
-additive change that does not modify existing behavior when the field is
-not set.
+This enhancement may introduce a new API (TBD - see Open Questions) for
+per-cluster configuration override, or it may be controlled solely by the
+BlockExternalDNSAccess feature gate with no new APIs.
 
-**SLIs for monitoring DNS operator health**:
-- Existing DNS operator condition `Degraded=False` should remain false
-- Existing DNS operator condition `Available=True` should remain true
-- DNS operator logs will include messages about NetworkPolicy creation,
-  updates, and reconciliation
+If a new API is introduced (e.g., a new CRD like
+`BaremetalDNSAccessPolicy`):
+
+**SLIs for monitoring**:
+- Standard Kubernetes API availability metrics apply
+- No specific operator health conditions are introduced (this is managed
+  by MCO or Node Firewall Operator)
 
 **Impact on existing SLIs**:
-- Minimal impact on API throughput as the DNS CR is infrequently updated
+- Minimal impact - new API would be infrequently updated (typically once
+  per cluster, if at all)
 - No impact on pod scheduling or other cluster operations
-- NetworkPolicy creation/updates are rare events (only when DNS CR changes
-  or during reconciliation)
-- DNS query performance should not be impacted (NetworkPolicies are
-  evaluated at network layer before reaching CoreDNS)
+- MachineConfig deployment may cause node reboots (standard MCO behavior)
+- DNS query performance should not be impacted (firewall rules are
+  evaluated at kernel level with minimal overhead)
 
 **Measurement**:
 - Performance testing will be conducted during Tech Preview to measure any
-  DNS query latency impact
-- Testing will be performed by the networking QE team as part of standard
-  regression testing
+  DNS query latency impact on bare metal nodes
+- Testing will be performed by the networking or bare metal QE team
 
 **Failure modes**:
-- **NetworkPolicy creation fails**: DNS operator will report Degraded
-  condition with a message indicating NetworkPolicy creation failure. DNS
-  resolution continues to work normally, but external access is not
-  blocked.
-- **CNI does not support NetworkPolicies**: DNS operator should detect
-  this and report Degraded condition with message "NetworkPolicy support
-  not available in cluster CNI". Feature cannot be enabled.
-- **NetworkPolicy is deleted by user**: DNS operator reconciliation will
-  recreate it within the reconciliation interval (typically 5-10 minutes).
+- **MachineConfig application fails**: MCO will report degraded status.
+  Firewall rules may not be applied to some nodes. DNS resolution
+  continues to work normally, but external access may not be blocked on
+  affected nodes.
+- **Firewall rules incorrectly block inter-node traffic**: Nodes may be
+  unable to query each other's CoreDNS. Requires fixing firewall rule
+  configuration (node IP allowlist).
+- **Feature gate enabled on non-bare-metal cluster**: No effect - feature
+  only applies to bare metal. No harm done.
 
 **Impact on cluster health**:
-- NetworkPolicy failures do not impact DNS resolution functionality
+- Firewall rule failures do not impact DNS resolution functionality
 - Cluster operations continue normally even if this feature fails
 - No impact on kube-controller-manager or other core components
+- Node reboots may occur when MachineConfig is first applied (standard MCO
+  behavior)
 
 **Teams involved in escalations**:
-- Primary: Networking team (DNS component)
-- Secondary: CNI team (OVN-Kubernetes) for NetworkPolicy enforcement issues
+- Primary: Networking team or Bare Metal team
+- Secondary: MCO team (if using MachineConfig approach) or Node Firewall
+  team (if using Node Firewall Operator)
 
 ## Support Procedures
 
 **Detecting failure modes**:
 
-1. **Feature gate is enabled but NetworkPolicies are not created**:
-   - Symptom: `oc get networkpolicies -n openshift-dns` shows no policies
-     related to CoreDNS access control, even though the feature gate is
-     enabled and `externalAccessPolicy` is empty or "Deny"
-   - Check DNS operator logs: `oc logs -n openshift-dns-operator deployment/
-     dns-operator`
-   - Look for errors mentioning NetworkPolicy creation
-   - Check DNS operator conditions: `oc get dns.operator.openshift.io/
-     default -o yaml` and examine status conditions
+1. **Feature gate is enabled but firewall rules are not applied**:
+   - Symptom: External DNS queries to on-prem CoreDNS on bare metal nodes
+     succeed even though the feature gate is enabled
+   - Check if MachineConfig exists: `oc get machineconfig | grep dns` or
+     `oc get nodefirewallconfiguration`
+   - Check MCO status: `oc get mcp` and examine status of bare metal
+     machine config pools
+   - SSH to a bare metal node and check firewall rules:
+     - `sudo nft list ruleset | grep 53`
+   - Check MCO logs: `oc logs -n openshift-machine-config-operator
+     deployment/machine-config-operator`
 
-2. **External access is still possible despite feature gate being enabled**:
-   - Symptom: External DNS queries to CoreDNS succeed even though the
-     feature gate is enabled and `externalAccessPolicy` is not set to
-     "Allow"
-   - Verify NetworkPolicies exist and are correctly configured
-   - Check if CNI supports NetworkPolicies: `oc get network.config.
-     openshift.io/cluster -o yaml` and examine networkType
-   - Verify CNI is enforcing policies (CNI-specific debugging)
+2. **Nodes cannot query each other's CoreDNS after enabling feature**:
+   - Symptom: Inter-node communication fails, nodes cannot resolve names
+     via other nodes' CoreDNS
+   - SSH to a node and check firewall rules to verify cluster node IPs are
+     in the allowlist
+   - Verify the firewall rule configuration includes correct node IP ranges
+   - Check if node IPs have changed (e.g., after node replacement)
 
-3. **Internal DNS resolution fails after enabling feature gate**:
-   - Symptom: Pods cannot resolve DNS after enabling the
-     BlockExternalDNSAccess feature gate
-   - Check NetworkPolicy rules to ensure cluster CIDRs are correctly
-     specified
-   - Verify pod and service CIDRs: `oc get network.config.openshift.io/
-     cluster -o yaml`
-   - Check NetworkPolicy logs/events in CNI plugin
+3. **Localhost DNS resolution fails after enabling feature gate**:
+   - Symptom: Services on the node itself cannot resolve DNS
+   - SSH to the node and check if localhost (127.0.0.1, ::1) is allowed in
+     firewall rules
+   - Verify firewall rules: `sudo nft list ruleset | grep 127.0.0.1`
 
 4. **External monitoring stops working after enabling feature gate**:
-   - Symptom: External monitoring systems can no longer query CoreDNS
-     after enabling the BlockExternalDNSAccess feature gate
+   - Symptom: External monitoring systems can no longer query on-prem
+     CoreDNS on bare metal nodes after enabling the BlockExternalDNSAccess
+     feature gate
    - This is expected behavior due to secure-by-default
-   - Solution: Set `externalAccessPolicy: Allow` if external access is
-     required
+   - Solution: Disable the feature gate or apply override configuration (if
+     available)
 
 **Allowing external access**:
 
-To allow external access to CoreDNS (disabling the default blocking):
-1. Update the DNS CR: `oc edit dns.operator.openshift.io/default` and
-   set `externalAccessPolicy: Allow`
-2. Verify NetworkPolicies are removed: `oc get networkpolicies -n
-   openshift-dns`
-3. External DNS queries should now succeed
+To allow external access to on-prem CoreDNS (disabling the default
+blocking):
+1. **Option 1**: Disable the BlockExternalDNSAccess feature gate entirely
+   - This removes the MachineConfig/NodeFirewallConfiguration
+   - External access will be allowed cluster-wide
+2. **Option 2**: Apply override configuration (if available - see Open
+   Questions)
+   - Create the appropriate configuration resource to override the default
+   - This may allow per-cluster customization
+3. Verify firewall rules are removed from nodes:
+   - SSH to a node and check: `sudo nft list ruleset | grep 53`
+4. External DNS queries should now succeed
 
 **Consequences of allowing external access**:
-- External entities can query CoreDNS (if network topology permits)
-- Security posture is reduced - cluster DNS becomes accessible from
+- External entities can query on-prem CoreDNS on bare metal nodes (if
+  network topology permits)
+- Security posture is reduced - on-prem DNS becomes accessible from
   outside the cluster
 - Increased risk of DNS-based reconnaissance and amplification attacks
+  targeting bare metal infrastructure
 - No impact on existing workloads or cluster health
 - No data loss or configuration loss
 
 **Graceful failure and recovery**:
-- If the DNS operator crashes while managing NetworkPolicies, the
-  NetworkPolicies remain in place (enforced by CNI)
-- When the DNS operator restarts, it will reconcile and recreate any
-  missing NetworkPolicies
-- If NetworkPolicies are manually deleted, the DNS operator will recreate
-  them during the next reconciliation cycle
-- Internal DNS resolution is never impacted by this feature's failure
-  (fail-open for internal traffic)
+- If MCO or Node Firewall Operator crashes, firewall rules remain in place
+  on nodes (enforced by kernel)
+- When MCO or Node Firewall Operator restarts, it will reconcile and
+  reapply any missing/incorrect firewall rules
+- If firewall rules are manually removed from a node, MCO will reapply
+  them on next reconciliation (or on node reboot)
+- DNS resolution functionality is never impacted by this feature's failure
+  - even if firewall rules fail to apply, localhost and inter-node DNS
+  continue to work
 
 ## Infrastructure Needed
 

--- a/enhancements/network/block-external-access-to-coredns.md
+++ b/enhancements/network/block-external-access-to-coredns.md
@@ -9,7 +9,7 @@ approvers:
 api-approvers:
   - TBD
 creation-date: 2026-03-25
-last-updated: 2026-03-31
+last-updated: 2026-06-01
 status: provisional
 tracking-link:
   - https://redhat.atlassian.net/browse/OPNET-679
@@ -29,12 +29,12 @@ BlockExternalDNSAccess feature gate is enabled, external access is
 automatically blocked unless explicitly allowed.
 
 This enhancement is **specific to bare metal nodes** and does NOT involve
-the cluster DNS Operator. It explores two implementation
-approaches:
-1. **Node-level firewall rules** using the Node Firewall Operator or
-   MachineConfig
-2. **CoreDNS ACL plugin** to reject queries from external sources at the
-   application level via CoreDNS configuration
+the cluster DNS Operator. The implementation adds firewall rule management
+to the `coredns-monitor` container in `openshift/baremetal-runtimecfg`,
+following the proven pattern established by `haproxy-monitor` for managing
+nftables rules on bare metal nodes. Configuration is controlled via a new
+`externalDNSAccessPolicy` field in the Infrastructure object's
+`BareMetalPlatformSpec`.
 
 This security hardening measure prevents unauthorized external entities
 from querying on-prem DNS, mitigates DNS amplification/reflection attacks,
@@ -78,13 +78,9 @@ the cluster.
   reduce the attack surface of my OpenShift cluster and comply with
   security policies that require DNS isolation.
 
-* As a **cluster administrator**, I want to deploy proof-of-concept (POC)
-  clusters without sitewide DNS changes.
-
-* As a **security engineer**, I want to ensure that DNS queries to the
-  on-prem CoreDNS instances can only originate from within the cluster
-  nodes or internal networks so that I can prevent DNS-based reconnaissance
-  and amplification attacks targeting my infrastructure.
+* As a **cluster administrator**, I want the option to allow external
+  access to on-prem CoreDNS when required (e.g., for external monitoring
+  systems) so that I can balance security hardening with operational needs.
 
 * As a **platform team member** managing multi-tenant OpenShift
   environments, I want to enforce DNS access control for on-prem
@@ -109,13 +105,10 @@ the cluster.
 * Reduce the risk of data exfiltration through DNS queries to on-prem
   CoreDNS on bare metal nodes
 * Ensure DNS queries to on-prem CoreDNS can only originate from localhost
-  or other cluster nodes (unless explicitly allowed)
-* Determine how to make this configurable (if needed) to allow external
-  access when required (e.g., for monitoring) without involving the DNS
-  Operator
-* Determine the most appropriate implementation approach (node firewall vs
-  CoreDNS ACL) based on operational considerations, performance, and
-  maintainability for bare metal deployments
+  by default (unless explicitly allowed via configuration)
+* Provide a simple configuration toggle (`externalDNSAccessPolicy` in the
+  Infrastructure object) to allow external access when required (e.g., for
+  monitoring) without involving the DNS Operator
 
 ### Non-Goals
 
@@ -126,7 +119,6 @@ the cluster.
   involve the cluster DNS Operator
 * Applying to cloud deployments (AWS, Azure, GCP, etc.) - this enhancement
   is specific to bare metal infrastructure
-* Blocking DNS queries between bare metal nodes within the cluster
 * Implementing DNS query rate limiting or throttling
 * Replacing or removing on-prem CoreDNS from bare metal nodes
 
@@ -146,74 +138,61 @@ the cluster DNS Operator, as the DNS Operator manages the in-cluster
 CoreDNS service used by workloads, not the on-prem CoreDNS on bare metal
 nodes.
 
-This enhancement explores two viable implementation approaches for bare
-metal deployments:
+### Implementation: coredns-monitor Firewall Management
 
-### Approach 1: Node-Level Firewall Rules
+The implementation adds nftables firewall rule management to the
+`coredns-monitor` container in the `openshift/baremetal-runtimecfg`
+repository. This follows the proven pattern established by
+`haproxy-monitor`, which already manages iptables/nftables rules for API
+VIP traffic redirection on bare metal nodes.
 
-Use node-level firewall mechanisms (nftables) to block external
-access to the CoreDNS service port (typically UDP/TCP 53) on each bare
-metal node. This could be implemented via:
-
-- **Node Firewall Operator**: Leverage existing Node Firewall Operator
-  (if available) to deploy and manage firewall rules across all
-  bare metal nodes
-- **Machine Config Operator (MCO)**: Use MCO to configure firewall rules
-  via MachineConfig resources targeting bare metal machine pools
+**Why coredns-monitor?**
+- `coredns-monitor` already runs as a sidecar alongside the CoreDNS static
+  pod on every bare metal node
+- It already monitors DNS config changes, watches `resolv.conf`, and
+  updates the CoreDNS Corefile
+- `haproxy-monitor` (same repository) already manages firewall rules,
+  providing a direct implementation analog
+- Using coredns-monitor means firewall rules are managed by the same
+  component that manages CoreDNS config
+- Works on Hypershift bare metal deployments without requiring MCO
+- No additional operator dependencies (Node Firewall Operator not
+  required)
 
 **Pros**:
 - Blocks traffic at the network layer before it reaches CoreDNS (defense
   in depth)
 - Works regardless of CoreDNS configuration or plugins
 - Provides OS-level enforcement that's harder to bypass
-- Can be applied consistently across all nodes
+- Leverages existing infrastructure (coredns-monitor is already deployed)
+- Proven pattern (haproxy-monitor already does this for API VIP)
+- No MCO dependency for rule management (avoids node reboots for rule
+  changes)
+- Works on both standalone and Hypershift bare metal deployments
 
 **Cons**:
 - Requires managing firewall state on every node
-- More complex to implement and maintain across different node OS versions
-- Potential conflicts with other firewall rules managed by different
-  operators
 - Harder to debug when issues occur (need to check firewall state on
   nodes)
-- Node Firewall Operator may not be available in all environments
 
 ### Proposed Implementation Path
 
-This enhancement proposes starting with **Approach 1 (Node-Level Firewall
-Rules)** as the initial implementation, with the following high-level
-steps:
-
-1. Create MachineConfig resources (or NodeFirewallConfiguration resources
-   if using Node Firewall Operator) that deploy firewall rules to bare
-   metal nodes
-2. Firewall rules will:
+1. Extend `coredns-monitor` in `openshift/baremetal-runtimecfg` to manage
+   nftables rules for DNS port access, modeled on `haproxy-monitor`'s
+   firewall rule management
+2. `coredns-monitor` reads the `externalDNSAccessPolicy` field from the
+   Infrastructure object's `BareMetalPlatformSpec` to determine behavior
+3. When `externalDNSAccessPolicy` is `Deny` (default) or unset,
+   `coredns-monitor` applies nftables rules that:
    - Allow DNS queries from localhost (127.0.0.1, ::1)
-   - Allow DNS queries from other cluster nodes (node IPs within cluster
-     CIDR)
    - Deny all other DNS queries from external sources
-3. Apply these configurations via one of the following methods:
-   - MCO MachineConfig targeting bare metal machine pools
-   - Node Firewall Operator NodeFirewallConfiguration resources
-4. Configuration will be enabled when the BlockExternalDNSAccess feature
-   gate is enabled
-
-**Open Questions**:
-1. The exact mechanism for deploying firewall rules (Node Firewall
-   Operator vs MCO) needs to be determined based on:
-   - Availability and maturity of Node Firewall Operator
-   - Complexity and maintainability of each approach
-   - Performance impact and resource overhead
-   - Compatibility with RHCOS and different node operating systems
-
-2. How to make this configurable if administrators need to allow external
-   access? Options:
-   - Feature gate controls default behavior only (no per-cluster config)
-   - Introduce a new CR/ConfigMap separate from DNS Operator
-   - Use cluster-level annotations or labels
-   - MCO-based configuration override mechanism
-
-The alternative approach 1 (CoreDNS ACL) remains a viable fallback if
-node-level firewall management proves too complex or problematic.
+4. When `externalDNSAccessPolicy` is `Allow`, `coredns-monitor` removes
+   or does not apply the blocking nftables rules
+5. `coredns-monitor` continuously reconciles the nftables rules, ensuring
+   they remain in place after node reboots or manual changes
+6. The BlockExternalDNSAccess feature gate controls the Tech Preview -> GA
+   lifecycle; once GA, the feature is always active and controlled by the
+   Infrastructure object field
 
 ### Workflow Description
 
@@ -223,53 +202,48 @@ security and configuration.
 **Bare metal node** is an OpenShift cluster node running CoreDNS on the
 host network for host-level DNS resolution.
 
-**MCO (Machine Config Operator)** or **Node Firewall Operator** is the
-component responsible for deploying and enforcing firewall rules on bare
-metal nodes.
+**coredns-monitor** is the sidecar container running alongside the
+CoreDNS static pod on each bare metal node, responsible for managing
+CoreDNS configuration and (with this enhancement) nftables firewall
+rules.
 
 #### Workflow: Enabling External Access Blocking (Default Secure Behavior)
 
 1. The cluster administrator enables the Tech Preview feature set
    on the cluster to activate the BlockExternalDNSAccess feature gate.
 
-2. When the feature gate is enabled, the system automatically applies the
-   secure-by-default behavior. A MachineConfig (or
-   NodeFirewallConfiguration) is deployed that configures firewall rules
-   on bare metal nodes to block external access to on-prem CoreDNS.
+2. When the feature gate is enabled, `coredns-monitor` on each bare metal
+   node reads the `externalDNSAccessPolicy` field from the Infrastructure
+   object. If the field is unset or set to `Deny`, `coredns-monitor`
+   applies the secure-by-default behavior.
 
-3. The MCO (or Node Firewall Operator) deploys the firewall configuration
-   to all bare metal nodes.
-
-4. Firewall rules are applied on each bare metal node that:
+3. `coredns-monitor` applies nftables rules on the node that:
    - Allow DNS traffic (UDP/TCP port 53) from localhost (127.0.0.1, ::1)
-   - Allow DNS traffic (UDP/TCP port 53) from other cluster node IPs
-     (within cluster node CIDR)
    - Deny all other DNS traffic from external sources to port 53
 
-5. The firewall mechanism (nftables) on each node
-   enforces the rules.
+4. The nftables rules on each node enforce the blocking.
 
-6. Any DNS queries to on-prem CoreDNS from external sources are blocked by
-   the node firewall, while internal node-to-node and localhost DNS
-   queries continue to work normally.
+5. Any DNS queries to on-prem CoreDNS from external sources are blocked by
+   the node firewall, while localhost DNS queries continue to work
+   normally.
 
-7. If a bare metal node is rebooted, the MCO ensures the firewall
-   configuration persists and is reapplied.
+6. `coredns-monitor` continuously reconciles the nftables rules, ensuring
+   they remain in place after node reboots or manual changes.
 
 ```mermaid
 sequenceDiagram
     participant Admin as Cluster Administrator
     participant FG as Feature Gate
-    participant MCO as MCO/Node Firewall Operator
-    participant Node as Bare Metal Nodes
+    participant Infra as Infrastructure Object
+    participant Monitor as coredns-monitor (per node)
+    participant Node as Bare Metal Node
 
     Admin->>FG: Enable BlockExternalDNSAccess feature gate
-    FG->>MCO: Feature gate enabled
-    MCO->>MCO: Create MachineConfig with firewall rules
-    MCO->>Node: Deploy firewall configuration
-    Node->>Node: Apply nftables rules
-    Note over Node: Block external DNS traffic Allow localhost + node IPs
-    MCO->>Node: Reconcile on reboot/config drift
+    Monitor->>Infra: Read externalDNSAccessPolicy
+    Infra-->>Monitor: Deny (default)
+    Monitor->>Node: Apply nftables rules
+    Note over Node: Block external DNS traffic Allow localhost only
+    Monitor->>Node: Reconcile on reboot/config drift
 ```
 
 #### Variation: Allowing External Access
@@ -278,44 +252,50 @@ If a cluster administrator needs to allow external access to on-prem
 CoreDNS on bare metal nodes (e.g., for external monitoring systems or
 specific network requirements):
 
-**Option 1: Disable the feature gate** (if external access is needed
-cluster-wide):
-1. The administrator disables the BlockExternalDNSAccess feature gate
-2. The MachineConfig with firewall rules is removed
-3. On-prem CoreDNS becomes accessible from external networks
-
-**Option 2: Override via custom configuration** (if per-cluster control is
-implemented):
-1. The administrator creates a custom configuration resource (exact
-   mechanism TBD - see Open Questions) that overrides the default blocking
-   behavior
-2. The MCO/Node Firewall Operator removes firewall rules based on the
-   override configuration
+1. The administrator sets `externalDNSAccessPolicy: Allow` in the
+   Infrastructure object's `BareMetalPlatformSpec`
+2. `coredns-monitor` on each node detects the configuration change and
+   removes the blocking nftables rules
 3. On-prem CoreDNS becomes accessible from external networks (subject to
    other network controls like hardware firewalls, network ACLs, etc.)
 
-**Note**: The exact mechanism for per-cluster configuration override is an
-open question that needs to be resolved during implementation design.
+Administrators needing fine-grained control (e.g., specific IP allowlists)
+can manage their own firewall rules in addition to this toggle. The
+`externalDNSAccessPolicy` field provides a simple cluster-wide on/off
+control for the common case.
 
 ### API Extensions
 
-This enhancement proposes a new API field.
-The implementation is controlled by a new
-BlockExternalDNSAccess feature gate and deployed 
-with one of the following methods:
+This enhancement adds a new field to the Infrastructure object's
+`BareMetalPlatformSpec` in `openshift/api`. The Infrastructure object is
+where most bare metal host networking configuration already lives
+(including `APIServerInternalIPs`, `IngressIPs`, and `MachineNetworks`),
+making it the natural location for this setting.
 
-- **MachineConfig resources** (if using MCO approach)
-- **NodeFirewallConfiguration resources** (if using Node Firewall Operator
-  approach)
+**New field in `BareMetalPlatformSpec`**:
 
-**Open Question**: If per-cluster configuration is needed (to allow
-administrators to override the default blocking behavior without disabling
-the feature gate entirely), the new API field is required. Options include:
-1. A new CRD specifically for on-prem CoreDNS access control (e.g.,
-   `BaremetalDNSAccessPolicy`)
-2. A field in an existing CRD like DNS
-3. A ConfigMap-based configuration
-4. Annotations on MachineConfigPool resources
+```go
+// ExternalDNSAccessPolicy controls whether external access to
+// on-prem CoreDNS instances on bare metal nodes is allowed.
+// When set to "Deny" (the default), coredns-monitor applies nftables
+// rules to block external DNS traffic, allowing only localhost access.
+// When set to "Allow", no blocking rules are applied and external
+// entities can query CoreDNS on bare metal nodes.
+// +kubebuilder:default=Deny
+// +optional
+ExternalDNSAccessPolicy ExternalDNSAccessPolicyType `json:"externalDNSAccessPolicy,omitempty"`
+```
+
+The `ExternalDNSAccessPolicyType` is a string type with two valid values:
+- `Deny` (default): Block external access to CoreDNS. `coredns-monitor`
+  applies nftables rules allowing only localhost.
+- `Allow`: Do not block external access. `coredns-monitor` removes or
+  skips blocking rules.
+
+The feature is additionally gated by the `BlockExternalDNSAccess` feature
+gate during the Tech Preview phase. Once the feature reaches GA, the
+feature gate is removed and the `externalDNSAccessPolicy` field is the
+sole control mechanism.
 
 ### Topology Considerations
 
@@ -324,13 +304,17 @@ CoreDNS runs on the host network namespace for node-level DNS resolution.
 
 #### Hypershift / Hosted Control Planes
 
-**Not Applicable**: Hypershift deployments typically run on cloud
-infrastructure (AWS, Azure, GCP) where network security is managed via
-cloud provider security groups and network ACLs. On-prem CoreDNS on host
-network is not a typical deployment pattern for Hypershift.
+**Applicable for bare metal Hypershift**: Bare metal Hypershift is an
+increasingly relevant deployment target. Since MCO does not run in hosted
+clusters, any MCO-based approach would not work for Hypershift. The
+`coredns-monitor` approach naturally handles this because `coredns-monitor`
+runs as part of the CoreDNS static pod on each bare metal node, regardless
+of whether the cluster is standalone or hosted. No MCO dependency is
+required for firewall rule management.
 
-If Hypershift is deployed on bare metal infrastructure, the same firewall
-rules would apply to the bare metal worker nodes in the hosted cluster.
+For cloud-based Hypershift deployments (AWS, Azure, GCP), this feature is
+not applicable as network security is managed via cloud provider security
+groups and network ACLs.
 
 #### Standalone Clusters
 
@@ -366,45 +350,42 @@ The implementation requires the following components and changes:
    - Jira component: Networking / DNS (or potentially Baremetal)
    - Contact person (bnemec)
 
-2. **Implementation approach** (one of the following):
+2. **API field**: Add `externalDNSAccessPolicy` field to the
+   `BareMetalPlatformSpec` in the Infrastructure object (see API
+   Extensions section).
 
-   **Option A: Machine Config Operator (MCO) approach**:
-   - Create MachineConfig resources that deploy firewall rules to bare
-     metal nodes
-   - MachineConfig will configure nftables rules directly
-   - Target bare metal machine pools specifically
-   - Firewall rules will:
-     - Allow DNS (UDP/TCP port 53) from localhost (127.0.0.1, ::1)
-     - Allow DNS from other cluster node IPs (determine dynamically or via
-       static CIDR configuration)
-     - Deny all other DNS traffic to port 53
+3. **coredns-monitor enhancement** (in `openshift/baremetal-runtimecfg`):
+   - Add nftables rule management to `coredns-monitor`, modeled on
+     `haproxy-monitor`'s existing firewall rule management
+   - `coredns-monitor` reads the Infrastructure object to determine the
+     value of `externalDNSAccessPolicy`
+   - When `Deny` (default): apply nftables rules that allow DNS
+     (UDP/TCP port 53) from localhost (127.0.0.1, ::1) and deny all other
+     DNS traffic to port 53
+   - When `Allow`: remove or skip the blocking nftables rules
+   - Continuously reconcile rules to ensure they persist across reboots
+     and configuration drift
 
-   **Option B: Node Firewall Operator approach (if available)**:
-   - Create NodeFirewallConfiguration resources
-   - Leverage Node Firewall Operator to manage firewall rules
-   - Simpler declarative API compared to MachineConfig
-   - Requires Node Firewall Operator to be available and mature
-
-3. **Configuration mechanism** (if per-cluster override is needed):
-   - Determine how administrators can override the default blocking
-     behavior
-   - Options: new CRD, ConfigMap, annotations, or feature gate
-     disable-only
-   - See Open Questions for decision points
+   Note: The concern about nftables rules not working with OVN-Kubernetes
+   shared gateway mode was investigated. For *inbound* external traffic to
+   host-network CoreDNS, nftables rules work because this traffic is not
+   managed by OVN-K. OVN-K shared gateway mode affects how egress traffic
+   is routed, not how inbound traffic to host-network services is
+   processed. The existing `haproxy-monitor` firewall rules for API VIP
+   redirection confirm that host-level nftables rules function correctly
+   in shared gateway mode.
 
 **Constraints and considerations**:
 
 - This feature applies **only to bare metal deployments**. Cloud
   deployments (AWS, Azure, GCP, etc.) are excluded.
-- The implementation must correctly identify cluster node IPs to allow
-  inter-node DNS queries while blocking external access.
-- Firewall rules must persist across node reboots.
-- MCO-managed configurations may cause node reboots when applied, which
-  needs to be documented.
-- The exact firewall mechanism (nftables) may
-  depend on the RHCOS version and node configuration.
-- Node Firewall Operator availability and maturity needs to be validated
-  for target OpenShift versions.
+- Firewall rules must persist across node reboots; `coredns-monitor`
+  reconciles rules continuously.
+- The `coredns-monitor` container already runs as part of the CoreDNS
+  static pod on bare metal nodes, so no new deployment mechanism is
+  needed.
+- The exact nftables rule syntax may depend on the RHCOS version and node
+  configuration.
 
 ### Risks and Mitigations
 
@@ -415,16 +396,15 @@ systems that rely on querying on-prem CoreDNS from outside the cluster.
 **Mitigation**:
 - Comprehensive documentation warning administrators about the
   secure-by-default behavior when enabling the feature gate
-- Provide clear instructions on how to disable the feature gate or apply
-  override configuration (if available) if external access is required
+- Provide clear instructions on how to set `externalDNSAccessPolicy:
+  Allow` in the Infrastructure object if external access is required
 - Start with Tech Preview to gather feedback from early adopters
   about any disruption scenarios
 - Include prominent warnings in release notes and feature gate
   documentation
 
-**Risk**: Firewall rules may inadvertently block legitimate DNS traffic if
-cluster node IP ranges are incorrectly identified or if there are edge
-cases in network topology or node IP address changes.
+**Risk**: Firewall rules may inadvertently block legitimate DNS traffic
+in edge cases related to network topology.
 
 **Mitigation**: Extensive testing across different bare metal network
 configurations (IPv4, IPv6, dual stack). Provide clear documentation on how
@@ -432,24 +412,13 @@ to verify firewall rules are working correctly and how to debug DNS access
 issues. Include instructions on checking firewall rules via SSH to nodes.
 Start with Tech Preview to gather feedback before promoting to GA.
 
-**Risk**: Firewall rule deployment via MachineConfig may cause node reboots
-on bare metal nodes, potentially disrupting workloads during initial
-deployment or configuration changes.
+**Risk**: Firewall rules applied by `coredns-monitor` may conflict with
+other firewall rules managed by different components on the node.
 
-**Mitigation**: Document the potential for node reboots clearly. Provide
-guidance on using maintenance windows when enabling the feature gate.
-Consider using Node Firewall Operator (if available) which may avoid node
-reboots for firewall rule changes.
-
-**Risk**: Changes to cluster node IP addresses during cluster lifecycle
-(e.g., node replacement, network reconfiguration) may cause firewall rules
-to become outdated, blocking legitimate inter-node DNS traffic.
-
-**Mitigation**: The MCO or Node Firewall Operator should reconcile firewall
-rules when node network configuration changes. Provide monitoring and
-alerting to detect when inter-node DNS queries are blocked. Document
-troubleshooting procedures for verifying and updating node IP allowlists in
-firewall rules.
+**Mitigation**: Use a dedicated nftables chain for DNS access control,
+following the same pattern used by `haproxy-monitor` for API VIP rules.
+This isolates the rules and avoids conflicts with other firewall
+management on the node.
 
 **Risk**: External monitoring or health check systems that need to query
 on-prem CoreDNS will be blocked by default when the feature gate is
@@ -457,10 +426,11 @@ enabled.
 
 **Mitigation**: Document this limitation clearly and prominently. Provide
 guidance on alternative approaches for external monitoring (e.g.,
-monitoring through cluster API or using internal monitoring agents). Make
-it easy to disable the feature gate or apply override configuration for
-clusters that require external access. Consider adding configuration to
-allow specific external IPs if needed in future iterations.
+monitoring through cluster API or using internal monitoring agents).
+Administrators can set `externalDNSAccessPolicy: Allow` in the
+Infrastructure object to restore external access. Administrators needing
+fine-grained control (specific IP allowlists) can manage their own
+firewall rules.
 
 ### Drawbacks
 
@@ -468,24 +438,23 @@ allow specific external IPs if needed in future iterations.
   immediately block external access, which could disrupt existing workflows
   or external monitoring systems that rely on querying on-prem CoreDNS
   from outside the cluster without warning
-- This feature adds complexity to bare metal node configuration management
-  with additional logic for managing node-level firewall rules or CoreDNS
-  configuration
-- Node-level firewall rules introduce additional complexity in node
-  configuration management and potential conflicts with other operators
-  managing firewall state
+- This feature adds complexity to the `coredns-monitor` container with
+  additional logic for managing nftables firewall rules
 - Organizations with external DNS monitoring or testing tools will need to
-  disable the feature gate or apply override configuration to maintain
-  their existing workflows
-- The implementation approach (node firewall vs CoreDNS ACL) has trade-offs
-  and requires careful evaluation before finalizing the design
+  set `externalDNSAccessPolicy: Allow` in the Infrastructure object to
+  maintain their existing workflows
 - Debugging firewall-related issues on nodes requires SSH access and
-  knowledge of node-level firewall mechanisms (nftables), which is more
-  complex than debugging Kubernetes-native resources
-- MachineConfig deployment may cause node reboots, impacting workload
-  availability during initial feature enablement
+  knowledge of nftables, which is more complex than debugging
+  Kubernetes-native resources
 
-## Alternatives
+### Removing a deprecated feature
+
+This enhancement does not remove any deprecated features. It introduces a
+new security hardening capability to block external access to CoreDNS
+instances running on bare metal cluster nodes. No existing functionality is
+being deprecated or removed as part of this enhancement.
+
+## Alternatives (Not Implemented)
 
 ### Alternative 1: CoreDNS ACL Plugin
 
@@ -552,53 +521,86 @@ enforces security best practices by default at the OpenShift cluster level,
 reducing the risk of misconfiguration and providing consistent security
 across all deployment environments.
 
+### Alternative 4: MCO-Based Firewall Management
+
+Use MCO to deploy nftables rules via MachineConfig on bare metal nodes.
+A controller watches the Infrastructure object and renders MachineConfig
+resources for MCO to apply.
+
+**Pros**:
+- Declarative, auditable configuration via MachineConfig
+- Well-understood operational model (MCO is standard for node config)
+- No code changes needed in `coredns-monitor` or `baremetal-runtimecfg`
+
+**Cons**:
+- Node reboots required when `externalDNSAccessPolicy` changes
+- No dynamic reconciliation — if rules are manually removed, they won't
+  be reapplied until next MCO render
+- Does not work on Hypershift bare metal deployments (MCO does not run
+  in hosted clusters)
+
+**Reason not selected**: MCO does not run in hosted clusters, making this
+approach incompatible with bare metal Hypershift deployments.
+`coredns-monitor` already runs on every bare metal node regardless of
+topology and provides dynamic reconciliation without node reboots.
+
 ## Open Questions
 
-1. Which implementation approach should we use?
-   - **Option A**: Node-level firewall rules (Node Firewall Operator, MCO,
-     or direct nftables management)
-   - **Option B**: CoreDNS ACL plugin configuration
-   - Decision criteria: availability of Node Firewall Operator, complexity,
-     maintainability, performance, security depth, platform compatibility
-   - **Recommendation needed** to finalize the approach
+### Resolved
 
-2. If using node-level firewall rules, which mechanism should deploy them?
-   - Node Firewall Operator (if available and mature)
-   - Machine Config Operator (MachineConfig resources)
-   - Direct management by DNS operator (most complex, least desirable)
+1. **Which implementation approach should we use?**
+   - **Resolved**: `coredns-monitor` in `openshift/baremetal-runtimecfg`
+     will manage nftables rules, following the proven pattern established
+     by `haproxy-monitor` for managing firewall rules on bare metal nodes.
 
-3. Should we provide configuration to allow specific external IP ranges
-   (e.g., for monitoring systems) in addition to the "Allow" and "Deny"
-   options?
+2. **Which mechanism should deploy the firewall rules?**
+   - **Resolved**: `coredns-monitor` manages rules directly. No MCO or
+     Node Firewall Operator dependency required.
 
-4. Should we add observability metrics to track blocked DNS queries from
-   external sources? (This may be more feasible with CoreDNS ACL than with
-   firewall rules)
+3. **Where should the configuration live?**
+   - **Resolved**: `externalDNSAccessPolicy` field in the Infrastructure
+     object's `BareMetalPlatformSpec`. This is where most bare metal host
+     networking configuration already lives.
 
-5. For future iterations, should we consider DNS query rate limiting as
+4. **Should we allow cross-node DNS queries?**
+   - **Resolved**: No. Each node has its own CoreDNS instance and there
+     is no normal use case where one node needs to query another's host
+     CoreDNS. Firewall rules allow localhost only by default.
+
+5. **Is the secure-by-default approach the right choice?**
+   - **Resolved**: Yes. The feature gate controls Tech Preview -> GA
+     lifecycle. Once GA, `externalDNSAccessPolicy` (defaulting to `Deny`)
+     provides the secure-by-default behavior. Administrators can set
+     `Allow` if external access is needed.
+
+### Open
+
+1. Should we add observability metrics to track blocked DNS queries from
+   external sources? This may be feasible by having `coredns-monitor` log
+   or expose metrics about nftables rule hit counts.
+
+2. For future iterations, should we consider DNS query rate limiting as
    an additional security layer?
 
-6. Is the secure-by-default approach (blocking external access when the
-   feature gate is enabled) the right choice, or should administrators be
-   required to explicitly opt-in to blocking? The current design prioritizes
-   security but may cause disruption for clusters with external dependencies
-   on on-prem CoreDNS.
+3. Should we provide configuration to allow specific external IP ranges
+   (e.g., for monitoring systems) in addition to the cluster-wide
+   `Allow`/`Deny` toggle? Current recommendation is that administrators
+   needing fine-grained control manage their own firewall rules.
 
 ## Test Plan
 
 The test plan will include:
 
 1. **Unit tests**:
-   - Logic for creating/updating/deleting MachineConfig or
-     NodeFirewallConfiguration resources
+   - `coredns-monitor` nftables rule generation and management logic
    - Feature gate detection and handling
-   - Firewall rule generation logic
+   - Infrastructure object `externalDNSAccessPolicy` field reading
 
 2. **Integration tests**:
    - Verify firewall rules are deployed when the feature gate is enabled
-   - Verify firewall rules are removed when the feature gate is disabled
+   - Verify firewall rules are removed when `externalDNSAccessPolicy` is
+     set to `Allow`
    - Verify firewall rules allow localhost DNS traffic
-   - Verify firewall rules allow inter-node DNS traffic
    - Verify firewall rules block external DNS traffic
 
 3. **E2E tests** (in openshift/origin or openshift-tests-extension):
@@ -609,14 +611,14 @@ The test plan will include:
      - `[Suite:openshift/baremetal]` - test suite label (if applicable)
      - Additional labels as needed: `[Serial]`, `[Slow]`, `[Disruptive]`
    - Test that localhost can resolve DNS after enabling the feature
-   - Test that nodes can query each other's CoreDNS after enabling the
-     feature
    - Test that external entities cannot query on-prem CoreDNS (requires
      test infrastructure to simulate external access)
    - Test on bare metal platforms only
    - Test upgrade scenarios where the feature is enabled before upgrade
-   - Test that MachineConfig or NodeFirewallConfiguration is correctly
-     applied and persists across node reboots
+   - Test that nftables rules are correctly applied and persist across
+     node reboots
+   - Test that setting `externalDNSAccessPolicy: Allow` removes blocking
+     rules
 
 For detailed test labeling conventions, see dev-guide/test-conventions.md.
 
@@ -632,16 +634,16 @@ TechPreviewNoUpgrade -> Default (GA).
   `[OCPFeatureGate:BlockExternalDNSAccess]` label covering:
   - Internal DNS resolution continues to work with feature enabled
     (default secure behavior)
-  - External DNS queries are blocked when `externalAccessPolicy` is
+  - External DNS queries are blocked when `externalDNSAccessPolicy` is
     empty/unset or set to "Deny"
-  - External DNS queries succeed when `externalAccessPolicy` is set to
+  - External DNS queries succeed when `externalDNSAccessPolicy` is set to
     "Allow"
   - Upgrade scenario with feature enabled
 
 **Documentation**:
 - End user documentation explaining:
   - The secure-by-default behavior when feature gate is enabled
-  - How to explicitly allow external access using `externalAccessPolicy:
+  - How to explicitly allow external access using `externalDNSAccessPolicy:
     Allow`
   - Limitations and CNI plugin requirements
   - How to verify the feature is working correctly
@@ -656,8 +658,8 @@ TechPreviewNoUpgrade -> Default (GA).
 - Gathered feedback from at least 3 early adopter bare metal clusters
 - Documented any workflows that were disrupted by the secure-by-default
   behavior
-- Validated that disabling the feature gate or override configuration
-  successfully addresses use cases requiring external access
+- Validated that setting `externalDNSAccessPolicy: Allow` successfully
+  addresses use cases requiring external access
 
 **API Stability** (if applicable):
 - Any new API field/CRD is stable and no breaking changes are anticipated
@@ -695,11 +697,11 @@ TechPreviewNoUpgrade -> Default (GA).
     external access (if applicable)
 - Downgrade testing:
   - Downgrade with feature enabled on bare metal
-  - Documentation for manual cleanup steps if needed (removing
-    MachineConfig or NodeFirewallConfiguration)
+  - Documentation for manual cleanup steps if needed (removing nftables
+    rules)
 - Node reboot testing:
   - Verify firewall rules persist across node reboots
-  - Verify MCO reapplies configuration after reboot
+  - Verify `coredns-monitor` reapplies rules after reboot
 - Scale testing:
   - Feature works correctly when nodes are added/removed from cluster
   - Firewall rules are correctly applied to new bare metal nodes
@@ -757,76 +759,73 @@ feature on bare metal:
   administrators explicitly enable the BlockExternalDNSAccess feature gate
 - **IMPORTANT**: Once the feature gate is enabled, the secure-by-default
   behavior activates immediately. External access to on-prem CoreDNS on
-  bare metal nodes will be blocked automatically via firewall rules
-- Administrators who need external CoreDNS access must proactively disable
-  the feature gate or apply override configuration (if available) before
-  or immediately after enabling to avoid service disruption
-- MachineConfig deployment may cause node reboots on bare metal nodes
+  bare metal nodes will be blocked automatically via nftables rules
+  managed by `coredns-monitor`
+- Administrators who need external CoreDNS access must proactively set
+  `externalDNSAccessPolicy: Allow` in the Infrastructure object before
+  or immediately after enabling the feature gate to avoid service
+  disruption
 
 When upgrading with the feature already enabled:
 - Firewall rules will persist during the upgrade
 - The feature should remain functional during the upgrade
 - The secure-by-default behavior persists across upgrades
-- MachineConfig or NodeFirewallConfiguration resources are reconciled by
-  MCO/Node Firewall Operator
+- `coredns-monitor` continues to reconcile nftables rules
 
 **Downgrades**:
 
 When downgrading from a version with this feature to a version without it
 on bare metal:
-- MachineConfig or NodeFirewallConfiguration resources may remain in the
-  cluster
-- Firewall rules may persist on nodes even after downgrade
+- nftables rules applied by `coredns-monitor` may persist on nodes after
+  downgrade if the older version of `coredns-monitor` does not manage them
+- The `externalDNSAccessPolicy` field in the Infrastructure object may
+  remain but will be ignored by the older version
 - Documentation will include steps to manually clean up:
-  - Remove MachineConfig resources related to this feature
-  - Remove NodeFirewallConfiguration resources (if applicable)
-  - Optionally manually remove firewall rules from nodes
+  - Remove nftables rules from nodes if they persist after downgrade
 
 ## Version Skew Strategy
 
-This feature is implemented via MachineConfig or NodeFirewallConfiguration
-resources and does not have significant version skew concerns:
+This feature is implemented via `coredns-monitor` managing nftables rules
+on each bare metal node and does not have significant version skew
+concerns:
 
 During an upgrade on bare metal:
-- MachineConfig resources are managed by MCO, which handles version skew
-- NodeFirewallConfiguration resources are managed by Node Firewall
-  Operator
+- Each node's `coredns-monitor` independently manages its own nftables
+  rules
 - Firewall rules are applied at the node level and persist regardless of
   cluster component versions
 - On-prem CoreDNS does not need to be aware of this feature
 
 If nodes are upgraded at different times:
-- Each node's firewall rules are managed independently by MCO or Node
-  Firewall Operator
+- Each node's firewall rules are managed independently by its local
+  `coredns-monitor` instance
 - Nodes at different versions can coexist - each enforces its own firewall
   rules
 - No coordination required between nodes for this feature
 
-If MCO or Node Firewall Operator is upgraded:
-- Existing firewall rules persist on nodes
-- The upgraded operator continues to reconcile the MachineConfig or
-  NodeFirewallConfiguration resources
-- No disruption to DNS access control during operator upgrades
+If `coredns-monitor` is upgraded (via static pod update):
+- Existing nftables rules persist on nodes
+- The upgraded `coredns-monitor` continues to reconcile nftables rules
+- No disruption to DNS access control during upgrades
 
 ## Operational Aspects of API Extensions
 
-This enhancement may introduce a new API (TBD - see Open Questions) for
-per-cluster configuration override, or it may be controlled solely by the
-BlockExternalDNSAccess feature gate with no new APIs.
-
-If a new API is introduced (e.g., a new CRD like
-`BaremetalDNSAccessPolicy`):
+This enhancement adds an `externalDNSAccessPolicy` field to the existing
+Infrastructure object's `BareMetalPlatformSpec`. No new CRDs are
+introduced.
 
 **SLIs for monitoring**:
-- Standard Kubernetes API availability metrics apply
-- No specific operator health conditions are introduced (this is managed
-  by MCO or Node Firewall Operator)
+- Standard Kubernetes API availability metrics apply (Infrastructure
+  object already exists)
+- No specific operator health conditions are introduced; `coredns-monitor`
+  manages rules as part of its existing sidecar role
 
 **Impact on existing SLIs**:
-- Minimal impact - new API would be infrequently updated (typically once
-  per cluster, if at all)
+- Minimal impact - the field is infrequently updated (typically once per
+  cluster, if at all)
 - No impact on pod scheduling or other cluster operations
-- MachineConfig deployment may cause node reboots (standard MCO behavior)
+- No node reboots required for configuration changes (coredns-monitor
+  applies rules dynamically)
 - DNS query performance should not be impacted (firewall rules are
   evaluated at kernel level with minimal overhead)
 
@@ -836,13 +835,13 @@ If a new API is introduced (e.g., a new CRD like
 - Testing will be performed by the networking or bare metal QE team
 
 **Failure modes**:
-- **MachineConfig application fails**: MCO will report degraded status.
-  Firewall rules may not be applied to some nodes. DNS resolution
-  continues to work normally, but external access may not be blocked on
-  affected nodes.
-- **Firewall rules incorrectly block inter-node traffic**: Nodes may be
-  unable to query each other's CoreDNS. Requires fixing firewall rule
-  configuration (node IP allowlist).
+- **coredns-monitor fails to apply rules**: If `coredns-monitor` crashes
+  or cannot apply nftables rules, DNS resolution continues to work
+  normally, but external access may not be blocked on affected nodes.
+  The `coredns-monitor` container will restart and retry.
+- **Firewall rules incorrectly block localhost traffic**: Localhost DNS
+  resolution may fail. Requires fixing firewall rule configuration to
+  ensure localhost (127.0.0.1, ::1) is in the allowlist.
 - **Feature gate enabled on non-bare-metal cluster**: No effect - feature
   only applies to bare metal. No harm done.
 
@@ -850,13 +849,10 @@ If a new API is introduced (e.g., a new CRD like
 - Firewall rule failures do not impact DNS resolution functionality
 - Cluster operations continue normally even if this feature fails
 - No impact on kube-controller-manager or other core components
-- Node reboots may occur when MachineConfig is first applied (standard MCO
-  behavior)
 
 **Teams involved in escalations**:
-- Primary: Networking team or Bare Metal team
-- Secondary: MCO team (if using MachineConfig approach) or Node Firewall
-  team (if using Node Firewall Operator)
+- Primary: Networking team or Bare Metal team (owners of
+  `openshift/baremetal-runtimecfg`)
 
 ## Support Procedures
 
@@ -865,48 +861,36 @@ If a new API is introduced (e.g., a new CRD like
 1. **Feature gate is enabled but firewall rules are not applied**:
    - Symptom: External DNS queries to on-prem CoreDNS on bare metal nodes
      succeed even though the feature gate is enabled
-   - Check if MachineConfig exists: `oc get machineconfig | grep dns` or
-     `oc get nodefirewallconfiguration`
-   - Check MCO status: `oc get mcp` and examine status of bare metal
-     machine config pools
+   - Check the Infrastructure object: `oc get infrastructure cluster -o
+     jsonpath='{.spec.platformSpec.baremetal.externalDNSAccessPolicy}'`
    - SSH to a bare metal node and check firewall rules:
      - `sudo nft list ruleset | grep 53`
-   - Check MCO logs: `oc logs -n openshift-machine-config-operator
-     deployment/machine-config-operator`
+   - Check `coredns-monitor` logs on the node:
+     - `crictl logs $(crictl ps --name coredns-monitor -q)`
 
-2. **Nodes cannot query each other's CoreDNS after enabling feature**:
-   - Symptom: Inter-node communication fails, nodes cannot resolve names
-     via other nodes' CoreDNS
-   - SSH to a node and check firewall rules to verify cluster node IPs are
-     in the allowlist
-   - Verify the firewall rule configuration includes correct node IP ranges
-   - Check if node IPs have changed (e.g., after node replacement)
-
-3. **Localhost DNS resolution fails after enabling feature gate**:
+2. **Localhost DNS resolution fails after enabling feature gate**:
    - Symptom: Services on the node itself cannot resolve DNS
    - SSH to the node and check if localhost (127.0.0.1, ::1) is allowed in
      firewall rules
    - Verify firewall rules: `sudo nft list ruleset | grep 127.0.0.1`
 
-4. **External monitoring stops working after enabling feature gate**:
+3. **External monitoring stops working after enabling feature gate**:
    - Symptom: External monitoring systems can no longer query on-prem
      CoreDNS on bare metal nodes after enabling the BlockExternalDNSAccess
      feature gate
    - This is expected behavior due to secure-by-default
-   - Solution: Disable the feature gate or apply override configuration (if
-     available)
+   - Solution: Set `externalDNSAccessPolicy: Allow` in the Infrastructure
+     object's `BareMetalPlatformSpec`
 
 **Allowing external access**:
 
 To allow external access to on-prem CoreDNS (disabling the default
 blocking):
-1. **Option 1**: Disable the BlockExternalDNSAccess feature gate entirely
-   - This removes the MachineConfig/NodeFirewallConfiguration
-   - External access will be allowed cluster-wide
-2. **Option 2**: Apply override configuration (if available - see Open
-   Questions)
-   - Create the appropriate configuration resource to override the default
-   - This may allow per-cluster customization
+1. Set `externalDNSAccessPolicy: Allow` in the Infrastructure object's
+   `BareMetalPlatformSpec`:
+   `oc patch infrastructure cluster --type merge -p '{"spec":{"platformSpec":{"baremetal":{"externalDNSAccessPolicy":"Allow"}}}}'`
+2. `coredns-monitor` on each node will detect the change and remove the
+   blocking nftables rules
 3. Verify firewall rules are removed from nodes:
    - SSH to a node and check: `sudo nft list ruleset | grep 53`
 4. External DNS queries should now succeed
@@ -922,15 +906,14 @@ blocking):
 - No data loss or configuration loss
 
 **Graceful failure and recovery**:
-- If MCO or Node Firewall Operator crashes, firewall rules remain in place
-  on nodes (enforced by kernel)
-- When MCO or Node Firewall Operator restarts, it will reconcile and
-  reapply any missing/incorrect firewall rules
-- If firewall rules are manually removed from a node, MCO will reapply
-  them on next reconciliation (or on node reboot)
+- If `coredns-monitor` crashes, firewall rules remain in place on nodes
+  (enforced by kernel)
+- When `coredns-monitor` restarts, it will reconcile and reapply any
+  missing/incorrect nftables rules
+- If firewall rules are manually removed from a node, `coredns-monitor`
+  will reapply them on next reconciliation cycle
 - DNS resolution functionality is never impacted by this feature's failure
-  - even if firewall rules fail to apply, localhost and inter-node DNS
-  continue to work
+  - even if firewall rules fail to apply, localhost DNS continues to work
 
 ## Infrastructure Needed
 


### PR DESCRIPTION
This enhancement proposes to block external access to CoreDNS instances running on bare metal OpenShift cluster nodes.