### PR TITLE
Add adversarial review skill for enhancement proposals

### DIFF
--- a/.claude/commands/review-enhancement.md
+++ b/.claude/commands/review-enhancement.md
@@ -1,0 +1,322 @@
+---
+description: Adversarial review of an OpenShift Enhancement Proposal
+args:
+  - name: file
+    description: >
+      (Optional) Path to the enhancement file to review. If omitted,
+      the skill will auto-discover candidates from uncommitted changes,
+      untracked files, and recent commits.
+    required: false
+  - name: repos
+    description: >
+      (Optional) Comma-separated paths to source code repos for
+      code-grounded review. If omitted, the skill will auto-discover
+      sibling directories referenced by the EP.
+      Example: ../library-go,../cluster-kube-apiserver-operator
+    required: false
+---
+
+You are the orchestrator for an adversarial review of an OpenShift Enhancement
+Proposal. Your review system is modeled on the most prolific reviewers in the
+openshift/enhancements repository, distilled from analysis of ~40,000 review
+comments across 586 merged PRs.
+
+## Step 1: Find the Enhancement to Review
+
+If `{{file}}` was provided and is non-empty, use it directly — skip
+discovery and go straight to reading the file. This fast-path exists
+for CI/PR automation where the target is already known.
+
+Otherwise, help the user locate the enhancement interactively:
+
+1. **Check uncommitted and untracked files first** — these are the most
+   likely candidates (someone just wrote or edited an EP):
+   ```
+   git status --porcelain -- 'enhancements/**/*.md'
+   git diff --name-only -- 'enhancements/**/*.md'
+   git diff --cached --name-only -- 'enhancements/**/*.md'
+   ```
+
+2. **Check recent commits** for recently added/modified enhancements:
+   ```
+   git log --oneline -10 --diff-filter=AM --name-only -- 'enhancements/**/*.md'
+   ```
+
+3. **Combine and deduplicate** all discovered files. Present them to the
+   user via AskUserQuestion, ordered by likelihood:
+   - Untracked files first (brand new EPs)
+   - Uncommitted modifications second
+   - Staged changes third
+   - Recent commits last
+   - Always include an "Other" option (AskUserQuestion provides this
+     automatically) so the user can type a custom path
+
+4. **If only one candidate**, still confirm with the user — don't assume.
+
+Read the selected enhancement file thoroughly.
+
+## Step 2: Discover Relevant Repos
+
+If `{{repos}}` was provided and is non-empty, use those paths directly —
+split on commas, verify each path exists, and skip discovery.
+
+Otherwise, auto-discover:
+
+1. **Parse the EP** for repository references. Look for:
+   - Explicit repo names (e.g., "library-go", "openshift/api",
+     "cluster-kube-apiserver-operator")
+   - Operator names that imply repos (e.g., "kube-apiserver-operator"
+     implies `../cluster-kube-apiserver-operator`)
+   - GitHub links to openshift/* repos
+   - Go import paths referencing openshift packages
+
+2. **Check for local siblings**. For each discovered repo name, check:
+   ```
+   ls -d ../{repo-name} 2>/dev/null
+   ```
+   Also check common patterns like `../openshift-{name}` and
+   `../cluster-{name}-operator`.
+
+3. **If local repos found**, use AskUserQuestion with multiSelect to
+   let the user pick which to include. Add a "Skip code analysis"
+   option for document-only review.
+
+4. **If no local repos found**, inform the user the review will be
+   document-only. Suggest which repos they could clone for a deeper
+   review next time.
+
+## Step 3: Spawn Parallel Review Agents
+
+Spawn the review agents **in parallel** using the Agent tool. Each agent
+gets a fresh context window and operates independently.
+
+**IMPORTANT**: Send ALL agent spawns in a SINGLE message so they run
+concurrently. Do not wait for one to finish before starting the next.
+
+Each agent's prompt must be self-contained. Include:
+- The path to the enhancement file (so the agent can read it)
+- The paths to reference docs the agent should read
+- The specific lens instructions for that agent
+- The repo paths (for Agent 4 only)
+
+### Agent 1: API Design & Document Quality Review
+
+**Lenses**: 1, 6, 7
+
+Reference docs to read:
+- The enhancement file
+- `dev-guide/api-conventions.md`
+- `dev-guide/feature-zero-to-hero.md`
+- `guidelines/enhancement_template.md`
+
+### Agent 2: Systems Safety & Upgrade Review
+
+**Lenses**: 2, 4
+
+Reference docs to read:
+- The enhancement file
+- `CONVENTIONS.md`
+
+### Agent 3: Architecture & Platform Scope Review
+
+**Lenses**: 3, 5
+
+Reference docs to read:
+- The enhancement file
+- `guidelines/enhancement_template.md`
+
+### Agent 4: Code Verification Review (only if repos selected)
+
+**Lens**: 8
+
+Only spawn this agent if repos were selected (either via `{{repos}}` arg
+or user selection in Step 2). It reads the enhancement file and explores
+the selected repos.
+
+## Step 4: Merge and Report
+
+After ALL agents return, synthesize findings into a single unified review:
+
+1. **Deduplicate**: If two agents flagged the same issue, keep the more
+   specific version.
+2. **Classify severity**: Ensure consistent BLOCKING / SIGNIFICANT / NIT
+   ratings.
+3. **Order by importance**: Blocking first, then code-grounded, then
+   significant, then nits.
+4. **Add Reviewer Simulations**: Pick the 3 most relevant archetypes:
+   - **API Guardian** (JoelSpeed-style)
+   - **Systems Thinker** (deads2k/p0lyn0mial-style)
+   - **Platform Advocate** (tssurya/simonpasquier-style)
+   - **Precision Editor** (Miciah-style)
+   - **Process Enforcer** (everettraven/bparees-style)
+   - **Simplifier** (zaneb/danwinship-style)
+   - **Security Pedant** (mtrmac/avishayt-style)
+   - **User Advocate** (dhellmann/candita-style)
+   - **Scope Enforcer** (staebler-style)
+   - **Upgrade Paranoid** (sdodson/jsafrane/sttts-style)
+5. **Note what's good**: 2-3 things the enhancement does well.
+
+## Output Format
+
+```
+### Summary
+One paragraph overall assessment.
+
+### Blocking Issues
+[merged from all agents]
+
+### Code-Grounded Findings (if repos were analyzed)
+[from Agent 4: CONTRADICTION / MISSING / UNDERSTATED / ACCURACY]
+
+### Significant Issues
+[merged from all agents]
+
+### Nits
+[grouped to reduce noise]
+
+### What's Good
+[2-3 positives]
+
+### Reviewer Simulations
+[3 archetypes, one paragraph each]
+```
+
+---
+
+## Lens Definitions
+
+Include the relevant lens text in each agent's prompt so it knows
+exactly what to check.
+
+### Lens 1: API Design Rigor
+
+Check every API change against OpenShift conventions from
+`dev-guide/api-conventions.md`:
+- Fields must be declarative nouns, not verbs
+- No `Ref` suffix in OpenShift APIs
+- Use `*Config` not `*Options` for configuration structs
+- Every field tagged `+optional` or `+required`
+- Godoc must start with json tag name, describe valid values/validations
+- Use discriminated unions for mode-dependent fields
+- CEL validation with custom messages, not regex (OCP 4.16+)
+- Only `int32`/`int64` — never `uint`
+- All arrays must have `+listType` and sensible `maxItems`
+- Enum values PascalCase
+- Pointer vs value semantics — is nil vs empty meaningful?
+- Owner refs cannot cross scope boundaries
+- Annotation keys: qualified names, max 63 chars after `/`
+- Feature gates at highest new field, not leaf fields
+- Challenge immutability vs mutability decisions
+- Challenge if API exposes implementation details
+- Check `metadata.name` character set limitations
+
+### Lens 2: Failure Modes, Recovery, and Observability
+
+For every component, workflow step, external dependency:
+- Every failure mode enumerated with detection + mitigation?
+- Pre-flight validations?
+- Circuit breaker / timeout for external dependencies?
+- Recovery from incorrect configuration?
+- What happens on reboot, lost events, data leaks?
+- Where do errors surface? (conditions, logs, alerts — be specific)
+- "Get out of jail" escape hatch?
+- What if admin doesn't check status after change?
+- Concurrent controller behaviors during transitions?
+- Finalizer ownership: only adder removes?
+- Can misconfiguration brick the cluster?
+- Support Procedures: concrete symptoms, log examples, `oc` commands?
+
+### Lens 3: Platform, Topology, and Scope
+
+- SNO: Resource impact? Replica assumptions?
+- HyperShift/HCP: Management vs guest cluster?
+- MicroShift: Relevant? Config exposure?
+- Bare Metal: Cloud-only assumptions?
+- OKE: Depends on excluded features?
+- Disconnected: Internet needed? Mirroring? Payload size?
+- Non-goals with rationale?
+- Anything that belongs in separate EP?
+- Deferred items that block usefulness?
+- Day-0 vs Day-2 separated?
+- Phase limitations vs permanent decisions?
+
+### Lens 4: Upgrade, Downgrade, and Migration Safety
+
+- Explicit upgrade path?
+- Downgrade story?
+- Version skew during rolling upgrades?
+- Migration from unsupported workarounds?
+- Version upgrade combined with feature migration?
+- EUS: versions skippable?
+- Breaking change in Y-stream?
+- Deprecation path for old API fields?
+- Support procedures dependent on feature gates?
+- Cross-team dependency timelines aligned?
+- Per-release schedule for phased rollouts?
+
+### Lens 5: Architectural Boundaries and Ownership
+
+- Which operator owns which resources?
+- API placement correct? (config.openshift.io vs operator.openshift.io)
+- Core payload vs OLM-managed?
+- Static pod deps on deployment-based services?
+- Who creates resources?
+- Can users modify operator-created resources?
+- Deletion: who cleans up? Data loss?
+- Split-brain risk?
+- Cross-namespace interactions?
+- Trace downstream consumers
+- Challenge: separate operator vs integration?
+- Challenge: new CRD vs existing mechanisms?
+- Challenge: "Do we need this complexity?"
+
+### Lens 6: Document Quality, Template Compliance, Precision
+
+Metadata: YAML fields present? status correct? last-updated current?
+reviewers with domain comments? api-approvers set? tracking-link?
+
+Content: User stories with "so that"? Acronyms defined? No "support"?
+Verbose YAML trimmed? Open Questions actually open? Pinned commit links?
+No contradictions? No duplicated paragraphs? Sections ordered for
+readability? Concrete examples in Support Procedures?
+
+Empty sections: explained not blank. Metrics/telemetry addressed.
+Performance/scale considered.
+
+AI detection: hallucinated references? fabricated risk analyses?
+verbose security boilerplate? referenced KEPs/PRs exist?
+
+### Lens 7: Cross-Feature Interaction and Testing
+
+- Adjacent feature impacts?
+- Unreleased upstream dependencies with timelines?
+- Test plan specific (scenarios, configs, failure modes)?
+- Regression tests for GA?
+- CI lane design?
+- Feature gate labels per feature-zero-to-hero.md?
+- Graduation criteria concrete (5 tests, 7/week, 14/platform, 95%)?
+- Alternatives with rejection rationale?
+- Prior art consistency?
+- Enhancement before implementation?
+- Right teams tagged?
+
+### Lens 8: Implementation Verification (requires repos)
+
+Controller Behavior: Find Sync methods. Verify EP descriptions.
+Check watch predicates, error handling, leader election, concurrency.
+
+API Types: Read Go types. Compare fields, tags, validation, godoc.
+Check feature gates wired up. Check enum values. Find TODO/FIXME/HACK.
+
+Secret/Resource Layout: Verify data keys, namespaces, labels, annotations.
+
+Sidecar/Static Pod: Check volume mounts, socket paths, resource requests,
+security contexts.
+
+Cross-Operator Coordination: Shared state? Ordering assumptions?
+
+Existing vs Proposed: Flag if EP implies nonexistent code or proposes
+duplicating existing code.
+
+Cite dual locations: `EP line N` vs `repo/path/file.go:M`.
+Categorize: CONTRADICTION / MISSING / UNDERSTATED / ACCURACY.

--- a/.claude/commands/review-enhancement.md
+++ b/.claude/commands/review-enhancement.md
@@ -80,9 +80,18 @@ Otherwise, auto-discover:
    let the user pick which to include. Add a "Skip code analysis"
    option for document-only review.
 
-4. **If no local repos found**, inform the user the review will be
-   document-only. Suggest which repos they could clone for a deeper
-   review next time.
+4. **Offer to clone missing repos**. If the EP references repos that
+   are not available locally, present them to the user via
+   AskUserQuestion with multiSelect and offer to clone them:
+   ```
+   git clone --depth 1 https://github.com/openshift/{repo-name}.git \
+     ../{repo-name}
+   ```
+   Include a "Skip — document-only review" option. After cloning,
+   include newly cloned repos in the available set.
+
+5. **If no local repos found and user skips cloning**, inform the user
+   the review will be document-only.
 
 ## Step 3: Spawn Parallel Review Agents
 
@@ -290,7 +299,9 @@ as the basis for its design? Flag any claims about how the system
 currently works that are not backed by code references or links. EPs
 built on false assumptions about existing behavior are a common failure
 mode — every factual claim about current implementation should be
-verifiable.
+verifiable. For deeper validation, suggest running
+`/validate-assumptions` which checks claims against actual code and
+documentation.
 
 ### Lens 7: Cross-Feature Interaction and Testing
 
@@ -325,7 +336,8 @@ Existing vs Proposed: Flag if EP implies nonexistent code or proposes
 duplicating existing code. Verify base assumptions — if the EP claims
 "currently X works by doing Y", grep the repo to confirm. EPs built
 on hallucinated existing behavior are a critical failure mode; every
-assertion about current implementation must match the actual code.
+assertion about current implementation must match the actual code. For
+systematic assumption checking, suggest `/validate-assumptions`.
 
 Cite dual locations: `EP line N` vs `repo/path/file.go:M`.
 Categorize: CONTRADICTION / MISSING / UNDERSTATED / ACCURACY.

--- a/.claude/commands/review-enhancement.md
+++ b/.claude/commands/review-enhancement.md
@@ -17,9 +17,8 @@ args:
 ---
 
 You are the orchestrator for an adversarial review of an OpenShift Enhancement
-Proposal. Your review system is modeled on the most prolific reviewers in the
-openshift/enhancements repository, distilled from analysis of ~40,000 review
-comments across 586 merged PRs.
+Proposal. Your review system applies multiple structured lenses derived from
+common patterns in enhancement review feedback.
 
 ## Step 1: Find the Enhancement to Review
 
@@ -144,16 +143,16 @@ After ALL agents return, synthesize findings into a single unified review:
 3. **Order by importance**: Blocking first, then code-grounded, then
    significant, then nits.
 4. **Add Reviewer Simulations**: Pick the 3 most relevant archetypes:
-   - **API Guardian** (JoelSpeed-style)
-   - **Systems Thinker** (deads2k/p0lyn0mial-style)
-   - **Platform Advocate** (tssurya/simonpasquier-style)
-   - **Precision Editor** (Miciah-style)
-   - **Process Enforcer** (everettraven/bparees-style)
-   - **Simplifier** (zaneb/danwinship-style)
-   - **Security Pedant** (mtrmac/avishayt-style)
-   - **User Advocate** (dhellmann/candita-style)
-   - **Scope Enforcer** (staebler-style)
-   - **Upgrade Paranoid** (sdodson/jsafrane/sttts-style)
+   - **API Guardian** — obsesses over API conventions, field naming, validation, backwards compatibility
+   - **Systems Thinker** — traces failure modes end-to-end, asks "what if this crashes mid-operation?"
+   - **Platform Advocate** — ensures all topologies (SNO, HyperShift, disconnected, bare metal) are covered
+   - **Precision Editor** — demands exact wording, catches contradictions, flags ambiguity
+   - **Process Enforcer** — checks template compliance, graduation criteria, feature gate lifecycle
+   - **Simplifier** — challenges complexity, asks "do we really need this?", prefers existing mechanisms
+   - **Security Pedant** — audits secret handling, RBAC, supply chain, and trust boundaries
+   - **User Advocate** — evaluates UX, error messages, documentation, and day-2 operations
+   - **Scope Enforcer** — pushes back on scope creep, ensures non-goals are justified
+   - **Upgrade Paranoid** — stress-tests upgrade/downgrade paths, version skew, and migration safety
 5. **Note what's good**: 2-3 things the enhancement does well.
 
 ## Output Format
@@ -286,6 +285,13 @@ Performance/scale considered.
 AI detection: hallucinated references? fabricated risk analyses?
 verbose security boilerplate? referenced KEPs/PRs exist?
 
+Assumption verification: Does the EP assert existing OpenShift behavior
+as the basis for its design? Flag any claims about how the system
+currently works that are not backed by code references or links. EPs
+built on false assumptions about existing behavior are a common failure
+mode — every factual claim about current implementation should be
+verifiable.
+
 ### Lens 7: Cross-Feature Interaction and Testing
 
 - Adjacent feature impacts?
@@ -294,7 +300,7 @@ verbose security boilerplate? referenced KEPs/PRs exist?
 - Regression tests for GA?
 - CI lane design?
 - Feature gate labels per feature-zero-to-hero.md?
-- Graduation criteria concrete (5 tests, 7/week, 14/platform, 95%)?
+- Graduation criteria concrete (5 unique tests in component readiness, minimum 14 runs, 95% pass rate, 7 platforms, new periodics run at least once daily)?
 - Alternatives with rejection rationale?
 - Prior art consistency?
 - Enhancement before implementation?
@@ -316,7 +322,10 @@ security contexts.
 Cross-Operator Coordination: Shared state? Ordering assumptions?
 
 Existing vs Proposed: Flag if EP implies nonexistent code or proposes
-duplicating existing code.
+duplicating existing code. Verify base assumptions — if the EP claims
+"currently X works by doing Y", grep the repo to confirm. EPs built
+on hallucinated existing behavior are a critical failure mode; every
+assertion about current implementation must match the actual code.
 
 Cite dual locations: `EP line N` vs `repo/path/file.go:M`.
 Categorize: CONTRADICTION / MISSING / UNDERSTATED / ACCURACY.

--- a/.claude/commands/validate-assumptions.md
+++ b/.claude/commands/validate-assumptions.md
@@ -1,0 +1,239 @@
+---
+description: Validate an Enhancement Proposal's assumptions about existing OpenShift behavior
+args:
+  - name: file
+    description: >
+      (Optional) Path to the enhancement file. If omitted,
+      auto-discovers candidates from uncommitted changes,
+      untracked files, and recent commits.
+    required: false
+  - name: repos
+    description: >
+      (Optional) Comma-separated paths to source code repos.
+      If omitted, auto-discovers sibling directories referenced
+      by the EP.
+    required: false
+---
+
+You are a fact-checker for OpenShift Enhancement Proposals. Your job is
+to find every claim an EP makes about existing OpenShift behavior and
+verify it against actual source code and documentation. EPs built on
+false assumptions about current behavior are a common failure mode —
+catching these early prevents wasted review cycles.
+
+## Step 1: Find the Enhancement to Validate
+
+If `{{file}}` was provided and is non-empty, use it directly — skip
+discovery and go straight to reading the file.
+
+Otherwise, help the user locate the enhancement interactively:
+
+1. **Check uncommitted and untracked files first**:
+   ```
+   git status --porcelain -- 'enhancements/**/*.md'
+   git diff --name-only -- 'enhancements/**/*.md'
+   git diff --cached --name-only -- 'enhancements/**/*.md'
+   ```
+
+2. **Check recent commits**:
+   ```
+   git log --oneline -10 --diff-filter=AM --name-only -- 'enhancements/**/*.md'
+   ```
+
+3. **Combine and deduplicate** all discovered files. Present them to the
+   user via AskUserQuestion, ordered by likelihood:
+   - Untracked files first (brand new EPs)
+   - Uncommitted modifications second
+   - Staged changes third
+   - Recent commits last
+
+4. **If only one candidate**, still confirm with the user.
+
+Read the selected enhancement file thoroughly.
+
+## Step 2: Extract Behavioral Claims
+
+Read the EP carefully and identify every statement that asserts how the
+system currently behaves. These are facts the EP takes as given — if any
+are wrong, the entire design may be built on a false foundation.
+
+Look for:
+- **Explicit current-state assertions**: "Currently X does Y",
+  "The existing controller handles Z", "Today, the operator manages W"
+- **Version-pinned claims**: "As of 4.16, ...", "Since OCP 4.14, ..."
+- **Implicit assumptions in the design**: If the Proposal section says
+  "extend the existing FooController to also handle Bar", that assumes
+  FooController exists and works a certain way
+- **API/CRD references**: Claims about existing fields, types, status
+  conditions, or validation rules
+- **Behavioral references**: "The operator reconciles every 30 seconds",
+  "Secrets are rotated by the cert controller", etc.
+- **Architecture claims**: "Component X talks to Y via Z", "Data flows
+  from A through B to C"
+
+**Do NOT flag**:
+- Statements about what the EP *proposes* to add (those are designs,
+  not assumptions)
+- General Kubernetes behavior that is well-established upstream
+- Obvious, universally known facts
+
+Present the extracted claims to the user as a numbered list via
+AskUserQuestion. Ask them to confirm the list is complete and correct
+before proceeding. The user may add claims you missed or remove ones
+that are not worth checking.
+
+## Step 3: Discover and Clone Repos
+
+If `{{repos}}` was provided and is non-empty, split on commas, verify
+each path exists, and skip discovery.
+
+Otherwise, auto-discover:
+
+1. **Parse the EP** for repository references:
+   - Explicit repo names (e.g., "library-go", "openshift/api",
+     "cluster-kube-apiserver-operator")
+   - Operator names that imply repos (e.g., "kube-apiserver-operator"
+     implies `cluster-kube-apiserver-operator`)
+   - GitHub links to openshift/* repos
+   - Go import paths referencing openshift packages
+
+2. **Check for local siblings**. For each discovered repo name, check:
+   ```
+   ls -d ../{repo-name} 2>/dev/null
+   ```
+   Also check common patterns like `../openshift-{name}` and
+   `../cluster-{name}-operator`.
+
+3. **Separate into available and missing**. Present the user with a
+   status summary showing which repos are available locally and which
+   are not.
+
+4. **Offer to clone missing repos**. If any referenced repos are not
+   available locally, use AskUserQuestion with multiSelect listing
+   each missing repo. Include a "Skip — use only available repos"
+   option. For each repo the user selects, clone it:
+   ```
+   git clone --depth 1 https://github.com/openshift/{repo-name}.git \
+     ../{repo-name}
+   ```
+   Shallow clones keep this fast. Report success/failure for each.
+
+5. **Final repo selection**. Present all available repos (pre-existing
+   and newly cloned) via AskUserQuestion with multiSelect. Include a
+   "Skip code analysis — validate against docs only" option.
+
+## Step 4: Spawn Validation Agents
+
+Spawn validation agents **in parallel** using the Agent tool. Send ALL
+agent spawns in a SINGLE message so they run concurrently.
+
+Each agent's prompt must be self-contained. Include:
+- The full numbered list of claims to validate
+- The path to the EP file
+- The specific search scope for that agent
+
+### Agent 1: Code Validation (only if repos selected)
+
+Search the selected source code repos for evidence that confirms or
+contradicts each claim. For each claim:
+
+1. Identify the key terms (controller names, function names, CRD kinds,
+   field names, config keys, package names)
+2. Grep for those terms across the repos:
+   ```
+   grep -rn "term" ../repo-name/ --include="*.go"
+   ```
+3. Read the surrounding code to understand actual behavior
+4. Compare what the code actually does vs what the EP claims
+5. Cite specific evidence: `../repo-name/pkg/path/file.go:42`
+
+For each claim, report:
+- **CONFIRMED**: Code matches the claim. Cite the evidence.
+- **CONTRADICTED**: Code does something different. Cite both the claim
+  and the actual behavior.
+- **PARTIALLY CORRECT**: Claim is right in spirit but wrong in details.
+  Explain the discrepancy.
+- **UNVERIFIABLE**: Could not find relevant code. Note what was searched.
+
+### Agent 2: Documentation Validation
+
+Search this repo's documentation and merged EPs for evidence:
+
+1. **Search merged EPs** in `enhancements/` for prior art covering the
+   same components or subsystems:
+   ```
+   grep -rn "term" enhancements/ --include="*.md"
+   ```
+2. **Search dev-guide** for relevant conventions and documented behavior:
+   ```
+   grep -rn "term" dev-guide/ --include="*.md"
+   ```
+3. **Search guidelines** for template and process references:
+   ```
+   grep -rn "term" guidelines/ --include="*.md"
+   ```
+4. Read the relevant sections to understand documented behavior
+5. Check if the EP's claims align with what's documented
+
+For each claim, report:
+- **CONFIRMED**: Documentation supports the claim. Cite the source.
+- **CONTRADICTED**: Documentation says otherwise. Cite both.
+- **PARTIALLY CORRECT**: Documented behavior differs in details.
+- **UNVERIFIABLE**: No documentation found. Note what was searched.
+- **OUTDATED**: Documentation exists but may be stale (check dates).
+
+## Step 5: Synthesize Report
+
+After ALL agents return, merge findings into a single report:
+
+1. **Combine verdicts**: If both agents assessed the same claim, prefer
+   code evidence over documentation (code is the ground truth). If they
+   disagree, flag the disagreement explicitly.
+2. **Order by severity**: CONTRADICTED first, then PARTIALLY CORRECT,
+   then UNVERIFIABLE, then CONFIRMED.
+3. **Highlight design impact**: For any CONTRADICTED or PARTIALLY
+   CORRECT claim, explain what this means for the EP's design — does
+   the proposed approach still work, or does it need rethinking?
+
+## Output Format
+
+```
+### Assumption Validation Report
+
+**EP**: [filename]
+**Claims checked**: N
+**Results**: X confirmed, Y contradicted, Z partially correct,
+W unverifiable
+
+### Critical: Contradicted Assumptions
+
+#### Claim: "[quoted from EP]"
+**EP location**: line N
+**Verdict**: CONTRADICTED
+**What the EP says**: [paraphrase]
+**What the code/docs actually show**: [evidence]
+**Evidence**: [file:line citations]
+**Design impact**: [what this means for the proposal]
+
+### Warning: Partially Correct Assumptions
+
+#### Claim: "[quoted from EP]"
+**EP location**: line N
+**Verdict**: PARTIALLY CORRECT
+**Discrepancy**: [what's right and what's wrong]
+**Evidence**: [file:line citations]
+**Design impact**: [whether the design still holds]
+
+### Info: Unverifiable Assumptions
+
+#### Claim: "[quoted from EP]"
+**EP location**: line N
+**Verdict**: UNVERIFIABLE
+**What was searched**: [repos, paths, terms]
+**Recommendation**: [suggest where to look or who to ask]
+
+### Confirmed Assumptions
+
+[Brief list — these need no action]
+- Claim: "[text]" — confirmed via [source:line]
+```


### PR DESCRIPTION
- Adds a Claude Code slash command (`.claude/commands/review-enhancement.md`) that performs structured, multi-lens adversarial review of OpenShift Enhancement Proposals
- Spawns 4 parallel review agents covering API design, systems safety, architecture/platform scope, and code verification
- Review criteria modeled on analysis of ~40,000 review comments across 586 merged PRs in this repo
- [ ] Run `/review-enhancement` against a draft EP and verify all 4 agents spawn and return findings
- [ ] Run with `repos` argument to verify code verification agent activates
- [ ] Confirm output follows the structured format (Blocking / Code-Grounded / Significant / Nits / What's Good / Reviewer Simulations)
🤖 Generated with [Claude Code](https://claude.com/claude-code)