### PR TITLE
Add agentic documentation for OpenShift enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ enhancement-tool
 tools/bin
 tools/cover.out
 super-linter.log
+
+# Node.js dependencies (for promptfoo evals)
+node_modules/
+package-lock.json
+
+# Promptfoo cache and results
+.promptfoo/
+promptfoo-results.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,187 @@
+# OpenShift Enhancements - Agent Navigation Index
+
+**Version**: 1.0 | **Docs**: ./ai-docs/ | **Role**: Ecosystem Hub
+
+---
+
+## CRITICAL: Retrieval Strategy
+
+**IMPORTANT**: Prefer retrieval-led reasoning over pre-training-led reasoning.
+
+When working on OpenShift:
+- ✅ **DO**: Read relevant docs from `./ai-docs/` first
+- ✅ **DO**: Verify patterns match current APIs (`oc explain`)
+- ✅ **DO**: Check enhancement guidelines in `./guidelines/`
+- ❌ **DON'T**: Rely solely on training data
+- ❌ **DON'T**: Guess at API structures or enhancement process
+
+---
+
+## AI Navigation: DON'T Read All Docs
+
+**Read 4-5 docs per task, not everything.**
+
+### Common Task Flows
+
+**Writing enhancement proposal?**
+→ `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/practices/development/api-evolution.md`
+
+**Building operator?**
+→ `./ai-docs/DESIGN_PHILOSOPHY.md` → `./ai-docs/platform/operator-patterns/controller-runtime.md` → `./ai-docs/platform/operator-patterns/status-conditions.md` → `./ai-docs/practices/testing/pyramid.md`
+
+**Adding API to existing operator?**
+→ `./ai-docs/practices/development/api-evolution.md` → `./ai-docs/domain/kubernetes/crds.md` → `./ai-docs/platform/operator-patterns/webhooks.md`
+
+**Understanding cluster upgrade process?**
+→ `./ai-docs/domain/openshift/clusterversion.md` → `./ai-docs/platform/openshift-specifics/upgrade-strategies.md` → `./ai-docs/decisions/adr-0001-cvo-orchestration.md`
+
+**Need visual map?**
+→ `./ai-docs/KNOWLEDGE_GRAPH.md`
+
+---
+
+## Quick Navigation by Role
+
+| Role | Start Here | Then Read |
+|------|-----------|-----------|
+| **Enhancement Author** | `./guidelines/enhancement_template.md` | `./ai-docs/workflows/enhancement-process.md` |
+| **Operator Developer** | `./ai-docs/DESIGN_PHILOSOPHY.md` | `./ai-docs/platform/operator-patterns/` |
+| **API Designer** | `./ai-docs/practices/development/api-evolution.md` | `./dev-guide/` |
+| **Platform Architect** | `./ai-docs/decisions/` | `./ai-docs/DESIGN_PHILOSOPHY.md` |
+
+---
+
+## Core Platform Concepts
+
+| Topic | File | Description |
+|-------|------|-------------|
+| **Design principles** | `./ai-docs/DESIGN_PHILOSOPHY.md` | Core architectural philosophy |
+| **Visual navigation** | `./ai-docs/KNOWLEDGE_GRAPH.md` | Graph-based doc navigation |
+| **Cluster operators** | `./ai-docs/domain/openshift/clusteroperator.md` | Status reporting, lifecycle |
+| **Cluster upgrades** | `./ai-docs/domain/openshift/clusterversion.md` | CVO orchestration, upgrade ordering |
+| **Custom resources** | `./ai-docs/domain/kubernetes/crds.md` | Extending Kubernetes API |
+| **Pods** | `./ai-docs/domain/kubernetes/pod.md` | Container workload fundamentals |
+| **Services** | `./ai-docs/domain/kubernetes/service.md` | Stable networking and discovery |
+
+---
+
+## Standard Operator Patterns
+
+| Pattern | File | When to Use |
+|---------|------|-------------|
+| **Controller runtime** | `./ai-docs/platform/operator-patterns/controller-runtime.md` | Every operator (reconcile loops) |
+| **Status conditions** | `./ai-docs/platform/operator-patterns/status-conditions.md` | Available/Progressing/Degraded reporting |
+| **Webhooks** | `./ai-docs/platform/operator-patterns/webhooks.md` | Validation/mutation/conversion |
+| **Finalizers** | `./ai-docs/platform/operator-patterns/finalizers.md` | Cleanup external resources on deletion |
+| **RBAC** | `./ai-docs/platform/operator-patterns/rbac.md` | Service account permissions |
+| **must-gather** | `./ai-docs/platform/operator-patterns/must-gather.md` | Debugging and diagnostics |
+| **Upgrade safety** | `./ai-docs/platform/openshift-specifics/upgrade-strategies.md` | N→N+1 version skew, CVO coordination |
+
+---
+
+## Engineering Practices
+
+| Area | Index | Description |
+|------|-------|-------------|
+| **Testing** | `./ai-docs/practices/testing/` | Pyramid (60/30/10), e2e framework |
+| **Security** | `./ai-docs/practices/security/` | STRIDE, RBAC patterns, secret handling |
+| **Reliability** | `./ai-docs/practices/reliability/` | SLI/SLO/SLA, degraded-mode patterns |
+| **Development** | `./ai-docs/practices/development/` | API evolution, compatibility |
+
+---
+
+## Workflows
+
+| Workflow | File | Links to Authoritative Source |
+|----------|------|-------------------------------|
+| **Enhancement process** | `./ai-docs/workflows/enhancement-process.md` | `./guidelines/enhancement_template.md` |
+| **Feature implementation** | `./ai-docs/workflows/implementing-features.md` | `./dev-guide/` |
+| **Exec-plan guidance** | `./ai-docs/workflows/exec-plans/` | Template for multi-week features |
+
+---
+
+## Component Repository Index
+
+**Finding component repos**: See `./ai-docs/references/repo-index.md`
+
+**Pattern**: Most components are in `openshift/<component-name>-operator` or `openshift/<component-name>`
+
+**Search**: [GitHub org search](https://github.com/orgs/openshift/repositories)
+
+---
+
+## Cross-Repo Architectural Decisions
+
+**Location**: `./ai-docs/decisions/`
+
+**Index**: See `./ai-docs/decisions/index.md`
+
+**Common ADRs**:
+- Why etcd as backend
+- Why CVO orchestration model
+- Why immutable nodes (RHCOS + rpm-ostree)
+
+---
+
+## Relationship to Other Documentation
+
+| Source | Purpose | When to Use |
+|--------|---------|-------------|
+| **This repo (`./ai-docs/`)** | AI-optimized ecosystem hub | Starting point, cross-repo patterns |
+| **`./guidelines/`** | Authoritative enhancement process | Writing enhancement proposals |
+| **`./dev-guide/`** | Development conventions | Git workflow, CI, coding standards |
+| **`./enhancements/`** | Historical design docs | Understanding past decisions |
+| **Component repos** | Implementation specifics | Component architecture, internal details |
+
+---
+
+## How to Use This Documentation
+
+### For AI Agents
+1. Start with task-specific flow (see "AI Navigation" section)
+2. Read 4-5 linked docs, not entire tree
+3. Use `oc explain <resource>` for field-level API details
+4. Check `./guidelines/` for authoritative enhancement process
+5. Link to component repos for implementation details
+
+### For Humans
+- **Skim**: Read index files (`index.md`) to orient
+- **Search**: Use `grep -r "keyword" ./ai-docs/`
+- **Verify**: Cross-reference with `oc explain` and `./guidelines/`
+- **Navigate**: Use `KNOWLEDGE_GRAPH.md` for visual map
+
+---
+
+## Documentation Structure
+
+```
+./ai-docs/
+├── DESIGN_PHILOSOPHY.md         # Core principles
+├── KNOWLEDGE_GRAPH.md            # Visual navigation
+├── platform/                     # Operator patterns
+│   ├── operator-patterns/        # Controller runtime, status, webhooks
+│   └── openshift-specifics/      # Upgrade safety, CVO coordination
+├── domain/                       # Core API concepts
+│   ├── kubernetes/               # Pod, Service, CRD, Node
+│   └── openshift/                # ClusterOperator, ClusterVersion, Machine
+├── practices/                    # Cross-cutting concerns
+│   ├── testing/                  # Pyramid, e2e framework
+│   ├── security/                 # STRIDE, RBAC, secrets
+│   ├── reliability/              # SLI/SLO, degraded mode
+│   └── development/              # API evolution, compatibility
+├── decisions/                    # Cross-repo ADRs
+├── workflows/                    # AI-optimized process guides
+│   ├── exec-plans/               # Feature tracking templates (Tier 1)
+│   ├── enhancement-process.md
+│   └── implementing-features.md
+└── references/                   # Pointers (GitHub links, oc commands)
+    ├── repo-index.md
+    ├── glossary.md
+    └── api-reference.md
+```
+
+---
+
+**Navigation**: Start with `KNOWLEDGE_GRAPH.md` for visual overview.
+
+**Feedback**: Report issues at https://github.com/openshift/enhancements/issues

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ When working on OpenShift:
 ### Common Task Flows
 
 **Writing enhancement proposal?**
-→ `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/practices/development/api-evolution.md`
+→ `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/workflows/topology-considerations-guide.md` → `./ai-docs/practices/development/api-evolution.md`
 
 **Building operator?**
 → `./ai-docs/DESIGN_PHILOSOPHY.md` → `./ai-docs/platform/operator-patterns/controller-runtime.md` → `./ai-docs/platform/operator-patterns/status-conditions.md` → `./ai-docs/practices/testing/pyramid.md`
@@ -44,7 +44,7 @@ When working on OpenShift:
 
 | Role | Start Here | Then Read |
 |------|-----------|-----------|
-| **Enhancement Author** | `./guidelines/enhancement_template.md` | `./ai-docs/workflows/enhancement-process.md` |
+| **Enhancement Author** | `./guidelines/enhancement_template.md` | `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/workflows/topology-considerations-guide.md` |
 | **Operator Developer** | `./ai-docs/DESIGN_PHILOSOPHY.md` | `./ai-docs/platform/operator-patterns/` |
 | **API Designer** | `./ai-docs/practices/development/api-evolution.md` | `./dev-guide/` |
 | **Platform Architect** | `./ai-docs/decisions/` | `./ai-docs/DESIGN_PHILOSOPHY.md` |
@@ -95,6 +95,7 @@ When working on OpenShift:
 | Workflow | File | Links to Authoritative Source |
 |----------|------|-------------------------------|
 | **Enhancement process** | `./ai-docs/workflows/enhancement-process.md` | `./guidelines/enhancement_template.md` |
+| **Topology considerations** | `./ai-docs/workflows/topology-considerations-guide.md` | Guide for SNO, MicroShift, Hypershift, OKE sections |
 | **Feature implementation** | `./ai-docs/workflows/implementing-features.md` | `./dev-guide/` |
 | **Exec-plan guidance** | `./ai-docs/workflows/exec-plans/` | Template for multi-week features |
 
@@ -171,8 +172,9 @@ When working on OpenShift:
 │   └── development/              # API evolution, compatibility
 ├── decisions/                    # Cross-repo ADRs
 ├── workflows/                    # AI-optimized process guides
-│   ├── exec-plans/               # Feature tracking templates (Tier 1)
+│   ├── exec-plans/               # Feature tracking templates (Platform)
 │   ├── enhancement-process.md
+│   ├── topology-considerations-guide.md
 │   └── implementing-features.md
 └── references/                   # Pointers (GitHub links, oc commands)
     ├── repo-index.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,9 @@ When working on OpenShift:
 **Writing enhancement proposal?**
 → `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/workflows/topology-considerations-guide.md` → `./ai-docs/practices/development/api-evolution.md`
 
+**Adding new component?**
+→ `./dev-guide/new-components.md` (payload vs OLM) → `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md`
+
 **Building operator?**
 → `./ai-docs/DESIGN_PHILOSOPHY.md` → `./ai-docs/platform/operator-patterns/controller-runtime.md` → `./ai-docs/platform/operator-patterns/status-conditions.md` → `./ai-docs/practices/testing/pyramid.md`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,36 @@ HACKMD_IMAGE=enhancements-hackmd-cli:latest # hackmd-cli image
 .PHONY: report-image
 report-image:
 	$(RUNTIME) build -f ./hack/Dockerfile.hackmd-cli --tag $(HACKMD_IMAGE)
+
+##@ Agentic Docs Evaluation
+
+.PHONY: eval
+eval: ## Run all agentic docs evaluations
+	@echo "Running agentic docs evaluations..."
+	test/eval/run-eval.sh
+
+.PHONY: eval-filter
+eval-filter: ## Run evaluations matching FILTER pattern (e.g., FILTER=anti-pattern)
+	@test -n "$(FILTER)" || (echo "Error: FILTER not set. Usage: make eval-filter FILTER=navigation"; exit 1)
+	@echo "Running evaluations (filter: $(FILTER))..."
+	test/eval/run-eval.sh "$(FILTER)"
+
+.PHONY: eval-navigation
+eval-navigation: ## Run navigation scenario tests
+	@echo "Running navigation scenarios..."
+	test/eval/run-eval.sh navigation
+
+.PHONY: eval-anti-pattern
+eval-anti-pattern: ## Run anti-pattern scenarios (tests what docs prevent)
+	@echo "Running anti-pattern scenarios..."
+	test/eval/run-eval.sh anti-pattern
+
+.PHONY: eval-view
+eval-view: ## Open web UI to view evaluation results
+	@echo "Opening evaluation results viewer..."
+	npx --yes promptfoo@latest view
+
+.PHONY: eval-clean
+eval-clean: ## Clean evaluation cache
+	@echo "Cleaning evaluation cache..."
+	rm -rf .promptfoo/

--- a/ai-docs/DESIGN_PHILOSOPHY.md
+++ b/ai-docs/DESIGN_PHILOSOPHY.md
@@ -1,0 +1,121 @@
+# OpenShift Design Philosophy
+
+**Purpose**: Core principles guiding OpenShift architecture and development
+
+**Last Updated**: YYYY-MM-DD
+
+---
+
+## Table of Contents
+
+1. [Kubernetes Foundation](#kubernetes-foundation)
+2. [The Operator Pattern](#the-operator-pattern)
+3. [Immutable Infrastructure](#immutable-infrastructure)
+4. [API-First Design](#api-first-design)
+5. [Declarative Over Imperative](#declarative-over-imperative)
+6. [Upgrade Safety](#upgrade-safety)
+7. [Observability by Default](#observability-by-default)
+
+---
+
+## Kubernetes Foundation
+
+### Desired State vs Current State
+
+**Core Principle**: Describe what you want, Kubernetes makes it happen.
+
+```
+User declares:  "I want 3 replicas"  (Desired State)
+Kubernetes sees: "I have 1 replica"  (Current State)
+Controller:     "I'll create 2 more" (Reconciliation)
+```
+
+**Why This Matters**:
+- Self-healing: If a pod dies, controller recreates it
+- Idempotent: Applying same config multiple times = same result
+- Eventual consistency: System converges to desired state
+
+---
+
+## The Operator Pattern
+
+**Principle**: Extend Kubernetes with domain-specific knowledge.
+
+**Pattern**: CustomResourceDefinition + Controller = Operator
+
+**Benefits**:
+- Codifies operational knowledge
+- Automates Day 2 operations
+- Follows Kubernetes patterns
+
+---
+
+## Immutable Infrastructure
+
+**Principle**: Nodes are immutable. Changes require reboot.
+
+**Implementation**: RHCOS + rpm-ostree + Ignition + MachineConfig
+
+**Benefits**:
+- Predictable state
+- Easier rollback
+- Reduced configuration drift
+
+---
+
+## API-First Design
+
+**Principle**: Everything is an API resource.
+
+**Pattern**: All configuration via Kubernetes/OpenShift APIs (no manual SSH, no local files)
+
+**Benefits**:
+- GitOps-friendly
+- Auditable
+- Version-controlled
+
+---
+
+## Declarative Over Imperative
+
+**Principle**: Declare intent, not steps.
+
+**Example**:
+- ❌ Imperative: "Run pod1, then pod2, then update service"
+- ✅ Declarative: "I want this state" (controller figures out steps)
+
+---
+
+## Upgrade Safety
+
+**Principle**: Zero-downtime upgrades for platform and workloads.
+
+**Mechanisms**:
+- CVO orchestrates operator upgrades
+- Rolling updates for nodes
+- Upgrade ordering (etcd → kube → operators)
+
+---
+
+## Observability by Default
+
+**Principle**: Platform components expose metrics, logs, and health status.
+
+**Implementation**:
+- Prometheus metrics
+- Status conditions (Available/Progressing/Degraded)
+- Structured logging
+
+---
+
+## Cross-Cutting Concerns
+
+- **Security by default**: RBAC, SCCs, network policies
+- **Multi-tenancy**: Namespace isolation
+- **Supportability**: must-gather, diagnostics
+
+---
+
+**See Also**:
+- [Operator Patterns](./platform/operator-patterns/)
+- [Platform APIs](./domain/openshift/)

--- a/ai-docs/KNOWLEDGE_GRAPH.md
+++ b/ai-docs/KNOWLEDGE_GRAPH.md
@@ -1,0 +1,136 @@
+# OpenShift Knowledge Graph
+
+**Purpose**: Visual navigation map showing how concepts connect
+
+**Last Updated**: YYYY-MM-DD
+
+---
+
+## How to Use This
+
+**Don't read everything.** Follow your task path:
+1. Find your task in "I want to..." table below
+2. Read only the 4-5 docs in your path
+3. Use cross-references as needed
+
+---
+
+## I Want To...
+
+| Task | Start Here | Then Read | Finally |
+|------|-----------|----------|---------|
+| **Build an operator** | DESIGN_PHILOSOPHY.md | platform/operator-patterns/controller-runtime.md<br>platform/operator-patterns/status-conditions.md | domain/openshift/clusteroperator.md |
+| **Add a feature** | workflows/index.md (links to enhancement process) | practices/development/index.md (links to API conventions) | practices/testing/index.md |
+| **Debug an issue** | practices/reliability/index.md | platform/operator-patterns/must-gather.md | references/repo-index.md |
+| **Understand a concept** | DESIGN_PHILOSOPHY.md | domain/kubernetes/ or domain/openshift/ | platform/operator-patterns/ |
+| **Find a component** | references/repo-index.md | Component's AGENTS.md | Component's agentic/ docs |
+
+---
+
+## Knowledge Map
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    DESIGN_PHILOSOPHY.md                      │
+│         (WHY - Core principles, read this first)             │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                ┌─────────────┼─────────────┐
+                │             │             │
+                ▼             ▼             ▼
+┌───────────────────┐ ┌──────────────┐ ┌──────────────────┐
+│  PLATFORM/        │ │   DOMAIN/    │ │   PRACTICES/     │
+│  (HOW patterns)   │ │   (WHAT)     │ │   (WHEN/WHERE)   │
+├───────────────────┤ ├──────────────┤ ├──────────────────┤
+│ operator-patterns/│ │ kubernetes/  │ │ testing/         │
+│ openshift-specifics│ │ openshift/   │ │ security/        │
+│                   │ │              │ │ reliability/     │
+│                   │ │              │ │ development/     │
+└───────────────────┘ └──────────────┘ └──────────────────┘
+         │                    │                  │
+         └────────────────────┼──────────────────┘
+                              │
+                              ▼
+                ┌─────────────────────────┐
+                │   DECISIONS/            │
+                │   (WHY decisions)       │
+                │   Cross-repo ADRs       │
+                └─────────────────────────┘
+                              │
+                              ▼
+                ┌─────────────────────────┐
+                │   REFERENCES/           │
+                │   (WHERE to find)       │
+                │   repo-index, glossary  │
+                └─────────────────────────┘
+```
+
+---
+
+## Concept Dependencies
+
+### Operator Development Path
+```
+DESIGN_PHILOSOPHY.md
+  ↓
+controller-runtime.md (how reconciliation works)
+  ↓
+status-conditions.md (how to report health)
+  ↓
+clusteroperator.md (how CVO sees your operator)
+  ↓
+webhooks.md, rbac.md, finalizers.md (advanced patterns)
+```
+
+### API Development Path
+```
+DESIGN_PHILOSOPHY.md
+  ↓
+practices/development/index.md (→ links to dev-guide/api-conventions.md)
+  ↓
+domain/kubernetes/crds.md (CustomResourceDefinition basics)
+  ↓
+platform/operator-patterns/webhooks.md (validation)
+```
+
+### Testing Path
+```
+practices/testing/index.md (→ links to dev-guide/test-conventions.md)
+  ↓
+Testing pyramid concept
+  ↓
+E2E framework specifics
+```
+
+---
+
+## Document Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| **Patterns** | How to implement | platform/operator-patterns/controller-runtime.md |
+| **Concepts** | What something is | domain/openshift/clusteroperator.md |
+| **Practices** | Links to official docs | practices/testing/index.md → dev-guide/ |
+| **Decisions** | Why choices were made | decisions/adr-0001-*.md |
+| **References** | Where to find things | references/repo-index.md |
+
+---
+
+## Progressive Disclosure
+
+**Read in this order**:
+
+1. **Foundation** (5 min): DESIGN_PHILOSOPHY.md
+2. **Your task** (10 min): 2-3 docs from task path above
+3. **Details** (20 min): Related patterns/concepts as needed
+4. **Reference** (on-demand): Glossary, repo index when needed
+
+**Total**: ~35 minutes to understand and start, not hours reading everything.
+
+---
+
+## Cross-References
+
+- Official docs: See ../../dev-guide/ and ../../guidelines/
+- Component repos: See references/repo-index.md
+- Enhancement proposals: See ../../enhancements/

--- a/ai-docs/decisions/adr-template.md
+++ b/ai-docs/decisions/adr-template.md
@@ -1,0 +1,100 @@
+# ADR-NNNN: [Title]
+
+**Status**: Proposed | Accepted | Deprecated | Superseded by [ADR-XXXX]  
+**Date**: YYYY-MM-DD  
+**Authors**: @username1, @username2  
+**Scope**: Cross-repository  
+
+## Context
+
+What is the issue or situation that motivates this decision?
+
+- Background information
+- Current state
+- Problem to solve
+- Constraints (technical, organizational, timeline)
+
+## Decision
+
+What is the decision we're making?
+
+State the decision clearly and concisely. Be specific about:
+- What we will do
+- What we won't do
+- How it will work
+
+### Example
+
+```yaml
+# If the decision involves API or code changes, include examples
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+status:
+  conditions:
+  - type: Available
+    status: "True"
+```
+
+## Rationale
+
+Why did we make this decision?
+
+- Benefits of this approach
+- How it solves the problem
+- Why this is better than alternatives
+
+## Consequences
+
+What are the implications of this decision?
+
+### Positive
+
+- Benefit 1
+- Benefit 2
+
+### Negative
+
+- Trade-off 1
+- Trade-off 2
+
+### Neutral
+
+- Change 1 (neither good nor bad, just different)
+
+## Alternatives Considered
+
+What other options did we evaluate?
+
+### Alternative 1: [Name]
+
+**Description**: What this alternative would look like
+
+**Pros**:
+- Pro 1
+- Pro 2
+
+**Cons**:
+- Con 1
+- Con 2
+
+**Rejected because**: Reason for rejection
+
+### Alternative 2: [Name]
+
+...
+
+## Implementation
+
+How will this decision be implemented?
+
+- Changes required (API, operators, components)
+- Migration path (if applicable)
+- Timeline (if applicable)
+- Affected components
+
+## References
+
+- Enhancement: [Link]
+- Related ADRs: [Link]
+- External docs: [Link]
+- Discussions: [Link to GitHub issue/PR]

--- a/ai-docs/decisions/index.md
+++ b/ai-docs/decisions/index.md
@@ -1,0 +1,72 @@
+# Architectural Decision Records (ADRs)
+
+Cross-repository architectural decisions that shape OpenShift platform.
+
+## Purpose
+
+ADRs document significant decisions affecting multiple components. They explain:
+- What decision was made
+- Why it was made
+- What alternatives were considered
+- Consequences and trade-offs
+
+## Template
+
+Use [adr-template.md](adr-template.md) for new ADRs.
+
+## Scope
+
+**Include here** (cross-repo decisions):
+- Platform-wide patterns (why etcd, why CVO orchestration)
+- API design principles (why status conditions pattern)
+- Architectural constraints (why immutable nodes)
+
+**Exclude** (component-specific):
+- Component implementation details (belongs in component repo)
+- Technology choices for single component
+- Temporary decisions
+
+## ADR List
+
+**Note**: This is a starter list. Create ADRs as needed for cross-repo decisions.
+
+Proposed ADRs:
+- `adr-0001-cvo-orchestration.md` - Why CVO orchestrates upgrades
+- `adr-0002-immutable-nodes.md` - Why RHCOS uses immutable infrastructure
+- `adr-0003-status-conditions-pattern.md` - Why Available/Progressing/Degraded
+
+## Creating ADRs
+
+```bash
+# Copy template
+cp ai-docs/decisions/adr-template.md ai-docs/decisions/adr-0001-my-decision.md
+
+# Fill in:
+# - Title, Date, Status
+# - Context, Decision, Consequences
+# - Alternatives considered
+
+# Add to this index
+
+# Create PR
+```
+
+## ADR Numbering
+
+- Use 4-digit numbers with leading zeros: `adr-0001-`
+- Sequential numbering (next available number)
+- Include slug in filename: `adr-0001-topic-name.md`
+
+## ADR Status
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Under discussion |
+| **Accepted** | Decision made, being implemented |
+| **Deprecated** | Superseded by another ADR |
+| **Superseded** | Replaced (link to new ADR) |
+
+## Related
+
+- **Pattern**: [Architectural Decision Records](https://adr.github.io/)
+- **Enhancement Process**: [../workflows/enhancement-process.md](../workflows/enhancement-process.md)

--- a/ai-docs/domain/kubernetes/crds.md
+++ b/ai-docs/domain/kubernetes/crds.md
@@ -1,0 +1,280 @@
+# Custom Resource Definitions (CRDs)
+
+**Category**: Kubernetes Core API  
+**API Group**: apiextensions.k8s.io/v1  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+CustomResourceDefinitions (CRDs) extend the Kubernetes API with new resource types. They allow operators to define domain-specific objects that behave like built-in Kubernetes resources.
+
+**Pattern**: CRD + Controller = Operator
+
+## Key Fields
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myresources.example.com  # plural.group
+spec:
+  group: example.com
+  names:
+    kind: MyResource
+    plural: myresources
+    singular: myresource
+    shortNames: [mr]
+  scope: Namespaced  # or Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true  # One version must be storage version
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 10
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+```
+
+## Key Concepts
+
+- **Group**: API group (e.g., `example.com`)
+- **Version**: API version (e.g., `v1`, `v1beta1`)
+- **Kind**: Resource type (e.g., `MyResource`)
+- **Scope**: Namespaced or Cluster
+- **Schema**: OpenAPI v3 validation
+- **Storage Version**: Version persisted in etcd
+- **Subresources**: `/status`, `/scale` endpoints
+
+## Schema Validation
+
+```yaml
+schema:
+  openAPIV3Schema:
+    type: object
+    required: ["spec"]
+    properties:
+      spec:
+        type: object
+        required: ["image"]
+        properties:
+          image:
+            type: string
+            pattern: '^[a-z0-9\-\.]+/[a-z0-9\-\.]+:[a-z0-9\-\.]+$'
+          replicas:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 3
+          tier:
+            type: string
+            enum: ["development", "staging", "production"]
+```
+
+## Versions and Conversion
+
+### Multiple Versions
+
+```yaml
+versions:
+- name: v1
+  served: true
+  storage: true  # Storage version
+  schema:
+    openAPIV3Schema: {...}
+  
+- name: v1beta1
+  served: true
+  storage: false  # Deprecated but still served
+  schema:
+    openAPIV3Schema: {...}
+```
+
+### Conversion Webhook
+
+```yaml
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: my-conversion-webhook
+          namespace: my-operator
+          path: /convert
+        caBundle: <base64-ca-cert>
+      conversionReviewVersions: ["v1"]
+```
+
+## Subresources
+
+### Status Subresource
+
+```yaml
+versions:
+- name: v1
+  served: true
+  storage: true
+  subresources:
+    status: {}  # Enables /status endpoint
+  schema:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec: {...}
+        status:
+          type: object
+          properties:
+            conditions: {...}
+```
+
+**Benefits**:
+- Separate RBAC for spec vs status
+- Update status without triggering validation webhooks on spec
+- ObservedGeneration pattern
+
+### Scale Subresource
+
+```yaml
+subresources:
+  scale:
+    specReplicasPath: .spec.replicas
+    statusReplicasPath: .status.replicas
+    labelSelectorPath: .status.labelSelector
+```
+
+**Enables**: `kubectl scale myresource/foo --replicas=5`
+
+## Printer Columns
+
+```yaml
+versions:
+- name: v1
+  additionalPrinterColumns:
+  - name: Replicas
+    type: integer
+    jsonPath: .spec.replicas
+  - name: Available
+    type: integer
+    jsonPath: .status.availableReplicas
+  - name: Age
+    type: date
+    jsonPath: .metadata.creationTimestamp
+```
+
+**Result**:
+```bash
+$ kubectl get myresources
+NAME    REPLICAS   AVAILABLE   AGE
+foo     3          3           5m
+```
+
+## Best Practices
+
+1. **Schema Validation**: Define comprehensive OpenAPI schema
+   - Prevent invalid objects from being created
+   - Better than validating in controller
+
+2. **Status Subresource**: Always use for resources with status
+   ```yaml
+   subresources:
+     status: {}
+   ```
+
+3. **Storage Version**: Only one version should be `storage: true`
+   - This is the version stored in etcd
+   - Others converted on read/write
+
+4. **Defaulting**: Use schema defaults when possible
+   ```yaml
+   replicas:
+     type: integer
+     default: 3
+   ```
+
+5. **Short Names**: Provide kubectl shortcuts
+   ```yaml
+   shortNames: [co]  # kubectl get co
+   ```
+
+## Common Patterns
+
+### Namespaced Resource
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myresources.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    kind: MyResource
+    plural: myresources
+```
+
+### Cluster-Scoped Resource
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterconfigs.example.com
+spec:
+  group: example.com
+  scope: Cluster
+  names:
+    kind: ClusterConfig
+    plural: clusterconfigs
+```
+
+## OpenShift Examples
+
+| CRD | Group | Purpose |
+|-----|-------|---------|
+| ClusterOperator | config.openshift.io | Platform component status |
+| ClusterVersion | config.openshift.io | Cluster upgrade orchestration |
+| Machine | machine.openshift.io | Node provisioning |
+| MachineConfig | machineconfiguration.openshift.io | Node configuration |
+
+## Validation
+
+```bash
+# View CRD
+oc get crd myresources.example.com -o yaml
+
+# Explain schema
+oc explain myresource.spec
+
+# List all CRDs
+oc get crds
+
+# View CRD instances
+oc get myresources -A
+```
+
+## Antipatterns
+
+❌ **Multiple storage versions**: Only one version should have `storage: true`  
+❌ **Missing schema**: No OpenAPI validation (allows invalid objects)  
+❌ **No status subresource**: Mixing spec and status updates  
+❌ **Breaking schema changes**: Removing required fields in new version
+
+## References
+
+- **API**: `oc explain customresourcedefinition`
+- **Upstream**: [Extend Kubernetes API](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+- **OpenShift**: [github.com/openshift/api](https://github.com/openshift/api)
+- **Pattern**: Implements "API-First Design" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/domain/kubernetes/index.md
+++ b/ai-docs/domain/kubernetes/index.md
@@ -1,0 +1,15 @@
+# Kubernetes Domain Concepts
+
+Core Kubernetes APIs fundamental to OpenShift.
+
+## APIs
+
+- [crds.md](crds.md) - Custom Resource Definitions (extending Kubernetes API)
+- [pod.md](pod.md) - Smallest deployable unit (containers, probes, resources)
+- [service.md](service.md) - Stable networking and service discovery
+
+## Related
+
+- **Full API reference**: `oc api-resources` or [Kubernetes API Docs](https://kubernetes.io/docs/reference/kubernetes-api/)
+- **Field details**: `oc explain <resource>` (e.g., `oc explain pod.spec`)
+- **OpenShift APIs**: [../openshift/](../openshift/)

--- a/ai-docs/domain/kubernetes/pod.md
+++ b/ai-docs/domain/kubernetes/pod.md
@@ -1,0 +1,333 @@
+# Pod
+
+**Category**: Kubernetes Core API  
+**API Group**: core/v1  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Pod is the smallest deployable unit in Kubernetes. It represents one or more containers running together on a node.
+
+**Key Principle**: Pods are ephemeral - they can be deleted and recreated at any time.
+
+## Key Fields
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: default
+  labels:
+    app: my-app
+spec:
+  containers:
+  - name: app
+    image: registry.io/my-app:v1.0
+    ports:
+    - containerPort: 8080
+    env:
+    - name: ENV_VAR
+      value: "value"
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    emptyDir: {}
+  restartPolicy: Always
+  serviceAccountName: my-sa
+status:
+  phase: Running
+  conditions:
+  - type: Ready
+    status: "True"
+  podIP: 10.128.0.5
+```
+
+## Pod Lifecycle
+
+| Phase | Meaning | Next State |
+|-------|---------|------------|
+| **Pending** | Waiting for scheduling | Running |
+| **Running** | At least one container running | Succeeded / Failed |
+| **Succeeded** | All containers exited successfully | Terminal |
+| **Failed** | At least one container exited with error | Terminal |
+| **Unknown** | Cannot determine state | Any |
+
+## Container States
+
+| State | Meaning | Reason |
+|-------|---------|--------|
+| **Waiting** | Not yet started | ContainerCreating, ImagePullBackOff |
+| **Running** | Executing | - |
+| **Terminated** | Finished or failed | Completed, Error, OOMKilled |
+
+## Key Concepts
+
+### Multi-Container Patterns
+
+**Sidecar**: Helper container (logging, monitoring)
+```yaml
+containers:
+- name: app
+  image: my-app:v1
+- name: log-collector
+  image: log-collector:v1  # Sidecar
+```
+
+**Init Containers**: Run before main containers
+```yaml
+initContainers:
+- name: setup
+  image: setup:v1
+  command: ["sh", "-c", "echo Setting up > /data/setup.txt"]
+  volumeMounts:
+  - name: data
+    mountPath: /data
+containers:
+- name: app
+  image: my-app:v1
+  volumeMounts:
+  - name: data
+    mountPath: /data
+```
+
+## Resource Requests and Limits
+
+```yaml
+resources:
+  requests:      # Scheduler uses for placement
+    memory: "64Mi"
+    cpu: "250m"
+  limits:        # Hard limits enforced by kubelet
+    memory: "128Mi"
+    cpu: "500m"
+```
+
+**Effects**:
+- **CPU limit exceeded**: Throttling
+- **Memory limit exceeded**: OOMKilled
+
+## Probes
+
+### Liveness Probe
+
+**Purpose**: Restart container if unhealthy
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+### Readiness Probe
+
+**Purpose**: Remove from service if not ready
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+```
+
+### Startup Probe
+
+**Purpose**: Delay liveness check until app started
+
+```yaml
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  failureThreshold: 30  # 30 * 10s = 5 minutes max startup
+  periodSeconds: 10
+```
+
+## Volumes
+
+```yaml
+volumes:
+# Empty directory (deleted with pod)
+- name: cache
+  emptyDir: {}
+
+# ConfigMap
+- name: config
+  configMap:
+    name: my-config
+
+# Secret
+- name: certs
+  secret:
+    secretName: my-certs
+
+# PersistentVolumeClaim
+- name: data
+  persistentVolumeClaim:
+    claimName: my-pvc
+```
+
+## Security Context
+
+```yaml
+# Pod-level
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level
+containers:
+- name: app
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    runAsUser: 1000
+```
+
+## Common Patterns
+
+### Job Pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-pod
+spec:
+  restartPolicy: Never  # Don't restart on completion
+  containers:
+  - name: job
+    image: job:v1
+    command: ["./run-job.sh"]
+```
+
+### DaemonSet Pod
+
+```yaml
+# One pod per node
+spec:
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  hostNetwork: true  # Common for node-level ops
+```
+
+## Debugging
+
+```bash
+# View pod
+oc get pod my-pod -o yaml
+
+# Check status
+oc describe pod my-pod
+
+# View logs
+oc logs my-pod
+
+# Previous logs (if restarted)
+oc logs my-pod --previous
+
+# Multi-container pod
+oc logs my-pod -c container-name
+
+# Execute command
+oc exec -it my-pod -- /bin/sh
+
+# Debug with ephemeral container (K8s 1.25+)
+oc debug pod/my-pod --image=busybox
+```
+
+## Common Issues
+
+### ImagePullBackOff
+
+```yaml
+status:
+  containerStatuses:
+  - state:
+      waiting:
+        reason: ImagePullBackOff
+        message: "Failed to pull image: unauthorized"
+```
+
+**Causes**: Wrong image, auth issues, network issues
+
+### CrashLoopBackOff
+
+```yaml
+status:
+  containerStatuses:
+  - restartCount: 5
+    state:
+      waiting:
+        reason: CrashLoopBackOff
+```
+
+**Causes**: App crashes on startup, missing config
+
+### OOMKilled
+
+```yaml
+status:
+  containerStatuses:
+  - lastState:
+      terminated:
+        reason: OOMKilled
+```
+
+**Fix**: Increase memory limit
+
+## Pod Conditions
+
+```yaml
+status:
+  conditions:
+  - type: PodScheduled
+    status: "True"
+  - type: Initialized
+    status: "True"
+  - type: ContainersReady
+    status: "True"
+  - type: Ready
+    status: "True"
+```
+
+## Best Practices
+
+1. **Always set resource requests**: Enables proper scheduling
+2. **Use readiness probe**: Prevents routing to unhealthy pods
+3. **Use liveness probe**: Automatic recovery from deadlock
+4. **Non-root user**: Security best practice
+5. **Immutable image tags**: Use SHA256 or semantic versions, not `latest`
+
+## Antipatterns
+
+❌ **No resource limits**: Can consume all node resources  
+❌ **No health probes**: Broken pods stay in service  
+❌ **Running as root**: Security risk  
+❌ **Host network for app pods**: Breaks network isolation  
+❌ **Local storage for stateful data**: Lost on pod deletion
+
+## References
+
+- **API**: `oc explain pod`
+- **Docs**: [Kubernetes Pods](https://kubernetes.io/docs/concepts/workloads/pods/)
+- **Related**: [service.md](./service.md)

--- a/ai-docs/domain/kubernetes/service.md
+++ b/ai-docs/domain/kubernetes/service.md
@@ -1,0 +1,383 @@
+# Service
+
+**Category**: Kubernetes Core API  
+**API Group**: core/v1  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Service provides stable networking for pods. It acts as a load balancer and service discovery mechanism.
+
+**Key Principle**: Pods are ephemeral, Services are stable.
+
+## Key Fields
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
+  selector:
+    app: my-app
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80        # Service port
+    targetPort: 8080 # Pod port
+  sessionAffinity: None
+status:
+  loadBalancer: {}
+```
+
+## Service Types
+
+| Type | Accessibility | Use Case |
+|------|--------------|----------|
+| **ClusterIP** | Internal only | Inter-service communication |
+| **NodePort** | External (node IP:port) | Development, testing |
+| **LoadBalancer** | External (cloud LB) | Production external access |
+| **ExternalName** | DNS CNAME | External service alias |
+
+## ClusterIP (Default)
+
+**Purpose**: Internal service discovery
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**Access**: `http://backend.default.svc.cluster.local:80`
+
+## NodePort
+
+**Purpose**: Expose service on each node's IP
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+    nodePort: 30080  # Optional (auto-assigned if omitted)
+```
+
+**Access**: `http://<node-ip>:30080`
+
+## LoadBalancer
+
+**Purpose**: Cloud provider load balancer
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-lb
+spec:
+  type: LoadBalancer
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**Status**:
+```yaml
+status:
+  loadBalancer:
+    ingress:
+    - ip: 203.0.113.5  # External IP
+```
+
+## Selectors and Endpoints
+
+**Service selects pods by labels**:
+
+```yaml
+# Service
+spec:
+  selector:
+    app: my-app
+    version: v1
+
+# Matching Pod
+metadata:
+  labels:
+    app: my-app
+    version: v1
+```
+
+**Endpoints (auto-created)**:
+```bash
+$ oc get endpoints my-service
+NAME         ENDPOINTS                     AGE
+my-service   10.128.0.5:8080,10.128.0.6:8080   5m
+```
+
+## Headless Service
+
+**Purpose**: Direct pod-to-pod DNS (no load balancing)
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-headless
+spec:
+  clusterIP: None  # Headless
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**DNS**: Returns pod IPs, not service IP
+```bash
+nslookup my-headless.default.svc.cluster.local
+# Returns: 10.128.0.5, 10.128.0.6 (pod IPs)
+```
+
+## Session Affinity
+
+```yaml
+spec:
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600
+```
+
+**Effect**: Same client IP always routed to same pod
+
+## Multiple Ports
+
+```yaml
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+```
+
+## Named Ports
+
+```yaml
+# Pod
+spec:
+  containers:
+  - name: app
+    ports:
+    - name: http
+      containerPort: 8080
+
+# Service (references named port)
+spec:
+  ports:
+  - port: 80
+    targetPort: http  # Port name, not number
+```
+
+## ExternalName
+
+**Purpose**: Alias for external service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-db
+spec:
+  type: ExternalName
+  externalName: db.example.com
+```
+
+**Access**: `external-db.default.svc.cluster.local` → `db.example.com`
+
+## Service Discovery
+
+### DNS
+
+```bash
+# Same namespace
+curl http://my-service
+
+# Different namespace
+curl http://my-service.other-namespace
+
+# Fully qualified
+curl http://my-service.other-namespace.svc.cluster.local
+```
+
+### Environment Variables
+
+```bash
+# Kubernetes injects for services in same namespace
+MY_SERVICE_SERVICE_HOST=10.96.0.5
+MY_SERVICE_SERVICE_PORT=80
+```
+
+## Common Patterns
+
+### Internal API Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: my-app
+spec:
+  type: ClusterIP
+  selector:
+    component: api
+  ports:
+  - port: 8080
+```
+
+### External Load Balancer
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+  type: LoadBalancer
+  selector:
+    component: frontend
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+### StatefulSet Headless Service
+
+```yaml
+# Headless service for StatefulSet
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  clusterIP: None
+  selector:
+    app: mysql
+  ports:
+  - port: 3306
+```
+
+**DNS**: Each pod gets stable DNS: `mysql-0.mysql.default.svc.cluster.local`
+
+## Debugging
+
+```bash
+# View service
+oc get svc my-service
+
+# Check endpoints
+oc get endpoints my-service
+
+# Describe (shows events)
+oc describe svc my-service
+
+# Test connectivity
+oc run test --rm -it --image=busybox -- wget -O- http://my-service
+
+# Check DNS
+oc run test --rm -it --image=busybox -- nslookup my-service
+```
+
+## Common Issues
+
+### No Endpoints
+
+```bash
+$ oc get endpoints my-service
+NAME         ENDPOINTS   AGE
+my-service   <none>      5m
+```
+
+**Causes**:
+- Selector doesn't match any pods
+- Pods not ready (readiness probe failing)
+- Pods in different namespace
+
+**Fix**: Check selector and pod labels match
+
+### Service Not Accessible
+
+**Checks**:
+1. Endpoints exist? `oc get endpoints`
+2. Pods ready? `oc get pods`
+3. Network policy blocking? `oc get networkpolicy`
+4. Firewall rules? (cloud provider)
+
+## OpenShift-Specific
+
+### Routes (External Access)
+
+```yaml
+# OpenShift Route (Layer 7 load balancing)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: my-route
+spec:
+  to:
+    kind: Service
+    name: my-service
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+```
+
+**Access**: `https://my-route-default.apps.cluster.example.com`
+
+## Best Practices
+
+1. **Use ClusterIP for internal**: Don't expose unnecessarily
+2. **Name ports**: Enables changing port numbers without updating service
+3. **Use Routes for external**: OpenShift Routes > NodePort for production
+4. **Set readiness probe**: Unhealthy pods excluded from endpoints
+5. **Use headless for StatefulSets**: Stable DNS per pod
+
+## Antipatterns
+
+❌ **NodePort for production**: Use LoadBalancer or Route instead  
+❌ **Selector matching all pods**: Too broad, wrong pods selected  
+❌ **No port names**: Hard to understand multi-port services  
+❌ **Hardcoded IPs**: Use DNS names instead  
+❌ **LoadBalancer for internal**: Expensive, use ClusterIP
+
+## References
+
+- **API**: `oc explain service`
+- **Docs**: [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- **OpenShift**: [Routes](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html)
+- **Related**: [pod.md](./pod.md)

--- a/ai-docs/domain/openshift/clusteroperator.md
+++ b/ai-docs/domain/openshift/clusteroperator.md
@@ -1,0 +1,250 @@
+# ClusterOperator
+
+**Category**: OpenShift Platform API  
+**API Group**: config.openshift.io/v1  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+ClusterOperator represents the status of a platform component. Every core OpenShift component reports its health via a ClusterOperator resource.
+
+**Purpose**: Centralized health monitoring and upgrade orchestration.
+
+## Key Fields
+
+```yaml
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: kube-apiserver
+spec: {}  # ClusterOperator has no spec
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+    message: "All 3 pods are ready"
+    lastTransitionTime: "2026-04-28T10:00:00Z"
+    lastHeartbeatTime: "2026-04-28T10:05:00Z"
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+    message: "Desired state reached"
+  - type: Degraded
+    status: "False"
+    reason: AsExpected
+    message: "Component is healthy"
+  - type: Upgradeable
+    status: "True"
+    reason: AsExpected
+    message: "Ready for upgrade"
+  versions:
+  - name: operator
+    version: 4.16.0
+  - name: kube-apiserver
+    version: 1.29.5
+  relatedObjects:
+  - group: ""
+    resource: namespaces
+    name: openshift-kube-apiserver
+  - group: apps
+    resource: deployments
+    namespace: openshift-kube-apiserver
+    name: kube-apiserver
+```
+
+## Key Concepts
+
+- **Conditions**: Available, Progressing, Degraded, Upgradeable
+- **Versions**: Operator version and operand versions
+- **RelatedObjects**: Resources managed by this operator
+- **Read-Only**: ClusterOperator has no spec (status only)
+
+## Required Conditions
+
+| Condition | Meaning | True When | False When |
+|-----------|---------|-----------|------------|
+| **Available** | Component functional | Pods ready, API serving | Pods not ready, API down |
+| **Progressing** | Reconciliation in progress | Upgrade/rollout active | Desired state reached |
+| **Degraded** | Impaired functionality | Partial failure | Fully healthy |
+| **Upgradeable** | Safe to upgrade | No blockers | Manual intervention needed |
+
+See [status-conditions.md](../../platform/operator-patterns/status-conditions.md) for detailed semantics.
+
+## Lifecycle
+
+```
+Component start:
+  1. Create ClusterOperator (if not exists)
+  2. Set all conditions (Available, Progressing, Degraded)
+  3. Update heartbeat every ~60s
+
+Normal operation:
+  1. Update conditions when state changes
+  2. Update heartbeat regularly
+
+Upgrade:
+  1. CVO updates operator image
+  2. Operator sets Progressing=True
+  3. Operator rolls out new workload
+  4. Operator sets Progressing=False, updates versions
+```
+
+## Monitoring
+
+```bash
+# View all ClusterOperators
+oc get clusteroperators
+
+# View specific operator
+oc get clusteroperator kube-apiserver -o yaml
+
+# Check degraded operators
+oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Degraded" and .status=="True")) | .metadata.name'
+
+# Check upgrade progress
+oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
+```
+
+## Creating ClusterOperator
+
+```go
+import (
+    configv1 "github.com/openshift/api/config/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ensureClusterOperator(ctx context.Context, client client.Client, name string) error {
+    co := &configv1.ClusterOperator{
+        ObjectMeta: metav1.ObjectMeta{
+            Name: name,
+        },
+    }
+    
+    _, err := controllerutil.CreateOrUpdate(ctx, client, co, func() error {
+        // Set conditions
+        setCondition(&co.Status.Conditions,
+            configv1.OperatorAvailable,
+            configv1.ConditionTrue,
+            "AsExpected",
+            "Component is available")
+        
+        // Set versions
+        co.Status.Versions = []configv1.OperandVersion{
+            {Name: "operator", Version: os.Getenv("RELEASE_VERSION")},
+        }
+        
+        // Set related objects
+        co.Status.RelatedObjects = []configv1.ObjectReference{
+            {
+                Group:    "",
+                Resource: "namespaces",
+                Name:     "my-operator-namespace",
+            },
+        }
+        
+        return nil
+    })
+    
+    return err
+}
+```
+
+## Versions
+
+```yaml
+status:
+  versions:
+  - name: operator
+    version: 4.16.0
+  - name: etcd
+    version: 3.5.12
+```
+
+**Operator version**: Version of the operator itself  
+**Operand versions**: Versions of managed components
+
+## RelatedObjects
+
+```yaml
+status:
+  relatedObjects:
+  - group: ""
+    resource: namespaces
+    name: openshift-kube-apiserver
+  - group: apps
+    resource: deployments
+    namespace: openshift-kube-apiserver
+    name: kube-apiserver
+```
+
+**Purpose**: Help must-gather and debugging tools find related resources.
+
+## Alerts
+
+```promql
+# Alert on unavailable component
+ALERT ClusterOperatorUnavailable
+  IF cluster_operator_conditions{type="Available", status="False"} == 1
+  FOR 15m
+  
+# Alert on degraded component
+ALERT ClusterOperatorDegraded
+  IF cluster_operator_conditions{type="Degraded", status="True"} == 1
+  FOR 15m
+
+# Alert on stale heartbeat
+ALERT ClusterOperatorStale
+  IF (time() - cluster_operator_conditions_last_heartbeat) > 300
+  FOR 5m
+```
+
+## Common ClusterOperators
+
+| Name | Component | Purpose |
+|------|-----------|---------|
+| kube-apiserver | Kubernetes API | API server availability |
+| etcd | etcd cluster | Data store health |
+| kube-controller-manager | KCM | Controller health |
+| machine-api | Machine API | Node provisioning |
+| cluster-network-operator | Networking | SDN/OVN health |
+| cluster-version | CVO | Upgrade orchestration |
+
+## Best Practices
+
+1. **Always set all conditions**: Available, Progressing, Degraded must always be present
+
+2. **Update heartbeat regularly**: Every 60s even if nothing changed
+   ```go
+   setCondition(&co.Status.Conditions, type, status, reason, message)
+   // Updates LastHeartbeatTime automatically
+   ```
+
+3. **Use Upgradeable to block**: Set to False when upgrade would break
+   ```yaml
+   - type: Upgradeable
+     status: "False"
+     reason: UnsupportedConfiguration
+     message: "Manual intervention required"
+   ```
+
+4. **Set RelatedObjects**: Help debugging
+   ```yaml
+   relatedObjects:
+   - resource: namespaces
+     name: my-operator-namespace
+   ```
+
+## Antipatterns
+
+❌ **Missing conditions**: Not setting Available/Progressing/Degraded  
+❌ **Stale heartbeat**: Not updating LastHeartbeatTime  
+❌ **Vague messages**: "Error" instead of "Pod xyz crash looping: OOMKilled"  
+❌ **Wrong Available semantics**: Setting False during normal upgrade
+
+## References
+
+- **API**: `oc explain clusteroperator`
+- **Source**: [github.com/openshift/api/config/v1](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go)
+- **Dev Guide**: [ClusterOperator Guidelines](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md)
+- **Pattern**: [status-conditions.md](../../platform/operator-patterns/status-conditions.md)

--- a/ai-docs/domain/openshift/clusteroperator.md
+++ b/ai-docs/domain/openshift/clusteroperator.md
@@ -2,13 +2,21 @@
 
 **Category**: OpenShift Platform API  
 **API Group**: config.openshift.io/v1  
-**Last Updated**: 2026-04-28  
+**Last Updated**: 2026-05-26
+**Scope**: All form factors (see HCP note below)
 
 ## Overview
 
 ClusterOperator represents the status of a platform component. Every core OpenShift component reports its health via a ClusterOperator resource.
 
 **Purpose**: Centralized health monitoring and upgrade orchestration.
+
+**⚠️ Form Factor Note**: In **Hypershift/HCP**, ClusterOperators exist in **both** clusters:
+- **Guest cluster**: Platform components serving the hosted cluster (same as standalone)
+- **Management cluster**: HyperShift platform components managing hosted control planes
+- The CVO in the **guest** cluster watches ClusterOperators in the guest cluster
+
+See [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) for authoritative details on CVO placement in HCP.
 
 ## Key Fields
 

--- a/ai-docs/domain/openshift/clusterversion.md
+++ b/ai-docs/domain/openshift/clusterversion.md
@@ -1,0 +1,277 @@
+# ClusterVersion
+
+**Category**: OpenShift Platform API  
+**API Group**: config.openshift.io/v1  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+ClusterVersion represents the desired and current version of the OpenShift cluster. The Cluster Version Operator (CVO) watches this resource and orchestrates upgrades.
+
+**Singleton**: Only one ClusterVersion exists, named `version`.
+
+## Key Fields
+
+```yaml
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version  # Always "version"
+spec:
+  channel: stable-4.16
+  clusterID: a1b2c3d4-5678-90ab-cdef-1234567890ab
+  desiredUpdate:
+    version: 4.16.1
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
+status:
+  availableUpdates:
+  - version: 4.16.1
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  - version: 4.16.2
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+  desired:
+    version: 4.16.0
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  history:
+  - state: Completed
+    version: 4.16.0
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+    startedTime: "2026-04-01T10:00:00Z"
+    completionTime: "2026-04-01T11:30:00Z"
+  observedGeneration: 5
+  versionHash: abc123def456
+```
+
+## Key Concepts
+
+- **Desired Update**: Target version set by admin
+- **Available Updates**: Valid upgrade paths from upstream
+- **History**: Past upgrade attempts and outcomes
+- **Channel**: Update stream (stable, fast, candidate, eus)
+- **CVO**: Cluster Version Operator orchestrates the upgrade
+
+## Upgrade Flow
+
+```
+1. Admin sets spec.desiredUpdate
+   ↓
+2. CVO validates update (N→N+1, supported path)
+   ↓
+3. CVO sets status.conditions.Progressing=True
+   ↓
+4. CVO updates operators in order:
+   - etcd
+   - kube-apiserver
+   - kube-controller-manager
+   - kube-scheduler
+   - other operators (parallel)
+   ↓
+5. Each operator reports Progressing=True → False
+   ↓
+6. CVO sets status.conditions.Progressing=False
+   ↓
+7. CVO adds entry to status.history
+```
+
+## Channels
+
+| Channel | Purpose | Update Frequency |
+|---------|---------|------------------|
+| **stable-X.Y** | Production | After candidate soak |
+| **fast-X.Y** | Early adopters | Weekly |
+| **candidate-X.Y** | Pre-release testing | Daily |
+| **eus-X.Y** | Extended Update Support | Long-term stable |
+
+**Example**: `stable-4.16`, `fast-4.17`, `eus-4.14`
+
+## Triggering Upgrade
+
+```bash
+# View current version
+oc get clusterversion
+
+# View available updates
+oc adm upgrade
+
+# Start upgrade to specific version
+oc adm upgrade --to=4.16.1
+
+# Start upgrade to latest
+oc adm upgrade --to-latest
+```
+
+## Monitoring Upgrade
+
+```bash
+# Watch upgrade progress
+oc get clusterversion -w
+
+# View operator status
+oc get clusteroperators
+
+# View progressing operators
+oc get co -o json | jq -r '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
+
+# View CVO logs
+oc logs -n openshift-cluster-version deployment/cluster-version-operator
+```
+
+## Upgrade Policies
+
+### Version Skew
+
+- **Supported**: N → N+1 (e.g., 4.15 → 4.16)
+- **Not supported**: N → N+2 (e.g., 4.14 → 4.16)
+- **EUS exception**: EUS releases allow skipping one version
+
+### Upgrade Paths
+
+```yaml
+# Valid upgrade graph
+4.14.0 → 4.14.1 → 4.14.2
+  ↓         ↓         ↓
+4.15.0 ← 4.15.1 ← 4.15.2
+  ↓         ↓         ↓
+4.16.0 ← 4.16.1 ← 4.16.2
+```
+
+**CVO validates**: Upgrade path exists in Cincinnati graph
+
+## Pausing Upgrades
+
+```bash
+# Pause cluster upgrades (for maintenance)
+oc adm upgrade --pause
+
+# Resume upgrades
+oc adm upgrade --resume
+```
+
+## Upgrade Conditions
+
+| Condition | Meaning | True When |
+|-----------|---------|-----------|
+| **Available** | CVO is functional | CVO pod running |
+| **Progressing** | Upgrade in progress | Operators being updated |
+| **Failing** | Upgrade failed | Operator reconciliation failed |
+| **RetrievedUpdates** | Update graph fetched | Cincinnati API reachable |
+
+## History
+
+```yaml
+status:
+  history:
+  - state: Completed
+    version: 4.16.0
+    completionTime: "2026-04-01T11:30:00Z"
+  - state: Completed
+    version: 4.15.5
+    completionTime: "2026-03-01T10:00:00Z"
+  - state: Partial
+    version: 4.15.4
+    startedTime: "2026-02-15T09:00:00Z"
+    # No completionTime = upgrade failed/rolled back
+```
+
+**States**: Completed, Partial
+
+## CVO Operator Ordering
+
+```yaml
+# manifests/0000_*.yaml files in release image
+0000_00_cluster-version-operator_*.yaml
+0000_50_cluster-etcd-operator_*.yaml
+0000_60_cluster-kube-apiserver-operator_*.yaml
+0000_70_cluster-kube-controller-manager-operator_*.yaml
+0000_80_cluster-kube-scheduler-operator_*.yaml
+0000_90_*  # All other operators (parallel)
+```
+
+**Ordering ensures**: etcd → API server → controllers → operators
+
+## Overrides
+
+```yaml
+spec:
+  overrides:
+  - kind: Deployment
+    name: my-operator
+    namespace: openshift-my-operator
+    unmanaged: true  # CVO won't update this
+```
+
+**Use case**: Prevent CVO from managing specific resources (debugging only)
+
+## Examples
+
+### View ClusterVersion
+
+```bash
+$ oc get clusterversion version -o yaml
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.16
+  clusterID: abc-123
+status:
+  desired:
+    version: 4.16.0
+  history:
+  - state: Completed
+    version: 4.16.0
+```
+
+### Upgrade Status
+
+```bash
+$ oc get clusterversion
+NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
+version   4.16.0    True        False         5h      Cluster version is 4.16.0
+```
+
+## Best Practices
+
+1. **Use Recommended Updates**: CVO validates upgrade paths
+   ```bash
+   oc adm upgrade  # Shows recommended updates only
+   ```
+
+2. **Monitor Operator Health Before Upgrade**:
+   ```bash
+   oc get co | grep -v "True.*False.*False"
+   ```
+
+3. **Check Upgrade Graph**: Ensure path exists
+   ```bash
+   oc adm upgrade --to=4.16.1  # Validates before starting
+   ```
+
+4. **Watch Operator Progress**: Don't interrupt during upgrade
+   ```bash
+   watch oc get co
+   ```
+
+## Antipatterns
+
+❌ **Version skipping**: 4.14 → 4.16 (use intermediate version)  
+❌ **Upgrading degraded cluster**: Fix issues first  
+❌ **Manual operator updates**: Always use CVO  
+❌ **Interrupting upgrade**: Can leave cluster in inconsistent state
+
+## References
+
+- **API**: `oc explain clusterversion`
+- **Source**: [github.com/openshift/api/config/v1](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go)
+- **CVO**: [cluster-version-operator](https://github.com/openshift/cluster-version-operator)
+- **Docs**: [Updating Clusters](https://docs.openshift.com/container-platform/latest/updating/index.html)
+- **Pattern**: [upgrade-strategies.md](../../platform/openshift-specifics/upgrade-strategies.md)

--- a/ai-docs/domain/openshift/clusterversion.md
+++ b/ai-docs/domain/openshift/clusterversion.md
@@ -2,13 +2,22 @@
 
 **Category**: OpenShift Platform API  
 **API Group**: config.openshift.io/v1  
-**Last Updated**: 2026-04-29  
+**Last Updated**: 2026-05-26
+**Scope**: All form factors (see HCP note below)
 
 ## Overview
 
 ClusterVersion represents the desired and current version of the OpenShift cluster. The Cluster Version Operator (CVO) watches this resource and orchestrates upgrades.
 
 **Singleton**: Only one ClusterVersion exists, named `version`.
+
+**⚠️ Form Factor Note**: In **Hypershift/HCP**:
+- ClusterVersion exists in the **guest cluster** (not management cluster)
+- The CVO runs in the **guest cluster** and manages guest cluster components
+- The **management cluster** uses HyperShift's `HostedCluster` API instead
+- Control plane and guest cluster have separate version lifecycles
+
+See [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) for authoritative details on HCP version tracking.
 
 ## Key Fields
 

--- a/ai-docs/domain/openshift/index.md
+++ b/ai-docs/domain/openshift/index.md
@@ -1,0 +1,14 @@
+# OpenShift Domain Concepts
+
+Core OpenShift platform APIs.
+
+## APIs
+
+- [clusteroperator.md](clusteroperator.md) - Platform component status and health reporting
+- [clusterversion.md](clusterversion.md) - Cluster upgrade orchestration and version management
+
+## Related
+
+- **Full API reference**: `oc api-resources | grep openshift` 
+- **Field details**: `oc explain <resource>` (e.g., `oc explain clusteroperator`)
+- **Kubernetes APIs**: [../kubernetes/](../kubernetes/)

--- a/ai-docs/platform/openshift-specifics/index.md
+++ b/ai-docs/platform/openshift-specifics/index.md
@@ -1,0 +1,13 @@
+# OpenShift-Specific Patterns
+
+Patterns unique to OpenShift platform.
+
+## Patterns
+
+- [upgrade-strategies.md](upgrade-strategies.md) - CVO orchestration, N→N+1 version skew, zero-downtime upgrades
+
+## Related
+
+- [Operator Patterns](../operator-patterns/) - Generic operator patterns
+- [ClusterOperator](../../domain/openshift/clusteroperator.md) - Status reporting for platform components
+- [ClusterVersion](../../domain/openshift/clusterversion.md) - Upgrade orchestration

--- a/ai-docs/platform/openshift-specifics/upgrade-strategies.md
+++ b/ai-docs/platform/openshift-specifics/upgrade-strategies.md
@@ -1,0 +1,265 @@
+# Upgrade Strategies
+
+**Category**: OpenShift-Specific Pattern  
+**Applies To**: All ClusterOperators  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+OpenShift upgrades are orchestrated by the Cluster Version Operator (CVO). Every operator must support N→N+1 version skew and coordinate with CVO for zero-downtime upgrades.
+
+**Goal**: Upgrade 1000-node cluster with zero application downtime.
+
+## Key Concepts
+
+- **CVO Ordering**: etcd → kube-apiserver → kube-controller-manager → operators
+- **Version Skew**: N→N+1 support (current and next minor version)
+- **Progressing Condition**: Signals upgrade in progress
+- **Upgradeable Condition**: Blocks upgrade if False
+- **Rolling Updates**: Update nodes one at a time
+
+## Upgrade Phases
+
+| Phase | CVO Action | Operator Responsibility |
+|-------|-----------|------------------------|
+| **Pre-upgrade** | Check Upgradeable=True | Set Upgradeable=False if unsafe |
+| **Upgrade** | Update operator image | Reconcile new version |
+| **Rollout** | Wait for Progressing=False | Update workloads, report progress |
+| **Post-upgrade** | Verify Available=True | Resume normal operation |
+
+## CVO Orchestration
+
+```
+CVO upgrade order:
+1. etcd operator
+2. kube-apiserver operator
+3. kube-controller-manager operator
+4. kube-scheduler operator
+5. All other operators (parallel)
+```
+
+**Why this order?**
+- etcd must be healthy before API server updates
+- API server must be upgraded before controllers (version skew)
+- Operators depend on API server, so upgrade last
+
+## Implementation
+
+### Setting Upgradeable Condition
+
+```go
+func (r *Reconciler) checkUpgradeable(ctx context.Context) (bool, string, string) {
+    // Check if upgrade would be unsafe
+    
+    // Example: Block if custom config is set
+    if hasUnsupportedConfig() {
+        return false, "UnsupportedConfig", 
+            "Custom configuration detected, manual intervention required"
+    }
+    
+    // Example: Block if degraded
+    if isDegraded() {
+        return false, "Degraded",
+            "Component is degraded, fix issues before upgrading"
+    }
+    
+    // Safe to upgrade
+    return true, "AsExpected", "Ready for upgrade"
+}
+
+func (r *Reconciler) updateStatus(ctx context.Context, co *configv1.ClusterOperator) {
+    upgradeable, reason, msg := r.checkUpgradeable(ctx)
+    
+    setCondition(&co.Status.Conditions,
+        configv1.OperatorUpgradeable,
+        boolToStatus(upgradeable),
+        reason, msg)
+}
+```
+
+### Handling Version Skew
+
+```go
+func (r *Reconciler) reconcile(ctx context.Context, obj *MyResource) error {
+    // Get desired version from CVO
+    desiredVersion := os.Getenv("RELEASE_VERSION")
+    
+    // Get current version from status
+    currentVersion := obj.Status.Version
+    
+    if desiredVersion != currentVersion {
+        // Upgrade in progress
+        if err := r.upgradeWorkload(ctx, obj, desiredVersion); err != nil {
+            return err
+        }
+        
+        // Update status
+        obj.Status.Version = desiredVersion
+        setCondition(&obj.Status.Conditions,
+            configv1.OperatorProgressing,
+            configv1.ConditionTrue,
+            "RollingOut",
+            fmt.Sprintf("Upgrading to %s", desiredVersion))
+    }
+    
+    return nil
+}
+```
+
+### Rolling Update Pattern
+
+```go
+func (r *Reconciler) upgradeDeployment(ctx context.Context, desired *appsv1.Deployment) error {
+    current := &appsv1.Deployment{}
+    err := r.Get(ctx, client.ObjectKeyFromObject(desired), current)
+    
+    if err != nil {
+        return err
+    }
+    
+    // Update with RollingUpdate strategy
+    desired.Spec.Strategy = appsv1.DeploymentStrategy{
+        Type: appsv1.RollingUpdateDeploymentStrategyType,
+        RollingUpdate: &appsv1.RollingUpdateDeployment{
+            MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+            MaxSurge:       &intstr.IntOrString{IntVal: 1},
+        },
+    }
+    
+    // Set PodDisruptionBudget for HA components
+    // (separate resource, not shown here)
+    
+    return r.Update(ctx, desired)
+}
+```
+
+## Best Practices
+
+1. **Always Support N→N+1**: Operator version X must work with X-1 and X+1
+   - API compatibility (don't remove fields)
+   - Schema changes must be backward compatible
+   
+2. **Use Progressing Condition**: Set to True during rollout
+   ```yaml
+   conditions:
+   - type: Progressing
+     status: "True"
+     reason: RollingOut
+     message: "Updating to version 4.16.0"
+   ```
+
+3. **Block Unsafe Upgrades**: Set Upgradeable=False if upgrade would break
+   ```yaml
+   conditions:
+   - type: Upgradeable
+     status: "False"
+     reason: UnsupportedConfiguration
+     message: "Remove custom config before upgrading"
+   ```
+
+4. **PodDisruptionBudgets**: Prevent all replicas going down
+   ```yaml
+   apiVersion: policy/v1
+   kind: PodDisruptionBudget
+   metadata:
+     name: my-component
+   spec:
+     minAvailable: 1
+     selector:
+       matchLabels:
+         app: my-component
+   ```
+
+5. **Graceful Shutdown**: Handle SIGTERM properly (30s default grace period)
+
+## Version Skew Scenarios
+
+### API Compatibility
+
+```go
+// ✅ Backward compatible (adding optional field)
+type MyResourceSpec struct {
+    Replicas int  `json:"replicas"`
+    Image    string `json:"image"`
+    NewField *string `json:"newField,omitempty"` // Optional, defaults to nil
+}
+
+// ❌ Not backward compatible (removing field)
+type MyResourceSpec struct {
+    Image string `json:"image"`
+    // Replicas removed - breaks old clients!
+}
+```
+
+### Storage Version Migration
+
+```yaml
+# Old version (v1alpha1)
+apiVersion: example.com/v1alpha1
+kind: MyResource
+spec:
+  field: value
+
+# Hub version (v1)
+apiVersion: example.com/v1
+kind: MyResource
+spec:
+  newField: value
+
+# Use conversion webhooks to handle both
+```
+
+## Node Upgrades
+
+**Machine Config Operator (MCO) pattern**:
+
+1. MCO creates new MachineConfig
+2. Nodes reboot one at a time (drain → reboot → uncordon)
+3. Max 1 node upgrading per pool at a time (configurable)
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker
+spec:
+  maxUnavailable: 1  # Only 1 node at a time
+  paused: false
+```
+
+## Monitoring Upgrades
+
+```bash
+# Check upgrade progress
+oc get clusterversion
+
+# Watch operator status
+oc get clusteroperators
+
+# View progressing operators
+oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
+```
+
+## Examples in Components
+
+| Component | Upgrade Strategy | Notes |
+|-----------|------------------|-------|
+| etcd | One pod at a time, quorum maintained | Must maintain 2/3 quorum |
+| kube-apiserver | Rolling update, PDB ensures 1+ available | Uses PodDisruptionBudget |
+| machine-config-operator | Node drain → reboot → uncordon | Can take 30+ minutes per node |
+| cluster-network-operator | Update CNI plugins in rolling fashion | Brief network interruptions possible |
+
+## Antipatterns
+
+❌ **Breaking API changes**: Removing fields in minor version  
+❌ **All replicas down**: No PodDisruptionBudget for HA components  
+❌ **Long rollouts**: Not reporting Progressing condition  
+❌ **Ignoring Upgradeable**: Allowing unsafe upgrades to proceed  
+❌ **Blocking CVO**: Long-running reconciliation preventing other operators from upgrading
+
+## References
+
+- **CVO**: [Cluster Version Operator](https://github.com/openshift/cluster-version-operator)
+- **Enhancement**: [Upgrade Ordering](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md)
+- **API**: [ClusterVersion](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go)
+- **Pattern**: Implements "Upgrade Safety" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/platform/openshift-specifics/upgrade-strategies.md
+++ b/ai-docs/platform/openshift-specifics/upgrade-strategies.md
@@ -2,13 +2,16 @@
 
 **Category**: OpenShift-Specific Pattern  
 **Applies To**: All ClusterOperators  
-**Last Updated**: 2026-04-28  
+**Last Updated**: 2026-05-26
+**Scope**: Primarily standalone clusters; see [HCP Differences](#hypershift--hosted-control-planes-hcp) section
 
 ## Overview
 
 OpenShift upgrades are orchestrated by the Cluster Version Operator (CVO). Every operator must support N→N+1 version skew and coordinate with CVO for zero-downtime upgrades.
 
 **Goal**: Upgrade 1000-node cluster with zero application downtime.
+
+**⚠️ Form Factor Note**: This document describes upgrade behavior in **standalone OpenShift clusters** (self-hosted control plane). For Hypershift/HCP deployments, control plane and data plane upgrade separately—see the HCP section below.
 
 ## Key Concepts
 
@@ -257,9 +260,96 @@ oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="
 ❌ **Ignoring Upgradeable**: Allowing unsafe upgrades to proceed  
 ❌ **Blocking CVO**: Long-running reconciliation preventing other operators from upgrading
 
+## Hypershift / Hosted Control Planes (HCP)
+
+**⚠️ Critical Difference**: In HCP, the control plane and data plane upgrade **independently**.
+
+### HCP Upgrade Model
+
+```
+Standalone:
+  CVO upgrades control plane → operators → workloads (all in same cluster)
+
+HCP:
+  Management Cluster:
+    HyperShift Operator upgrades → Hosted Control Plane components
+  Guest Cluster:
+    CVO in guest upgrades → operators in guest → workloads
+```
+
+### Key Differences
+
+| Aspect | Standalone | HCP |
+|--------|-----------|-----|
+| **Control plane location** | Same cluster as workloads | Management cluster |
+| **Upgrade orchestrator** | CVO in same cluster | HyperShift Operator (mgmt) + CVO (guest) |
+| **Version skew** | N→N+1 within cluster | Control plane and data plane can differ |
+| **Node upgrades** | MCO reboots nodes | Guest MCO manages guest nodes; mgmt cluster nodes managed separately |
+| **Operator location** | Depends—some in mgmt, some in guest | Must explicitly consider |
+
+**Note on node upgrades in HCP**: The control plane runs as **pods** in the management cluster (not on dedicated nodes). The management cluster has its own worker nodes where these control plane pods run. Those management cluster nodes are upgraded by the **management cluster's MCO**, independently from the guest cluster. The **guest cluster's MCO** only manages guest cluster worker nodes.
+
+### HCP Considerations for Operators
+
+**If your operator runs in the management cluster**:
+- ✅ Upgraded by HyperShift Operator, not CVO
+- ✅ Must tolerate guest cluster version skew (guest may be older)
+- ✅ Network access to guest cluster required (via KAS)
+
+**If your operator runs in the guest cluster**:
+- ✅ Upgraded by CVO in guest (same as standalone)
+- ✅ Must tolerate control plane version skew (control plane may be newer)
+- ✅ API calls go through remote KAS (in management cluster)
+
+**If your operator is split across both**:
+- ✅ Coordination required—design for independent upgrade order
+- ✅ Must tolerate partial upgrade state (mgmt upgraded, guest not yet)
+- ✅ Document dependencies in enhancement proposal
+
+### SNO (Single-Node OpenShift) Considerations
+
+**Resource Constraints**:
+- All overhead runs on ONE node (control plane + workloads)
+- No HA—single point of failure during node reboot
+- Node upgrade = full cluster downtime (1 node can't drain itself)
+
+**Upgrade Impact**:
+```yaml
+# Standalone HA cluster
+3 control plane nodes + N worker nodes
+→ Rolling update, zero downtime
+
+# SNO
+1 node
+→ Node reboot = cluster downtime (~5-10 minutes)
+```
+
+**Design Considerations**:
+- Accept brief downtime during upgrades (unavoidable in SNO)
+- Ensure rapid reconciliation after reboot
+- Test with `replica: 1` configurations
+
+### MicroShift Considerations
+
+**Different Upgrade Model**:
+- No CVO—upgrades via RPM/greenboot
+- No MCO—host OS managed separately
+- Operators may not exist (smaller footprint)
+
+**If your enhancement involves**:
+- ✅ New APIs → May not be available in MicroShift
+- ✅ Operators → May not run in MicroShift
+- ✅ CVO coordination → Not applicable to MicroShift
+
+See [topology-considerations-guide.md](../../workflows/topology-considerations-guide.md) for comprehensive form factor guidance.
+
 ## References
 
 - **CVO**: [Cluster Version Operator](https://github.com/openshift/cluster-version-operator)
 - **Enhancement**: [Upgrade Ordering](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md)
 - **API**: [ClusterVersion](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go)
 - **Pattern**: Implements "Upgrade Safety" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)
+- **Form Factors**: [topology-considerations-guide.md](../../workflows/topology-considerations-guide.md) - Comprehensive HCP/SNO/MicroShift guidance
+- **HCP Enhancements** (authoritative sources for HCP upgrade behavior):
+  - [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) - Management vs guest upgrade orchestration
+  - [monitoring.md](../../../enhancements/hypershift/monitoring.md) - Control plane/guest cluster separation

--- a/ai-docs/platform/operator-patterns/controller-runtime.md
+++ b/ai-docs/platform/operator-patterns/controller-runtime.md
@@ -1,0 +1,165 @@
+# Controller Runtime Pattern
+
+**Category**: Platform Pattern  
+**Applies To**: All Operators  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+The controller-runtime pattern implements the Kubernetes reconciliation loop: continuously compare desired state (spec) with current state (status) and take actions to converge.
+
+**Core Principle**: Watch → Reconcile → Update Status → Repeat
+
+## Key Concepts
+
+- **Reconcile Loop**: Core function that runs when resources change
+- **Watch**: Monitor specific resources for changes (create/update/delete events)
+- **Requeue**: Return from reconcile with delay to retry later
+- **Idempotence**: Reconcile must handle being called multiple times safely
+- **Level-Triggered**: React to current state, not edge events
+
+## Implementation
+
+```go
+import (
+    ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *MyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    // 1. Fetch current resource
+    obj := &MyResource{}
+    if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+        return ctrl.Result{}, client.IgnoreNotFound(err)
+    }
+    
+    // 2. Compare desired (obj.Spec) vs current state
+    current := r.getCurrentState()
+    
+    // 3. Take action to converge
+    if !stateMatches(obj.Spec, current) {
+        if err := r.reconcileState(ctx, obj); err != nil {
+            return ctrl.Result{}, err
+        }
+    }
+    
+    // 4. Update status
+    obj.Status.ObservedGeneration = obj.Generation
+    if err := r.Status().Update(ctx, obj); err != nil {
+        return ctrl.Result{}, err
+    }
+    
+    return ctrl.Result{}, nil
+}
+```
+
+## Best Practices
+
+1. **Idempotent Reconciliation**: Calling reconcile multiple times = same result
+   - Check current state before creating resources
+   - Use `CreateOrUpdate()` instead of `Create()`
+   
+2. **Status Updates Separate from Spec**: 
+   - Use `Status().Update()` not `Update()`
+   - ObservedGeneration pattern to detect spec changes
+   
+3. **Requeue Strategy**:
+   - `Result{Requeue: true}` - retry immediately
+   - `Result{RequeueAfter: 5*time.Minute}` - retry after delay
+   - Return error - exponential backoff
+
+4. **Garbage Collection**:
+   - Use `OwnerReferences` for automatic cleanup
+   - Set `controller: true` for primary owner
+
+## Common Patterns
+
+### Basic Reconcile Structure
+```go
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    // Pattern: Fetch → Check → Act → Status → Requeue
+    
+    // 1. Fetch
+    obj := &v1.MyResource{}
+    if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+        return ctrl.Result{}, client.IgnoreNotFound(err)
+    }
+    
+    // 2. Check deletion
+    if !obj.DeletionTimestamp.IsZero() {
+        return r.handleDeletion(ctx, obj)
+    }
+    
+    // 3. Reconcile owned resources
+    if err := r.ensureDeployment(ctx, obj); err != nil {
+        return ctrl.Result{}, err
+    }
+    
+    if err := r.ensureService(ctx, obj); err != nil {
+        return ctrl.Result{}, err
+    }
+    
+    // 4. Update status
+    return r.updateStatus(ctx, obj)
+}
+```
+
+### Watch Setup
+```go
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+    return ctrl.NewControllerManagedBy(mgr).
+        For(&v1.MyResource{}).               // Primary resource
+        Owns(&appsv1.Deployment{}).          // Owned resources (auto-watch)
+        Watches(
+            &corev1.ConfigMap{},             // External resource
+            handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToOwner),
+        ).
+        Complete(r)
+}
+```
+
+### Error Handling
+```go
+// Transient error - retry with backoff
+if err := r.createPod(ctx, obj); err != nil {
+    return ctrl.Result{}, fmt.Errorf("failed to create pod: %w", err)
+}
+
+// Expected condition - requeue later
+if !r.isReady(obj) {
+    return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+// Success - no requeue
+return ctrl.Result{}, nil
+```
+
+## Watches and Events
+
+| Watch Type | When to Use | Example |
+|------------|-------------|---------|
+| `For()` | Primary resource | `.For(&MyResource{})` |
+| `Owns()` | Resources with OwnerReference | `.Owns(&Deployment{})` |
+| `Watches()` | External resources | Cluster-scoped resources, ConfigMaps |
+
+## Examples in Components
+
+| Component | Pattern | Notes |
+|-----------|---------|-------|
+| cluster-version-operator | CVO reconciles ClusterVersion | Orchestrates operator upgrades |
+| machine-api-operator | Machine controller | Creates cloud instances |
+| cluster-network-operator | Network config reconciliation | Multi-resource coordination |
+
+## Antipatterns
+
+❌ **Imperative logic**: Storing state in controller (use cluster state as source of truth)  
+❌ **Long-running operations**: Blocking reconcile loop (use requeue instead)  
+❌ **Event-driven**: Relying on event order (level-triggered, not edge-triggered)  
+❌ **Side effects without idempotency**: Creating resources without checking existence
+
+## References
+
+- **Upstream**: [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime)
+- **Book**: [Kubebuilder Book - Controllers](https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html)
+- **OpenShift**: [status-conditions.md](./status-conditions.md)
+- **Pattern**: Implements "Desired State" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/platform/operator-patterns/controller-runtime.md
+++ b/ai-docs/platform/operator-patterns/controller-runtime.md
@@ -2,13 +2,21 @@
 
 **Category**: Platform Pattern  
 **Applies To**: All Operators  
-**Last Updated**: 2026-04-28  
+**Last Updated**: 2026-05-26 
+**Scope**: All form factors (see HCP note below)
 
 ## Overview
 
 The controller-runtime pattern implements the Kubernetes reconciliation loop: continuously compare desired state (spec) with current state (status) and take actions to converge.
 
 **Core Principle**: Watch → Reconcile → Update Status → Repeat
+
+**⚠️ Form Factor Note**: In **Hypershift/HCP**, operators may run in:
+- **Guest cluster**: Same as standalone (operator manages guest workloads)
+- **Management cluster**: Operator manages hosted control plane components
+- **Split across both**: Some controllers in management, some in guest (requires careful design)
+
+See [Hypershift Operator Placement](#hypershift-operator-placement) section below for guidance.
 
 ## Key Concepts
 
@@ -157,9 +165,59 @@ return ctrl.Result{}, nil
 ❌ **Event-driven**: Relying on event order (level-triggered, not edge-triggered)  
 ❌ **Side effects without idempotency**: Creating resources without checking existence
 
+## Hypershift Operator Placement
+
+In **Hypershift/HCP**, operators run in different locations depending on what they manage.
+
+### Decision Matrix
+
+| Operator Manages | Runs In | Example | Why |
+|------------------|---------|---------|-----|
+| **Control plane components** | Management cluster | kube-apiserver-operator, etcd-operator | Control plane pods run in management cluster |
+| **Guest workloads** | Guest cluster | openshift-monitoring (workload metrics) | Monitors workloads running in guest cluster |
+| **Platform infrastructure** | Management cluster | HyperShift Operator | Orchestrates HostedCluster lifecycle |
+| **Both control plane and guest** | Split deployment | cluster-network-operator | Control plane networking in mgmt, pod networking in guest |
+
+### Design Considerations
+
+1. **Where does the operator watch resources?**
+   - Management cluster: `HostedCluster`, `HostedControlPlane`, control plane pods
+   - Guest cluster: `ClusterOperator`, workload resources (Pods, Deployments)
+
+2. **Version skew tolerance**
+   - Management cluster operator may be newer than guest cluster
+   - Must tolerate N→N+1 version differences
+
+3. **RBAC and permissions**
+   - Management cluster: Needs RBAC for `HostedCluster`, infrastructure resources
+   - Guest cluster: Same RBAC as standalone operator
+
+4. **Cross-cluster communication**
+   - If operator in management needs to watch guest resources → requires KAS access
+   - If operator in guest needs to watch management resources → rarely needed, avoid
+
+### Testing HCP Operators
+
+```bash
+# Check where operator runs
+oc --context=management get pods -A | grep my-operator
+oc --context=guest get pods -A | grep my-operator
+
+# Check what operator watches
+oc --context=management logs -n my-namespace my-operator-pod | grep "Watching"
+
+# Verify RBAC in correct cluster
+oc --context=management get clusterrole my-operator-role
+```
+
+See [topology-considerations-guide.md](../../workflows/topology-considerations-guide.md) for comprehensive HCP guidance.
+
 ## References
 
 - **Upstream**: [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime)
 - **Book**: [Kubebuilder Book - Controllers](https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html)
 - **OpenShift**: [status-conditions.md](./status-conditions.md)
 - **Pattern**: Implements "Desired State" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)
+- **HCP Enhancements** (authoritative sources for HCP operator placement):
+  - [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) - CPO in management, CVO in guest
+  - [node-tuning.md](../../../enhancements/hypershift/node-tuning.md) - Example of split operator pattern

--- a/ai-docs/platform/operator-patterns/finalizers.md
+++ b/ai-docs/platform/operator-patterns/finalizers.md
@@ -1,0 +1,277 @@
+# Finalizers Pattern
+
+**Category**: Platform Pattern  
+**Applies To**: Operators managing external resources  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Finalizers enable cleanup of external resources before a Kubernetes object is deleted. They block deletion until the finalizer is removed, allowing controllers to perform cleanup logic.
+
+**Use Case**: Delete external resources (cloud VMs, load balancers) when Kubernetes object is deleted.
+
+## Key Concepts
+
+- **Finalizer**: String in `metadata.finalizers` that blocks deletion
+- **DeletionTimestamp**: Set when object is marked for deletion
+- **Cleanup Logic**: Controller removes external resources, then removes finalizer
+- **Blocking Deletion**: Object stays in "deleting" state until finalizers removed
+
+## Lifecycle
+
+```
+1. User creates object
+   → Controller adds finalizer
+
+2. User deletes object
+   → DeletionTimestamp set (object marked for deletion)
+   → Object still exists (blocked by finalizer)
+
+3. Controller sees DeletionTimestamp
+   → Cleanup external resources
+   → Remove finalizer
+
+4. No finalizers remain
+   → Kubernetes deletes object from etcd
+```
+
+## Implementation
+
+### Adding Finalizer
+
+```go
+import (
+    "sigs.k8s.io/controller-runtime/pkg/controllerutil"
+)
+
+const finalizerName = "myoperator.example.com/finalizer"
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    obj := &v1.MyResource{}
+    if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+        return ctrl.Result{}, client.IgnoreNotFound(err)
+    }
+    
+    // Add finalizer if not present
+    if obj.DeletionTimestamp.IsZero() {
+        if !controllerutil.ContainsFinalizer(obj, finalizerName) {
+            controllerutil.AddFinalizer(obj, finalizerName)
+            if err := r.Update(ctx, obj); err != nil {
+                return ctrl.Result{}, err
+            }
+        }
+    } else {
+        // Handle deletion
+        if controllerutil.ContainsFinalizer(obj, finalizerName) {
+            if err := r.cleanup(ctx, obj); err != nil {
+                return ctrl.Result{}, err
+            }
+            
+            controllerutil.RemoveFinalizer(obj, finalizerName)
+            if err := r.Update(ctx, obj); err != nil {
+                return ctrl.Result{}, err
+            }
+        }
+    }
+    
+    return ctrl.Result{}, nil
+}
+```
+
+### Cleanup Logic
+
+```go
+func (r *Reconciler) cleanup(ctx context.Context, obj *v1.MyResource) error {
+    // Delete external resources
+    if err := r.deleteCloudInstance(ctx, obj); err != nil {
+        return fmt.Errorf("failed to delete cloud instance: %w", err)
+    }
+    
+    if err := r.deleteLoadBalancer(ctx, obj); err != nil {
+        return fmt.Errorf("failed to delete load balancer: %w", err)
+    }
+    
+    log.Info("cleaned up external resources", "name", obj.Name)
+    return nil
+}
+```
+
+## Best Practices
+
+1. **Use Domain-Specific Finalizer Names**: Include domain to avoid conflicts
+   ```go
+   const finalizerName = "machine.openshift.io/finalizer"  // ✅ Good
+   const finalizerName = "finalizer"                        // ❌ Bad (generic)
+   ```
+
+2. **Idempotent Cleanup**: Handle cleanup being called multiple times
+   ```go
+   func (r *Reconciler) cleanup(ctx context.Context, obj *v1.MyResource) error {
+       // Check if resource exists before deleting
+       instance, err := r.cloudProvider.GetInstance(obj.Spec.InstanceID)
+       if err != nil {
+           if isNotFoundError(err) {
+               return nil  // Already deleted
+           }
+           return err
+       }
+       
+       return r.cloudProvider.DeleteInstance(instance.ID)
+   }
+   ```
+
+3. **Handle Errors Gracefully**: Don't remove finalizer if cleanup fails
+   ```go
+   if err := r.cleanup(ctx, obj); err != nil {
+       // Log error, requeue for retry
+       return ctrl.Result{}, err  // Don't remove finalizer
+   }
+   ```
+
+4. **Set Status During Cleanup**: Update status to show cleanup in progress
+   ```go
+   if !obj.DeletionTimestamp.IsZero() {
+       obj.Status.Phase = "Terminating"
+       r.Status().Update(ctx, obj)
+   }
+   ```
+
+5. **Timeout Cleanup**: Don't block forever on stuck cleanup
+   ```go
+   cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+   defer cancel()
+   
+   if err := r.cleanup(cleanupCtx, obj); err != nil {
+       return ctrl.Result{}, err
+   }
+   ```
+
+## Common Patterns
+
+### Machine Finalizer (Machine API)
+
+```yaml
+apiVersion: machine.openshift.io/v1beta1
+kind: Machine
+metadata:
+  name: my-machine
+  finalizers:
+  - machine.machine.openshift.io  # Blocks deletion until cloud VM deleted
+spec:
+  providerSpec:
+    value:
+      instanceType: m5.large
+```
+
+### Multiple Finalizers
+
+```go
+const (
+    finalizerVM        = "myoperator.example.com/vm"
+    finalizerStorage   = "myoperator.example.com/storage"
+)
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    obj := &v1.MyResource{}
+    r.Get(ctx, req.NamespacedName, obj)
+    
+    if obj.DeletionTimestamp.IsZero() {
+        // Add both finalizers
+        controllerutil.AddFinalizer(obj, finalizerVM)
+        controllerutil.AddFinalizer(obj, finalizerStorage)
+        r.Update(ctx, obj)
+    } else {
+        // Remove in order: storage first, then VM
+        if controllerutil.ContainsFinalizer(obj, finalizerStorage) {
+            r.cleanupStorage(ctx, obj)
+            controllerutil.RemoveFinalizer(obj, finalizerStorage)
+            r.Update(ctx, obj)
+        }
+        
+        if controllerutil.ContainsFinalizer(obj, finalizerVM) {
+            r.cleanupVM(ctx, obj)
+            controllerutil.RemoveFinalizer(obj, finalizerVM)
+            r.Update(ctx, obj)
+        }
+    }
+    
+    return ctrl.Result{}, nil
+}
+```
+
+## Debugging
+
+### View Finalizers
+
+```bash
+# Check finalizers on object
+oc get machine my-machine -o jsonpath='{.metadata.finalizers}'
+
+# View object stuck in deletion
+oc get machines | grep Terminating
+```
+
+### Remove Stuck Finalizer (Emergency)
+
+```bash
+# Only use if cleanup is stuck and manual intervention needed
+oc patch machine my-machine -p '{"metadata":{"finalizers":[]}}' --type=merge
+```
+
+**Warning**: This bypasses cleanup logic and may leak external resources.
+
+## Examples in Components
+
+| Component | Finalizer Use | Cleanup Action |
+|-----------|--------------|----------------|
+| machine-api-operator | `machine.machine.openshift.io` | Delete cloud VM |
+| cluster-network-operator | `network.operator.openshift.io/finalizer` | Remove network config |
+| cluster-autoscaler | `autoscaler.openshift.io/finalizer` | Delete autoscaler config |
+
+## Troubleshooting
+
+### Object Stuck in Terminating
+
+**Symptoms**: `oc get` shows object in "Terminating" state for >5 minutes
+
+**Causes**:
+1. Cleanup logic failing (check operator logs)
+2. External resource doesn't exist (idempotent cleanup not implemented)
+3. Controller not running (no reconciliation)
+
+**Debug**:
+```bash
+# Check controller logs
+oc logs -n my-operator deployment/my-operator
+
+# Check finalizers
+oc get myresource my-obj -o yaml | grep -A5 finalizers
+
+# View events
+oc describe myresource my-obj
+```
+
+### Finalizer Not Added
+
+**Symptoms**: Object deleted immediately without cleanup
+
+**Causes**:
+1. Finalizer not added during creation
+2. Race condition (object deleted before finalizer added)
+
+**Fix**: Add finalizer in admission webhook or immediately on creation
+
+## Antipatterns
+
+❌ **Removing finalizer before cleanup**: Leaks external resources  
+❌ **Generic finalizer names**: Conflicts with other operators  
+❌ **Not handling cleanup errors**: Object stuck forever  
+❌ **Synchronous long-running cleanup**: Blocks reconcile loop  
+❌ **No idempotent cleanup**: Fails if cleanup called twice
+
+## References
+
+- **Kubernetes**: [Finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/)
+- **controller-runtime**: [controllerutil](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controllerutil)
+- **OpenShift**: Machine API uses finalizers extensively
+- **Related**: [controller-runtime.md](./controller-runtime.md)

--- a/ai-docs/platform/operator-patterns/index.md
+++ b/ai-docs/platform/operator-patterns/index.md
@@ -1,0 +1,22 @@
+# Operator Patterns
+
+Standard patterns used across all OpenShift operators.
+
+## Core Patterns
+
+- [controller-runtime.md](controller-runtime.md) - Reconciliation loop pattern (watch → reconcile → update status)
+- [status-conditions.md](status-conditions.md) - Available/Progressing/Degraded health reporting
+- [webhooks.md](webhooks.md) - Validation, mutation, and conversion webhooks
+
+## Resource Management
+
+- [finalizers.md](finalizers.md) - Cleanup external resources before deletion
+- [rbac.md](rbac.md) - Service account and RBAC permissions
+
+## Operations
+
+- [must-gather.md](must-gather.md) - Debugging and diagnostics collection
+
+## Related
+
+- [OpenShift-Specific Patterns](../openshift-specifics/) - Upgrade strategies, CVO coordination

--- a/ai-docs/platform/operator-patterns/must-gather.md
+++ b/ai-docs/platform/operator-patterns/must-gather.md
@@ -1,0 +1,286 @@
+# Must-Gather Pattern
+
+**Category**: Platform Pattern  
+**Applies To**: All Operators  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+must-gather is OpenShift's debugging tool for collecting diagnostic data. Operators should provide must-gather scripts to aid in troubleshooting production issues.
+
+**Purpose**: Collect logs, resources, and diagnostics for support cases.
+
+## Key Concepts
+
+- **must-gather**: Command-line tool that runs scripts in a pod
+- **Gather Script**: Shell script that collects data
+- **Image**: Container image with gather scripts
+- **Output**: Tarball with collected data
+
+## must-gather Workflow
+
+```
+User runs:
+  oc adm must-gather --image=<operator-must-gather-image>
+
+↓
+
+1. Creates temporary namespace
+2. Runs gather pod with image
+3. Executes gather scripts in pod
+4. Copies data from pod to local machine
+5. Creates tarball (must-gather.local.XXX/)
+6. Deletes temporary namespace
+```
+
+## Implementation
+
+### Directory Structure
+
+```
+must-gather/
+├── Dockerfile
+├── collection-scripts/
+│   ├── gather                    # Main gather script
+│   ├── gather_clusteroperator   # Collect ClusterOperator
+│   ├── gather_pods              # Collect pod logs
+│   └── gather_custom_resources  # Collect CRs
+└── README.md
+```
+
+### Main Gather Script
+
+```bash
+#!/bin/bash
+# collection-scripts/gather
+
+BASE_COLLECTION_PATH="/must-gather"
+mkdir -p ${BASE_COLLECTION_PATH}
+
+# Collect namespace resources
+oc adm inspect --dest-dir=${BASE_COLLECTION_PATH} \
+  --all-namespaces \
+  namespace/my-operator-namespace
+
+# Collect custom resources
+oc adm inspect --dest-dir=${BASE_COLLECTION_PATH} \
+  --all-namespaces \
+  myresources.example.com
+
+# Collect ClusterOperator
+/usr/bin/gather_clusteroperator
+
+# Collect pod logs
+/usr/bin/gather_pods
+
+echo "Collection complete"
+exit 0
+```
+
+### Collect ClusterOperator
+
+```bash
+#!/bin/bash
+# collection-scripts/gather_clusteroperator
+
+BASE_COLLECTION_PATH="/must-gather"
+OPERATOR_NAME="my-operator"
+
+# Get ClusterOperator
+oc get clusteroperator ${OPERATOR_NAME} -o yaml \
+  > ${BASE_COLLECTION_PATH}/clusteroperator.yaml
+
+# Get status conditions
+oc get clusteroperator ${OPERATOR_NAME} \
+  -o jsonpath='{.status.conditions}' | jq . \
+  > ${BASE_COLLECTION_PATH}/conditions.json
+```
+
+### Collect Pod Logs
+
+```bash
+#!/bin/bash
+# collection-scripts/gather_pods
+
+BASE_COLLECTION_PATH="/must-gather"
+NAMESPACE="my-operator-namespace"
+
+mkdir -p ${BASE_COLLECTION_PATH}/pods
+
+# Get all pods
+oc get pods -n ${NAMESPACE} -o yaml \
+  > ${BASE_COLLECTION_PATH}/pods/pods.yaml
+
+# Collect logs from each pod
+for POD in $(oc get pods -n ${NAMESPACE} -o name); do
+  POD_NAME=$(basename ${POD})
+  
+  # Current logs
+  oc logs -n ${NAMESPACE} ${POD_NAME} --all-containers \
+    > ${BASE_COLLECTION_PATH}/pods/${POD_NAME}.log 2>&1
+  
+  # Previous logs (if pod restarted)
+  oc logs -n ${NAMESPACE} ${POD_NAME} --all-containers --previous \
+    > ${BASE_COLLECTION_PATH}/pods/${POD_NAME}-previous.log 2>&1
+done
+```
+
+### Dockerfile
+
+```dockerfile
+FROM registry.redhat.io/openshift4/ose-cli:latest
+
+# Copy gather scripts
+COPY collection-scripts/* /usr/bin/
+
+# Make executable
+RUN chmod +x /usr/bin/gather*
+
+# Set entrypoint
+ENTRYPOINT ["/usr/bin/gather"]
+```
+
+## What to Collect
+
+### Required
+
+| Resource | Why |
+|----------|-----|
+| **ClusterOperator** | Status conditions, versions |
+| **Operator pods** | Current and previous logs |
+| **Custom resources** | State of managed resources |
+| **Events** | Recent events in operator namespace |
+
+### Optional
+
+| Resource | When to Collect |
+|----------|----------------|
+| **Deployments/StatefulSets** | Operand state |
+| **ConfigMaps** | Configuration (redact secrets!) |
+| **Node resources** | For node-level operators |
+| **Metrics** | Performance issues |
+
+## Best Practices
+
+1. **Redact Sensitive Data**: Never collect secrets or credentials
+   ```bash
+   # ❌ Don't collect secrets
+   oc get secrets -n my-namespace -o yaml
+   
+   # ✅ Collect metadata only
+   oc get secrets -n my-namespace -o jsonpath='{.items[*].metadata.name}'
+   ```
+
+2. **Use `oc adm inspect`**: Purpose-built for gathering
+   ```bash
+   # Collect namespace resources
+   oc adm inspect --dest-dir=/must-gather namespace/my-namespace
+   
+   # Collect specific resources
+   oc adm inspect --dest-dir=/must-gather myresources.example.com
+   ```
+
+3. **Organize Output**: Use directories for readability
+   ```
+   must-gather/
+   ├── clusteroperator.yaml
+   ├── pods/
+   │   ├── operator-xyz.log
+   │   └── operator-xyz-previous.log
+   ├── custom-resources/
+   │   └── myresources.yaml
+   └── events.yaml
+   ```
+
+4. **Handle Errors Gracefully**: Don't fail entire gather on one error
+   ```bash
+   # Continue on error
+   oc logs pod/xyz > logs.txt 2>&1 || echo "Failed to get logs"
+   ```
+
+5. **Add Timestamps**: Help correlate issues
+   ```bash
+   echo "Collection started: $(date)" > /must-gather/metadata.txt
+   ```
+
+## Running must-gather
+
+```bash
+# Basic usage
+oc adm must-gather --image=quay.io/my-org/my-operator-must-gather:latest
+
+# Specify destination
+oc adm must-gather \
+  --image=quay.io/my-org/my-operator-must-gather:latest \
+  --dest-dir=/tmp/my-gather
+
+# Multiple images (collect from multiple operators)
+oc adm must-gather \
+  --image=quay.io/openshift/must-gather:latest \
+  --image=quay.io/my-org/my-operator-must-gather:latest
+```
+
+## Output Structure
+
+```
+must-gather.local.XXXXXXXXX/
+├── timestamp                           # Collection time
+├── version                            # OpenShift version
+├── my-operator-namespace/
+│   ├── core/
+│   │   ├── pods.yaml
+│   │   ├── services.yaml
+│   │   └── events.yaml
+│   ├── apps/
+│   │   └── deployments.yaml
+│   └── example.com/
+│       └── myresources.yaml
+├── clusteroperator.yaml
+└── pods/
+    ├── my-operator-xyz.log
+    └── my-operator-xyz-previous.log
+```
+
+## Testing must-gather
+
+```bash
+# Build image
+podman build -t my-must-gather:test must-gather/
+
+# Run locally
+oc adm must-gather --image=localhost/my-must-gather:test
+
+# Verify output
+ls -R must-gather.local.*/
+```
+
+## Examples in Components
+
+| Component | must-gather Repo | Key Collections |
+|-----------|------------------|----------------|
+| Machine API | [machine-api-must-gather](https://github.com/openshift/machine-api-operator/tree/master/must-gather) | Machines, MachineSets, cloud provider data |
+| Network | [cluster-network-operator-must-gather](https://github.com/openshift/cluster-network-operator/tree/master/must-gather) | Network configs, OVN logs |
+| Storage | [csi-driver-must-gather](https://github.com/openshift/csi-operator/tree/master/must-gather) | PVs, PVCs, CSI driver logs |
+
+## Integration with Support
+
+**Support cases**: Attach must-gather output to Jira/support cases
+
+**Automated analysis**: Support tools parse must-gather for known issues
+
+**Privacy**: Ensure no customer data or secrets in output
+
+## Antipatterns
+
+❌ **Collecting secrets**: Leaks credentials  
+❌ **No error handling**: Entire gather fails on one error  
+❌ **Huge output**: Collecting full etcd dump (too large)  
+❌ **No organization**: All files in one directory  
+❌ **Missing previous logs**: Only collecting current pod logs
+
+## References
+
+- **Command**: `oc adm must-gather --help`
+- **OpenShift**: [Gathering cluster data](https://docs.openshift.com/container-platform/latest/support/gathering-cluster-data.html)
+- **Example**: [openshift/must-gather](https://github.com/openshift/must-gather)
+- **Best Practices**: Use `oc adm inspect` for resource collection

--- a/ai-docs/platform/operator-patterns/rbac.md
+++ b/ai-docs/platform/operator-patterns/rbac.md
@@ -1,0 +1,309 @@
+# RBAC Patterns
+
+**Category**: Platform Pattern  
+**Applies To**: All Operators  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Role-Based Access Control (RBAC) restricts access to Kubernetes resources. Operators need appropriate permissions to manage resources, and should follow least-privilege principles.
+
+**Pattern**: ServiceAccount + Role/ClusterRole + RoleBinding/ClusterRoleBinding
+
+## Key Concepts
+
+- **ServiceAccount**: Identity for pods
+- **Role**: Namespaced permissions
+- **ClusterRole**: Cluster-wide permissions
+- **RoleBinding**: Grants Role to ServiceAccount (namespaced)
+- **ClusterRoleBinding**: Grants ClusterRole to ServiceAccount (cluster-wide)
+
+## RBAC Resources
+
+| Resource | Scope | Use Case |
+|----------|-------|----------|
+| **Role** | Namespace | Permissions for namespaced resources in one namespace |
+| **ClusterRole** | Cluster | Permissions for cluster-scoped or all-namespace resources |
+| **RoleBinding** | Namespace | Grant Role to users/groups/ServiceAccounts |
+| **ClusterRoleBinding** | Cluster | Grant ClusterRole to users/groups/ServiceAccounts |
+
+## Operator RBAC Pattern
+
+```yaml
+# ServiceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-operator
+  namespace: my-operator-namespace
+
+---
+# ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-operator
+rules:
+# Watch and manage custom resources
+- apiGroups: ["example.com"]
+  resources: ["myresources"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Update status subresource
+- apiGroups: ["example.com"]
+  resources: ["myresources/status"]
+  verbs: ["get", "update", "patch"]
+
+# Manage deployments (operands)
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Read configmaps
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+
+---
+# ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: my-operator
+subjects:
+- kind: ServiceAccount
+  name: my-operator
+  namespace: my-operator-namespace
+```
+
+## Best Practices
+
+1. **Least Privilege**: Grant only required permissions
+   ```yaml
+   # ✅ Good: Specific resources and verbs
+   - apiGroups: ["apps"]
+     resources: ["deployments"]
+     verbs: ["get", "list", "watch", "update"]
+   
+   # ❌ Bad: Wildcard permissions
+   - apiGroups: ["*"]
+     resources: ["*"]
+     verbs: ["*"]
+   ```
+
+2. **Separate Status Permissions**: Use status subresource
+   ```yaml
+   # Spec updates (user-facing)
+   - apiGroups: ["example.com"]
+     resources: ["myresources"]
+     verbs: ["update", "patch"]
+   
+   # Status updates (controller-only)
+   - apiGroups: ["example.com"]
+     resources: ["myresources/status"]
+     verbs: ["update", "patch"]
+   ```
+
+3. **Use ClusterRole for CRDs**: Even if namespaced, CRD management needs ClusterRole
+   ```yaml
+   - apiGroups: ["apiextensions.k8s.io"]
+     resources: ["customresourcedefinitions"]
+     verbs: ["get", "list", "watch"]  # Usually read-only
+   ```
+
+4. **Scope Appropriately**: Use Role for namespace-specific operators
+   ```yaml
+   # Namespace-scoped operator (single namespace)
+   kind: Role  # Not ClusterRole
+   
+   # Multi-namespace operator
+   kind: ClusterRole
+   ```
+
+## Common Permission Sets
+
+### CRD Management
+
+```yaml
+rules:
+# Watch CRD
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+
+# Manage custom resources
+- apiGroups: ["example.com"]
+  resources: ["myresources"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Update status
+- apiGroups: ["example.com"]
+  resources: ["myresources/status"]
+  verbs: ["get", "update", "patch"]
+```
+
+### Core Resources
+
+```yaml
+rules:
+# Pods
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+
+# Services
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# ConfigMaps (read-only)
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+
+# Secrets (read-only, specific names)
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["my-operator-tls"]
+  verbs: ["get"]
+```
+
+### Events
+
+```yaml
+rules:
+# Create events for debugging
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+```
+
+### Leader Election
+
+```yaml
+rules:
+# ConfigMap-based leader election
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["my-operator-leader"]
+  verbs: ["get", "update", "patch"]
+
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+
+# Lease-based leader election (preferred)
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "create", "update", "patch"]
+```
+
+## OpenShift-Specific RBAC
+
+### Security Context Constraints (SCCs)
+
+```yaml
+# ClusterRole to use specific SCC
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-operator-scc
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]  # Or custom SCC
+  verbs: ["use"]
+```
+
+### OpenShift Config Resources
+
+```yaml
+rules:
+# Read cluster config
+- apiGroups: ["config.openshift.io"]
+  resources: ["clusterversions", "infrastructures", "networks"]
+  verbs: ["get", "list", "watch"]
+
+# Update ClusterOperator status
+- apiGroups: ["config.openshift.io"]
+  resources: ["clusteroperators"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["config.openshift.io"]
+  resources: ["clusteroperators/status"]
+  verbs: ["update", "patch"]
+```
+
+## Kubebuilder Markers
+
+```go
+// Generate RBAC manifests using kubebuilder markers
+
+//+kubebuilder:rbac:groups=example.com,resources=myresources,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=example.com,resources=myresources/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+func (r *MyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    // Controller logic
+}
+```
+
+**Generate manifests**: `make manifests` creates RBAC YAML from markers.
+
+## Debugging RBAC
+
+### Check Permissions
+
+```bash
+# Can I create deployments?
+oc auth can-i create deployments --as=system:serviceaccount:my-ns:my-sa
+
+# What can this SA do?
+oc auth can-i --list --as=system:serviceaccount:my-ns:my-sa
+
+# View ClusterRole
+oc describe clusterrole my-operator
+
+# View bindings
+oc get clusterrolebinding | grep my-operator
+```
+
+### Common Errors
+
+**Error**: `forbidden: User "system:serviceaccount:my-ns:my-sa" cannot create resource`
+
+**Cause**: Missing RBAC permissions
+
+**Fix**:
+1. Check ClusterRole has required verbs
+2. Verify ClusterRoleBinding references correct SA
+3. Ensure SA exists
+
+## Examples in Components
+
+| Component | RBAC Pattern | Notes |
+|-----------|-------------|-------|
+| machine-api-operator | ClusterRole for Machines | Cluster-scoped resources |
+| kube-apiserver | ClusterRole + privileged SCC | Needs elevated permissions |
+| cluster-network-operator | ClusterRole for network config | Cluster-wide networking |
+
+## Antipatterns
+
+❌ **Wildcard permissions**: `apiGroups: ["*"]`, `resources: ["*"]`  
+❌ **Overly broad verbs**: `verbs: ["*"]` instead of specific verbs  
+❌ **No status subresource**: Mixing spec and status permissions  
+❌ **Hardcoded namespace**: ClusterRoleBinding with hardcoded namespace  
+❌ **Secrets without resourceNames**: Allowing read of all secrets
+
+## References
+
+- **Kubernetes**: [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- **OpenShift**: [RBAC Guide](https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html)
+- **SCCs**: [Security Context Constraints](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html)
+- **Kubebuilder**: [RBAC Markers](https://book.kubebuilder.io/reference/markers/rbac.html)

--- a/ai-docs/platform/operator-patterns/status-conditions.md
+++ b/ai-docs/platform/operator-patterns/status-conditions.md
@@ -1,0 +1,236 @@
+# Status Conditions Pattern
+
+**Category**: Platform Pattern  
+**Applies To**: All ClusterOperators, Recommended for all Operators  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+Status conditions provide standardized health reporting for OpenShift components. Every ClusterOperator must report Available, Progressing, and Degraded conditions.
+
+**Purpose**: Enable cluster-wide health monitoring and upgrade orchestration.
+
+## Key Concepts
+
+- **Condition**: Named state with Type, Status, Reason, Message
+- **Available**: Component is functioning and serving requests
+- **Progressing**: Component is reconciling changes (upgrade, config change)
+- **Degraded**: Component is running but functionality is impaired
+- **ObservedGeneration**: Detect spec changes requiring reconciliation
+
+## Condition Types
+
+### Required for ClusterOperators
+
+| Type | Meaning | True When | False When |
+|------|---------|-----------|------------|
+| **Available** | Component is functional | API serving, pods ready | Pods not ready, API down |
+| **Progressing** | Reconciliation in progress | Upgrade/rollout active | Desired state reached |
+| **Degraded** | Impaired but functional | Partial failure, degraded mode | Fully healthy |
+
+### Optional Conditions
+
+| Type | Use Case |
+|------|----------|
+| **Upgradeable** | Blocks cluster upgrade if False |
+| **Disabled** | Component intentionally disabled |
+
+## Implementation
+
+```go
+import (
+    configv1 "github.com/openshift/api/config/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Update condition helper
+func setCondition(conditions *[]configv1.ClusterOperatorStatusCondition, 
+                  condType configv1.ClusterStatusConditionType,
+                  status configv1.ConditionStatus,
+                  reason, message string) {
+    now := metav1.Now()
+    
+    for i := range *conditions {
+        if (*conditions)[i].Type == condType {
+            // Update existing
+            if (*conditions)[i].Status != status {
+                (*conditions)[i].LastTransitionTime = now
+            }
+            (*conditions)[i].Status = status
+            (*conditions)[i].Reason = reason
+            (*conditions)[i].Message = message
+            (*conditions)[i].LastHeartbeatTime = now
+            return
+        }
+    }
+    
+    // Add new condition
+    *conditions = append(*conditions, configv1.ClusterOperatorStatusCondition{
+        Type:               condType,
+        Status:             status,
+        Reason:             reason,
+        Message:            message,
+        LastTransitionTime: now,
+        LastHeartbeatTime:  now,
+    })
+}
+```
+
+## Best Practices
+
+1. **Always Set All Three**: Available, Progressing, Degraded must always be set
+   
+2. **Heartbeat Updates**: Update LastHeartbeatTime even if condition unchanged
+   - Shows controller is alive
+   - Stale heartbeat triggers alerts
+   
+3. **Reason vs Message**:
+   - **Reason**: Machine-readable CamelCase token (e.g., `PodsNotReady`)
+   - **Message**: Human-readable sentence (e.g., "2 of 3 pods are not ready")
+   
+4. **ObservedGeneration**: Track spec changes
+   ```go
+   status.ObservedGeneration = obj.Generation
+   ```
+
+5. **Transition Timing**: LastTransitionTime changes only when Status changes
+
+## Common Patterns
+
+### Healthy State
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+    message: "All pods are ready"
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+    message: "Desired state reached"
+  - type: Degraded
+    status: "False"
+    reason: AsExpected
+    message: "Component is healthy"
+```
+
+### Upgrade in Progress
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+    message: "3 of 3 pods ready"
+  - type: Progressing
+    status: "True"
+    reason: RollingOut
+    message: "Rolling out new version 4.16.0"
+  - type: Degraded
+    status: "False"
+    reason: AsExpected
+    message: "Rollout is healthy"
+```
+
+### Degraded State
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: DegradedMode
+    message: "Serving requests with reduced capacity"
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+    message: "No changes in progress"
+  - type: Degraded
+    status: "True"
+    reason: PodCrashLooping
+    message: "Pod api-server-xyz is crash looping, 1 of 3 replicas unavailable"
+```
+
+### Unavailable State
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "False"
+    reason: NoPodsReady
+    message: "0 of 3 pods are ready"
+  - type: Progressing
+    status: "True"
+    reason: Reconciling
+    message: "Attempting to start pods"
+  - type: Degraded
+    status: "True"
+    reason: AllPodsDown
+    message: "Component is not serving requests"
+```
+
+## Decision Logic
+
+```go
+func computeConditions(deployment *appsv1.Deployment) []configv1.ClusterOperatorStatusCondition {
+    available := false
+    progressing := false
+    degraded := false
+    
+    // Available: at least 1 pod ready
+    if deployment.Status.AvailableReplicas > 0 {
+        available = true
+    }
+    
+    // Progressing: rollout in progress
+    if deployment.Status.UpdatedReplicas < deployment.Status.Replicas {
+        progressing = true
+    }
+    
+    // Degraded: some pods not ready
+    if deployment.Status.AvailableReplicas < deployment.Status.Replicas {
+        degraded = true
+    }
+    
+    return []configv1.ClusterOperatorStatusCondition{
+        makeCondition(configv1.OperatorAvailable, available, ...),
+        makeCondition(configv1.OperatorProgressing, progressing, ...),
+        makeCondition(configv1.OperatorDegraded, degraded, ...),
+    }
+}
+```
+
+## Monitoring
+
+```promql
+# Alert on unavailable ClusterOperator
+cluster_operator_conditions{type="Available", status="False"}
+
+# Alert on prolonged Degraded
+cluster_operator_conditions{type="Degraded", status="True"}
+
+# Alert on stale heartbeat
+time() - cluster_operator_conditions_last_heartbeat > 300
+```
+
+## Examples in Components
+
+| Component | Typical States | Notes |
+|-----------|---------------|-------|
+| kube-apiserver | Available during rollout | Uses PodDisruptionBudget |
+| machine-config-operator | Progressing during node updates | Can take 30+ minutes |
+| cluster-network-operator | Degraded if SDN pods crash | Network still partially functional |
+
+## Antipatterns
+
+❌ **Skipping conditions**: All three (Available/Progressing/Degraded) must be set  
+❌ **Stale status**: Not updating heartbeat regularly  
+❌ **Unclear messages**: "Error occurred" (not useful) vs "Pod xyz crash looping: OOMKilled"  
+❌ **Wrong semantics**: Available=False during normal upgrade (should be True)
+
+## References
+
+- **API**: [github.com/openshift/api/config/v1](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go)
+- **Enhancement**: [cluster-operator-conditions](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md)
+- **Command**: `oc get clusteroperators` to view all conditions
+- **Pattern**: Implements "Observability by Default" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/platform/operator-patterns/webhooks.md
+++ b/ai-docs/platform/operator-patterns/webhooks.md
@@ -1,0 +1,260 @@
+# Webhooks Pattern
+
+**Category**: Platform Pattern  
+**Applies To**: Operators with API validation/mutation needs  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+Webhooks extend Kubernetes API server with custom validation, mutation, and conversion logic. They intercept API requests before objects are persisted to etcd.
+
+**Types**: ValidatingWebhook, MutatingWebhook, ConversionWebhook
+
+## Key Concepts
+
+- **Admission Webhook**: Intercepts CREATE/UPDATE/DELETE operations
+- **Validating**: Approve or reject requests (cannot modify)
+- **Mutating**: Modify requests before persistence (set defaults, inject sidecars)
+- **Conversion**: Convert between API versions (v1alpha1 ↔ v1beta1)
+- **Fail Policy**: FailClosed (reject on error) vs FailOpen (allow on error)
+
+## Webhook Types
+
+| Type | Purpose | Can Modify | Use Cases |
+|------|---------|------------|-----------|
+| **Validating** | Enforce invariants | No | Reject invalid configs |
+| **Mutating** | Set defaults, inject | Yes | Default values, sidecar injection |
+| **Conversion** | API version migration | Yes | v1alpha1 ↔ v1 |
+
+## Implementation
+
+### Validating Webhook
+
+```go
+import (
+    "k8s.io/api/admission/v1"
+    "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type MyValidator struct {
+    decoder *admission.Decoder
+}
+
+func (v *MyValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+    obj := &MyResource{}
+    if err := v.decoder.Decode(req, obj); err != nil {
+        return admission.Errored(http.StatusBadRequest, err)
+    }
+    
+    // Validate
+    if obj.Spec.Replicas > 10 {
+        return admission.Denied("replicas cannot exceed 10")
+    }
+    
+    if obj.Spec.Image == "" {
+        return admission.Denied("image is required")
+    }
+    
+    return admission.Allowed("")
+}
+```
+
+### Mutating Webhook
+
+```go
+func (m *MyMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+    obj := &MyResource{}
+    if err := m.decoder.Decode(req, obj); err != nil {
+        return admission.Errored(http.StatusBadRequest, err)
+    }
+    
+    // Set defaults
+    if obj.Spec.Replicas == 0 {
+        obj.Spec.Replicas = 3
+    }
+    
+    if obj.Spec.Strategy == "" {
+        obj.Spec.Strategy = "RollingUpdate"
+    }
+    
+    // Return patched object
+    return admission.Patched("defaults applied", obj)
+}
+```
+
+### Conversion Webhook
+
+```go
+func (c *MyConverter) ConvertTo(dst conversion.Hub) error {
+    // Convert from this version to hub version
+    dstObj := dst.(*v1.MyResource)
+    dstObj.Spec.NewField = c.Spec.OldField
+    return nil
+}
+
+func (c *MyConverter) ConvertFrom(src conversion.Hub) error {
+    // Convert from hub version to this version
+    srcObj := src.(*v1.MyResource)
+    c.Spec.OldField = srcObj.Spec.NewField
+    return nil
+}
+```
+
+## Best Practices
+
+1. **Fail Policies**:
+   - **FailClosed** (default): Reject requests if webhook unavailable (safer)
+   - **FailOpen**: Allow requests if webhook unavailable (for non-critical validation)
+
+2. **Idempotent Mutations**: Applying mutation multiple times = same result
+   ```go
+   // ✅ Idempotent
+   if obj.Labels == nil {
+       obj.Labels = make(map[string]string)
+   }
+   obj.Labels["injected"] = "true"
+   
+   // ❌ Not idempotent
+   obj.Spec.Env = append(obj.Spec.Env, newVar)
+   ```
+
+3. **Validation Order**: Mutating webhooks run before validating webhooks
+
+4. **Namespace Selectors**: Limit webhook scope to avoid performance issues
+   ```yaml
+   namespaceSelector:
+     matchExpressions:
+     - key: admission.openshift.io/ignore
+       operator: DoesNotExist
+   ```
+
+5. **Timeout**: Default 10s (can configure 1-30s)
+
+## Common Patterns
+
+### WebhookConfiguration
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: my-validator
+webhooks:
+- name: validate.myresource.example.com
+  clientConfig:
+    service:
+      name: my-webhook-service
+      namespace: my-operator
+      path: /validate
+    caBundle: <base64-ca-cert>
+  rules:
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: ["example.com"]
+    apiVersions: ["v1"]
+    resources: ["myresources"]
+  failurePolicy: Fail
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+  timeoutSeconds: 10
+```
+
+### Certificate Management
+
+```go
+// Use cert-manager or controller-runtime's cert provisioning
+import (
+    "sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func main() {
+    mgr, _ := ctrl.NewManager(cfg, ctrl.Options{
+        CertDir: "/tmp/k8s-webhook-server/serving-certs",
+    })
+    
+    // Certs automatically provisioned
+    mgr.GetWebhookServer().Register("/validate", &webhook.Admission{
+        Handler: &MyValidator{},
+    })
+}
+```
+
+### Validation Example: Cross-Field
+
+```go
+func validateCrossField(obj *MyResource) error {
+    // Ensure replicas matches tier
+    if obj.Spec.Tier == "production" && obj.Spec.Replicas < 3 {
+        return fmt.Errorf("production tier requires at least 3 replicas")
+    }
+    
+    // Ensure resources set for production
+    if obj.Spec.Tier == "production" && obj.Spec.Resources == nil {
+        return fmt.Errorf("production tier requires resource limits")
+    }
+    
+    return nil
+}
+```
+
+## Testing Webhooks
+
+```go
+func TestWebhook(t *testing.T) {
+    decoder, _ := admission.NewDecoder(scheme)
+    validator := &MyValidator{decoder: decoder}
+    
+    obj := &MyResource{
+        Spec: MyResourceSpec{
+            Replicas: 15, // Invalid
+        },
+    }
+    
+    req := admission.Request{
+        AdmissionRequest: v1.AdmissionRequest{
+            Object: runtime.RawExtension{Object: obj},
+        },
+    }
+    
+    resp := validator.Handle(context.TODO(), req)
+    assert.False(t, resp.Allowed)
+    assert.Contains(t, resp.Result.Message, "cannot exceed 10")
+}
+```
+
+## Examples in Components
+
+| Component | Webhook Type | Purpose |
+|-----------|--------------|---------|
+| machine-api-operator | Validating | Validate Machine/MachineSet specs |
+| kube-apiserver | Mutating | Inject service account tokens |
+| cluster-network-operator | Validating | Prevent invalid network config changes |
+
+## Performance Considerations
+
+- **Timeout**: Keep webhook logic fast (<1s ideal, 10s max)
+- **Namespace Filtering**: Use selectors to reduce webhook invocations
+- **Caching**: Cache expensive lookups (don't query API in every request)
+- **Monitoring**: Track webhook latency and failure rates
+
+```promql
+# Webhook latency
+histogram_quantile(0.99, rate(admission_webhook_request_duration_seconds_bucket[5m]))
+
+# Webhook rejections
+rate(admission_webhook_rejections_total[5m])
+```
+
+## Antipatterns
+
+❌ **Slow webhooks**: Blocking API server for >1s  
+❌ **External dependencies**: Webhook depends on external service (network partition = cluster unavailable)  
+❌ **FailOpen for critical validation**: Allows invalid configs during webhook downtime  
+❌ **No namespace filtering**: Webhook called for every pod/deployment in cluster  
+❌ **Non-idempotent mutations**: Applying mutation twice gives different results
+
+## References
+
+- **Upstream**: [Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)
+- **controller-runtime**: [Webhook Guide](https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation.html)
+- **OpenShift**: [Admission Plugins](https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html)
+- **Pattern**: Implements "API-First Design" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/platform/operator-patterns/webhooks.md
+++ b/ai-docs/platform/operator-patterns/webhooks.md
@@ -2,13 +2,16 @@
 
 **Category**: Platform Pattern  
 **Applies To**: Operators with API validation/mutation needs  
-**Last Updated**: 2026-04-28  
+**Last Updated**: 2026-05-26 
+**Scope**: All form factors with networking considerations (see below)
 
 ## Overview
 
 Webhooks extend Kubernetes API server with custom validation, mutation, and conversion logic. They intercept API requests before objects are persisted to etcd.
 
 **Types**: ValidatingWebhook, MutatingWebhook, ConversionWebhook
+
+**⚠️ Form Factor Note**: In **Hypershift/HCP**, the documented pattern is deploying webhooks as sidecars to kube-apiserver (in the management cluster). See [azure-workload-identity-webhook.md](../../../enhancements/hypershift/azure-workload-identity-webhook.md) for the authoritative HCP webhook pattern.
 
 ## Key Concepts
 
@@ -258,3 +261,5 @@ rate(admission_webhook_rejections_total[5m])
 - **controller-runtime**: [Webhook Guide](https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation.html)
 - **OpenShift**: [Admission Plugins](https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html)
 - **Pattern**: Implements "API-First Design" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)
+- **HCP Enhancements** (authoritative webhook pattern for HCP):
+  - [azure-workload-identity-webhook.md](../../../enhancements/hypershift/azure-workload-identity-webhook.md) - KAS sidecar webhook pattern in HyperShift

--- a/ai-docs/practices/development/api-evolution.md
+++ b/ai-docs/practices/development/api-evolution.md
@@ -1,0 +1,273 @@
+# API Evolution
+
+**Category**: Engineering Practice  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Evolving APIs requires backward compatibility. OpenShift follows Kubernetes API conventions for stability and versioning.
+
+**Key Principle**: Never break existing clients.
+
+## API Stability Levels
+
+| Level | Meaning | Breaking Changes Allowed | Removal Allowed |
+|-------|---------|-------------------------|-----------------|
+| **v1** | Stable | No | No (deprecated only) |
+| **v1beta1** | Pre-release | Minimal | After deprecation period |
+| **v1alpha1** | Experimental | Yes | Yes |
+
+## Compatibility Rules
+
+### Safe Changes ✅
+
+| Change | Example | Why Safe |
+|--------|---------|----------|
+| Add optional field | `newField *string` | Old clients ignore unknown fields |
+| Add new API version | `v1beta1 → v1` | Conversion preserves old version |
+| Add values to enum | `enum: [A, B, C]` | Old clients handle unknown values |
+| Deprecate field | `// Deprecated: use newField` | Field still works |
+
+### Breaking Changes ❌
+
+| Change | Example | Why Breaking |
+|--------|---------|--------------|
+| Remove field | Delete `oldField` | Old clients fail validation |
+| Rename field | `replicas → count` | Old clients send wrong field name |
+| Change field type | `string → int` | Old clients send wrong type |
+| Make optional field required | `*string → string` | Old resources lack required field |
+| Remove enum value | `enum: [A, B]` (was `[A, B, C]`) | Old resources have invalid value |
+
+## Versioning Strategy
+
+### Adding New API Version
+
+```go
+// v1alpha1 (initial)
+type MyResourceSpec struct {
+    Replicas int    `json:"replicas"`
+    Image    string `json:"image"`
+}
+
+// v1beta1 (add features)
+type MyResourceSpec struct {
+    Replicas int    `json:"replicas"`
+    Image    string `json:"image"`
+    Strategy string `json:"strategy,omitempty"` // New optional field
+}
+
+// v1 (stable)
+type MyResourceSpec struct {
+    Replicas int    `json:"replicas"`
+    Image    string `json:"image"`
+    Strategy string `json:"strategy,omitempty"`
+}
+```
+
+### Deprecating Fields
+
+```go
+type MyResourceSpec struct {
+    // Deprecated: Use Strategy instead
+    // +optional
+    OldStrategy string `json:"oldStrategy,omitempty"`
+    
+    Strategy string `json:"strategy,omitempty"`
+}
+
+func (r *Reconciler) reconcile(obj *MyResource) {
+    // Handle both old and new fields
+    strategy := obj.Spec.Strategy
+    if strategy == "" && obj.Spec.OldStrategy != "" {
+        strategy = obj.Spec.OldStrategy
+    }
+}
+```
+
+### Deprecation Timeline
+
+```
+Version N:   Field announced as deprecated (still works)
+Version N+1: Field still works, warnings in logs
+Version N+2: Field removed (only if v1alpha1/v1beta1)
+```
+
+**Stable APIs (v1)**: Cannot remove deprecated fields (mark deprecated forever)
+
+## Conversion Webhooks
+
+```go
+// Hub version (v1)
+type MyResource struct {
+    Spec MyResourceSpec `json:"spec"`
+}
+
+// Spoke version (v1beta1)
+func (src *MyResource) ConvertTo(dstRaw conversion.Hub) error {
+    dst := dstRaw.(*v1.MyResource)
+    
+    // Convert fields
+    dst.Spec.Replicas = src.Spec.Replicas
+    dst.Spec.NewField = convertOldToNew(src.Spec.OldField)
+    
+    return nil
+}
+
+func (dst *MyResource) ConvertFrom(srcRaw conversion.Hub) error {
+    src := srcRaw.(*v1.MyResource)
+    
+    // Reverse conversion
+    dst.Spec.Replicas = src.Spec.Replicas
+    dst.Spec.OldField = convertNewToOld(src.Spec.NewField)
+    
+    return nil
+}
+```
+
+## Default Values
+
+```yaml
+# CRD schema with defaults
+schema:
+  openAPIV3Schema:
+    properties:
+      spec:
+        properties:
+          replicas:
+            type: integer
+            default: 3  # Applied if not specified
+          strategy:
+            type: string
+            default: RollingUpdate
+```
+
+**Alternative**: Mutating webhook sets defaults
+
+## Validation
+
+```yaml
+# CRD validation
+schema:
+  openAPIV3Schema:
+    properties:
+      spec:
+        required: ["image"]  # Required field
+        properties:
+          replicas:
+            type: integer
+            minimum: 1
+            maximum: 100
+          tier:
+            type: string
+            enum: ["dev", "staging", "prod"]
+```
+
+## Migration Strategies
+
+### Adding Required Field (Without Breaking)
+
+```go
+// Step 1: Add optional field (version N)
+type MyResourceSpec struct {
+    Image string  `json:"image"`
+    Tier  *string `json:"tier,omitempty"` // Optional
+}
+
+// Step 2: Set default via webhook (version N)
+func (m *Mutator) Default(obj *MyResource) {
+    if obj.Spec.Tier == nil {
+        tier := "dev"
+        obj.Spec.Tier = &tier
+    }
+}
+
+// Step 3: Make required after all resources migrated (version N+2)
+type MyResourceSpec struct {
+    Image string `json:"image"`
+    Tier  string `json:"tier"` // Now required
+}
+```
+
+### Renaming Field
+
+```go
+// Step 1: Add new field, deprecate old (version N)
+type MyResourceSpec struct {
+    // Deprecated: Use Count instead
+    Replicas *int `json:"replicas,omitempty"`
+    Count    *int `json:"count,omitempty"`
+}
+
+// Step 2: Handle both in controller
+func (r *Reconciler) getCount(obj *MyResource) int {
+    if obj.Spec.Count != nil {
+        return *obj.Spec.Count
+    }
+    if obj.Spec.Replicas != nil {
+        return *obj.Spec.Replicas
+    }
+    return 3 // default
+}
+
+// Step 3: Remove old field (version N+2, only if not v1)
+```
+
+## Storage Version
+
+```yaml
+versions:
+- name: v1
+  served: true
+  storage: true  # Stored in etcd as v1
+  
+- name: v1beta1
+  served: true
+  storage: false  # Converted to v1 before storing
+```
+
+**Migration**: `oc adm migrate storage` to rewrite old versions
+
+## Testing API Changes
+
+```go
+func TestBackwardCompatibility(t *testing.T) {
+    // Old object (v1beta1)
+    old := &v1beta1.MyResource{
+        Spec: v1beta1.MyResourceSpec{
+            OldField: "value",
+        },
+    }
+    
+    // Convert to new version (v1)
+    new := &v1.MyResource{}
+    old.ConvertTo(new)
+    
+    // Verify conversion preserves data
+    assert.Equal(t, "value", new.Spec.NewField)
+    
+    // Convert back
+    roundtrip := &v1beta1.MyResource{}
+    roundtrip.ConvertFrom(new)
+    
+    // Verify roundtrip preserves data
+    assert.Equal(t, old.Spec.OldField, roundtrip.Spec.OldField)
+}
+```
+
+## Decision Table: Can I Make This Change?
+
+| Current API | Change | Allowed | Alternative |
+|-------------|--------|---------|-------------|
+| v1 | Remove field | ❌ | Deprecate only |
+| v1 | Rename field | ❌ | Add new, keep old deprecated |
+| v1 | Add optional field | ✅ | Safe |
+| v1 | Add required field | ❌ | Add optional + default |
+| v1beta1 | Remove field | ✅ (after deprecation) | Deprecate in N, remove in N+1 |
+| v1beta1 | Change type | ✅ (with conversion) | Conversion webhook |
+| v1alpha1 | Any change | ✅ | No guarantees |
+
+## References
+
+- **Kubernetes**: [API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
+- **Dev Guide**: [api-conventions.md](../../../dev-guide/api-conventions.md)
+- **OpenShift**: [API Review Process](https://github.com/openshift/api/blob/master/REVIEW.md)

--- a/ai-docs/practices/development/api-evolution.md
+++ b/ai-docs/practices/development/api-evolution.md
@@ -38,6 +38,48 @@ Evolving APIs requires backward compatibility. OpenShift follows Kubernetes API 
 | Make optional field required | `*string → string` | Old resources lack required field |
 | Remove enum value | `enum: [A, B]` (was `[A, B, C]`) | Old resources have invalid value |
 
+## Graduation Path Policy
+
+OpenShift generally follows the **alpha → beta → GA** progression, but this is **not always required**.
+
+### When You Can Skip Beta/TechPreview
+
+You may go **alpha → GA directly** when:
+- ✅ API is stable and well-understood
+- ✅ Implementation is production-quality from the start
+- ✅ No expectation of API changes before GA
+- ✅ Sufficient confidence to commit to long-term support
+
+**BUT** you must still meet GA quality requirements (see below).
+
+### When Beta/TechPreview Is Required
+
+Use **TechPreview** stage when:
+- ⚠️ API design needs real-world validation
+- ⚠️ Implementation quality unknown (scalability, stability)
+- ⚠️ Want flexibility to change API without migration path
+- ⚠️ Feature requires special enablement (feature gate)
+
+### Testing Requirements for GA (Cannot Be Skipped)
+
+**Whether you go alpha → GA directly or alpha → beta → GA, GA requires:**
+
+| Requirement | Why |
+|-------------|-----|
+| **Sufficient test coverage** | Unit, integration, e2e tests |
+| **Upgrade/downgrade testing** | N→N+1 and rollback scenarios |
+| **Scale testing** | Load testing, resource usage validation |
+| **End-to-end tests** | Required for non-optional features |
+| **SLI/SLO definition** | Service level indicators and objectives |
+| **User documentation** | openshift-docs PRs |
+| **Sufficient feedback time** | Real-world usage validation |
+
+**Skipping TechPreview does NOT skip these requirements** - you still need production-quality testing.
+
+**Key Rule**: If unsure about API or implementation, use TechPreview. Going directly to GA means **no breaking changes ever** AND **full production quality from day one**.
+
+See [supportability.md](../../../guidelines/supportability.md) for official Tech Preview policy and [enhancement_template.md](../../../guidelines/enhancement_template.md) for graduation criteria details.
+
 ## Versioning Strategy
 
 ### Adding New API Version
@@ -49,14 +91,14 @@ type MyResourceSpec struct {
     Image    string `json:"image"`
 }
 
-// v1beta1 (add features)
+// v1beta1 (add features) - OPTIONAL stage
 type MyResourceSpec struct {
     Replicas int    `json:"replicas"`
     Image    string `json:"image"`
     Strategy string `json:"strategy,omitempty"` // New optional field
 }
 
-// v1 (stable)
+// v1 (stable) - can skip v1beta1 if confident
 type MyResourceSpec struct {
     Replicas int    `json:"replicas"`
     Image    string `json:"image"`
@@ -271,3 +313,5 @@ func TestBackwardCompatibility(t *testing.T) {
 - **Kubernetes**: [API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
 - **Dev Guide**: [api-conventions.md](../../../dev-guide/api-conventions.md)
 - **OpenShift**: [API Review Process](https://github.com/openshift/api/blob/master/REVIEW.md)
+- **Supportability**: [supportability.md](../../../guidelines/supportability.md) - Tech Preview vs GA policy
+- **Graduation Criteria**: [enhancement_template.md](../../../guidelines/enhancement_template.md) - Testing requirements for GA

--- a/ai-docs/practices/development/index.md
+++ b/ai-docs/practices/development/index.md
@@ -1,0 +1,20 @@
+# Development Practices
+
+Software development practices and conventions.
+
+## Guides
+
+- [api-evolution.md](api-evolution.md) - API versioning, compatibility, and migration strategies
+
+## Dev Guide References
+
+For authoritative development conventions, see:
+- [../../dev-guide/api-conventions.md](../../../dev-guide/api-conventions.md) - API design conventions
+- [../../dev-guide/breaking-changes.md](../../../dev-guide/breaking-changes.md) - Breaking change policy
+- [../../dev-guide/operators.md](../../../dev-guide/operators.md) - Operator development guide
+- [../../dev-guide/feature-zero-to-hero.md](../../../dev-guide/feature-zero-to-hero.md) - Feature development workflow
+
+## Related
+
+- [Platform Patterns](../../platform/operator-patterns/) - Operator implementation patterns
+- [Domain Concepts](../../domain/) - Core API documentation

--- a/ai-docs/practices/development/index.md
+++ b/ai-docs/practices/development/index.md
@@ -13,6 +13,10 @@ For authoritative development conventions, see:
 - [../../dev-guide/breaking-changes.md](../../../dev-guide/breaking-changes.md) - Breaking change policy
 - [../../dev-guide/operators.md](../../../dev-guide/operators.md) - Operator development guide
 - [../../dev-guide/feature-zero-to-hero.md](../../../dev-guide/feature-zero-to-hero.md) - Feature development workflow
+- [../../guidelines/commit_and_pr_text.md](../../../guidelines/commit_and_pr_text.md) - PR title and commit message conventions
+- [../../dev-guide/new-components.md](../../../dev-guide/new-components.md) - Policy for adding components to payload vs OLM
+- [../../dev-guide/host-port-registry.md](../../../dev-guide/host-port-registry.md) - Authoritative host port allocation registry (9000-9999)
+- [../../dev-guide/release-blocker-definition.md](../../../dev-guide/release-blocker-definition.md) - When bugs block releases
 
 ## Related
 

--- a/ai-docs/practices/index.md
+++ b/ai-docs/practices/index.md
@@ -1,0 +1,23 @@
+# Engineering Practices
+
+Cross-cutting engineering practices for OpenShift development.
+
+## Practice Areas
+
+- [testing/](testing/) - Testing pyramid, test conventions
+- [development/](development/) - API evolution, compatibility
+- [security/](security/) - RBAC, threat modeling, secret handling
+- [reliability/](reliability/) - SLI/SLO/SLA, degraded mode, high availability
+
+## Dev Guide References
+
+Most authoritative guidance lives in:
+- [../../dev-guide/](../../dev-guide/) - Development conventions
+- [../../guidelines/](../../guidelines/) - Enhancement process
+
+These practice docs provide AI-optimized structure (tables, checklists) and fill gaps.
+
+## Related
+
+- **Platform Patterns**: [../platform/](../platform/) - Operator implementation patterns
+- **Workflows**: [../workflows/](../workflows/) - Process guides

--- a/ai-docs/practices/reliability/index.md
+++ b/ai-docs/practices/reliability/index.md
@@ -1,0 +1,39 @@
+# Reliability Practices
+
+Reliability patterns and SLI/SLO/SLA definitions for OpenShift.
+
+## Guidance
+
+Reliability practices are primarily documented in:
+- [../../dev-guide/](../../../dev-guide/) - Component readiness, release blockers
+- [Status Conditions Pattern](../../platform/operator-patterns/status-conditions.md)
+
+## SLI/SLO/SLA
+
+| Term | Definition | Example |
+|------|------------|---------|
+| **SLI** | Service Level Indicator (metric) | API server 99th percentile latency |
+| **SLO** | Service Level Objective (target) | p99 latency < 1s |
+| **SLA** | Service Level Agreement (contract) | 99.95% uptime guarantee |
+
+## Degraded Mode Patterns
+
+| Pattern | Use Case | Example |
+|---------|----------|---------|
+| **Partial Availability** | Some replicas down | 2/3 pods ready → Available=True, Degraded=True |
+| **Reduced Capacity** | Performance degraded | Serving requests but slower |
+| **Read-Only Mode** | Write path broken | API reads work, writes fail |
+
+## High Availability
+
+| Pattern | When to Use | Reference |
+|---------|-------------|-----------|
+| **PodDisruptionBudget** | Prevent all replicas down | [PDB Docs](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
+| **Multiple Replicas** | Redundancy | 3+ replicas for HA |
+| **Leader Election** | Single writer | [controller-runtime leader election](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/leaderelection) |
+
+## Related
+
+- **Dev Guide**: [../../dev-guide/component-readiness.md](../../../dev-guide/component-readiness.md)
+- **Status Conditions**: [../../platform/operator-patterns/status-conditions.md](../../platform/operator-patterns/status-conditions.md)
+- **Upgrade Strategies**: [../../platform/openshift-specifics/upgrade-strategies.md](../../platform/openshift-specifics/upgrade-strategies.md)

--- a/ai-docs/practices/security/index.md
+++ b/ai-docs/practices/security/index.md
@@ -1,0 +1,34 @@
+# Security Practices
+
+Security patterns and threat modeling for OpenShift components.
+
+## Guidance
+
+Security practices are primarily documented in:
+- [../../dev-guide/](../../../dev-guide/) - Security conventions
+- [OpenShift Security Guide](https://docs.openshift.com/container-platform/latest/security/index.html)
+
+## Key Security Patterns
+
+| Pattern | When to Use | Reference |
+|---------|-------------|-----------|
+| **RBAC** | API access control | [RBAC Docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) |
+| **SCCs** | Pod security | [SCC Guide](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html) |
+| **Secret Handling** | Credentials, tokens | Never log/expose secrets |
+| **Network Policies** | Network segmentation | [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) |
+
+## Threat Modeling (STRIDE)
+
+| Threat | Mitigation |
+|--------|------------|
+| **Spoofing** | Use service accounts, RBAC |
+| **Tampering** | Immutable infrastructure, admission controllers |
+| **Repudiation** | Audit logs, structured logging |
+| **Information Disclosure** | Secret encryption, RBAC |
+| **Denial of Service** | Resource limits, rate limiting |
+| **Elevation of Privilege** | RBAC, SCCs, least privilege |
+
+## Related
+
+- **Dev Guide**: [../../dev-guide/](../../../dev-guide/)
+- **Platform Patterns**: [../../platform/](../../platform/)

--- a/ai-docs/practices/testing/index.md
+++ b/ai-docs/practices/testing/index.md
@@ -1,0 +1,18 @@
+# Testing Practices
+
+Testing strategies and conventions for OpenShift components.
+
+## Guides
+
+- [pyramid.md](pyramid.md) - Testing pyramid (60% unit, 30% integration, 10% e2e)
+
+## Dev Guide References
+
+For authoritative testing conventions, see:
+- [../../dev-guide/test-conventions.md](../../../dev-guide/test-conventions.md) - Official test conventions
+- [../../dev-guide/ci/](../../../dev-guide/ci/) - CI configuration and integration
+
+## Related
+
+- [E2E Framework](https://github.com/openshift/origin/tree/master/test/extended)
+- [CI Documentation](https://docs.ci.openshift.org/)

--- a/ai-docs/practices/testing/pyramid.md
+++ b/ai-docs/practices/testing/pyramid.md
@@ -1,0 +1,209 @@
+# Testing Pyramid
+
+**Category**: Engineering Practice  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+OpenShift follows the testing pyramid: many unit tests, fewer integration tests, minimal e2e tests.
+
+**Ratio**: 60% unit, 30% integration, 10% e2e
+
+## Test Levels
+
+| Level | % of Tests | Speed | Scope | When to Use |
+|-------|-----------|-------|-------|-------------|
+| **Unit** | 60% | <100ms | Single function/method | Logic, edge cases, error handling |
+| **Integration** | 30% | <5s | Multiple components | API contracts, DB interactions |
+| **E2E** | 10% | 1-30min | Full system | Critical user flows, upgrade paths |
+
+## Unit Tests
+
+**Characteristics**:
+- Fast (<100ms per test)
+- No external dependencies (mock DB, API calls)
+- Test single functions/methods
+- High coverage (>80% for new code)
+
+```go
+// Example: Unit test with mocking
+func TestReconcileDeployment(t *testing.T) {
+    client := fake.NewClientBuilder().WithObjects(
+        &appsv1.Deployment{...},
+    ).Build()
+    
+    r := &Reconciler{client: client}
+    
+    result, err := r.reconcileDeployment(context.TODO(), req)
+    
+    assert.NoError(t, err)
+    assert.False(t, result.Requeue)
+}
+```
+
+**Best practices**:
+- ✅ Mock external dependencies
+- ✅ Test error paths
+- ✅ Test edge cases (nil, empty, max values)
+- ❌ Don't test framework code (controller-runtime handles watches)
+
+## Integration Tests
+
+**Characteristics**:
+- Moderate speed (<5s per test)
+- Real components (etcd via envtest)
+- Test API contracts and multi-component interactions
+- Run in CI on every PR
+
+```go
+// Example: Integration test with envtest
+func TestControllerIntegration(t *testing.T) {
+    testEnv := &envtest.Environment{
+        CRDDirectoryPaths: []string{"config/crd/bases"},
+    }
+    
+    cfg, _ := testEnv.Start()
+    defer testEnv.Stop()
+    
+    k8sClient, _ := client.New(cfg, client.Options{})
+    
+    // Create resource
+    obj := &v1.MyResource{...}
+    k8sClient.Create(ctx, obj)
+    
+    // Wait for reconciliation
+    Eventually(func() bool {
+        k8sClient.Get(ctx, key, obj)
+        return obj.Status.Ready
+    }, timeout, interval).Should(BeTrue())
+}
+```
+
+**Best practices**:
+- ✅ Use envtest for realistic API server
+- ✅ Test CRD validation, webhooks
+- ✅ Test controller watches and reconciliation
+- ❌ Don't test full cluster setup (use e2e instead)
+
+## E2E Tests
+
+**Characteristics**:
+- Slow (1-30 minutes)
+- Real cluster (OpenShift CI)
+- Test critical user flows
+- Run on merge and nightly
+
+```go
+// Example: E2E test
+func TestUpgrade(t *testing.T) {
+    // Install operator
+    installOperator(t)
+    
+    // Deploy workload
+    deployApp(t)
+    
+    // Trigger upgrade
+    upgradeCluster(t, "4.16.0", "4.16.1")
+    
+    // Verify workload still running
+    assertAppHealthy(t)
+}
+```
+
+**Best practices**:
+- ✅ Test critical paths only (upgrade, install, day-2 ops)
+- ✅ Clean up resources (don't leak)
+- ✅ Use retries and timeouts
+- ❌ Don't test every feature (use integration tests)
+
+## When to Use Each Level
+
+| Scenario | Test Level | Rationale |
+|----------|-----------|-----------|
+| Validate input parsing | Unit | Pure logic, no dependencies |
+| Check CRD schema validation | Integration | Needs API server CRD handling |
+| Verify operator reconciles resource | Integration | Needs controller-runtime + envtest |
+| Confirm cluster upgrade works | E2E | Needs full cluster + CVO |
+| Test edge case (nil pointer) | Unit | Fast, isolated |
+| Verify webhook rejects invalid config | Integration | Needs admission controller |
+| Test N→N+1 version skew | E2E | Needs multi-version cluster |
+
+## Test Organization
+
+```
+my-operator/
+├── pkg/
+│   └── controller/
+│       ├── reconcile.go
+│       └── reconcile_test.go        # Unit tests
+├── test/
+│   ├── integration/
+│   │   └── controller_test.go       # Integration tests (envtest)
+│   └── e2e/
+│       ├── install_test.go          # E2E tests
+│       └── upgrade_test.go
+└── Makefile
+    ├── test-unit
+    ├── test-integration
+    └── test-e2e
+```
+
+## CI Integration
+
+```yaml
+# .ci-operator.yaml
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+
+- as: integration
+  commands: make test-integration
+  container:
+    from: src
+
+- as: e2e
+  steps:
+    cluster_profile: aws
+    test:
+    - as: test
+      commands: make test-e2e
+      from: src
+```
+
+## Coverage Targets
+
+| Test Level | Coverage Target | Measurement |
+|-----------|----------------|-------------|
+| Unit | >80% | `go test -cover` |
+| Integration | API contracts | All CRDs, webhooks tested |
+| E2E | Critical paths | Install, upgrade, day-2 ops |
+
+## Common Antipatterns
+
+❌ **Inverted pyramid**: More e2e than unit tests (slow CI)  
+❌ **Testing framework**: Unit testing controller-runtime watch logic  
+❌ **No mocks**: Unit tests calling real API server  
+❌ **Flaky e2e**: No retries, tight timeouts  
+❌ **Missing cleanup**: e2e tests leak resources
+
+## Examples in Components
+
+| Component | Test Strategy | Notes |
+|-----------|--------------|-------|
+| cluster-version-operator | Heavy integration, critical e2e | Tests upgrade orchestration |
+| machine-api-operator | Integration for API, e2e for cloud | Cloud provider interactions |
+| kube-apiserver | Unit for logic, e2e for availability | HA and upgrade critical |
+
+## Tools
+
+- **Unit**: `go test`, `testify/assert`, `gomock`
+- **Integration**: `controller-runtime/envtest`, `ginkgo`
+- **E2E**: OpenShift CI, `e2e-framework`
+
+## References
+
+- **Dev Guide**: [test-conventions.md](../../../dev-guide/test-conventions.md)
+- **E2E Framework**: [origin/test/extended](https://github.com/openshift/origin/tree/master/test/extended)
+- **CI**: [ci-operator](https://docs.ci.openshift.org/)

--- a/ai-docs/references/api-reference.md
+++ b/ai-docs/references/api-reference.md
@@ -1,0 +1,141 @@
+# API Reference
+
+**Purpose**: Pointers to authoritative API documentation  
+**Last Updated**: 2026-04-29  
+
+## Primary API Sources
+
+### oc explain (Authoritative)
+
+```bash
+# View resource schema
+oc explain <resource>
+
+# Examples:
+oc explain pod
+oc explain clusteroperator
+oc explain machine
+
+# View specific field
+oc explain pod.spec.containers
+
+# Show all fields recursively
+oc explain pod --recursive
+```
+
+**Why use `oc explain`?**
+- Always up-to-date with cluster version
+- Shows exact schema (required fields, types, validation)
+- Matches what API server validates
+
+### GitHub API Repository
+
+[github.com/openshift/api](https://github.com/openshift/api)
+
+**Structure**:
+```
+api/
+├── config/v1/              # Platform config APIs
+│   ├── types_cluster_operator.go
+│   └── types_cluster_version.go
+├── machine/v1beta1/        # Machine API
+├── operator/v1/            # Operator APIs
+└── ...
+```
+
+### List All APIs
+
+```bash
+# All resource types
+oc api-resources
+
+# OpenShift-specific resources
+oc api-resources | grep openshift
+
+# By API group
+oc api-resources --api-group=config.openshift.io
+```
+
+## Core API Groups
+
+| API Group | Purpose | Example Resources |
+|-----------|---------|------------------|
+| `config.openshift.io` | Platform configuration | ClusterOperator, ClusterVersion |
+| `machine.openshift.io` | Node lifecycle | Machine, MachineSet |
+| `machineconfiguration.openshift.io` | Node config | MachineConfig, MachineConfigPool |
+| `operator.openshift.io` | Operator configs | KubeAPIServer, Etcd |
+| `apps` | Kubernetes workloads | Deployment, StatefulSet |
+| `core` (v1) | Kubernetes primitives | Pod, Service, ConfigMap |
+
+## API Discovery
+
+### Find API Group for Resource
+
+```bash
+# Get API group
+oc api-resources | grep <resource-name>
+
+# Example:
+$ oc api-resources | grep clusteroperator
+clusteroperators     co       config.openshift.io/v1    false   ClusterOperator
+```
+
+### Get Full Resource Schema
+
+```bash
+# Get as YAML
+oc get crd <resource-plural>.<group> -o yaml
+
+# Example:
+oc get crd clusteroperators.config.openshift.io -o yaml
+```
+
+## Documentation Locations
+
+### Kubernetes APIs
+
+- **Upstream Docs**: [kubernetes.io/docs/reference/kubernetes-api/](https://kubernetes.io/docs/reference/kubernetes-api/)
+- **Source**: [github.com/kubernetes/api](https://github.com/kubernetes/api)
+
+### OpenShift APIs
+
+- **Source**: [github.com/openshift/api](https://github.com/openshift/api)
+- **Product Docs**: [docs.openshift.com](https://docs.openshift.com/container-platform/latest/)
+
+## Common Queries
+
+### View CRD Schema
+
+```bash
+oc get crd myresources.example.com -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema}' | jq
+```
+
+### List API Versions
+
+```bash
+oc api-versions
+```
+
+### Get Resource from Specific API Version
+
+```bash
+oc get clusteroperator kube-apiserver -o yaml --show-managed-fields=false
+```
+
+## Anti-Staleness Strategy
+
+**Don't include** (gets stale):
+- ❌ Full API field documentation
+- ❌ All available resources list
+- ❌ Every API group
+
+**Do include** (stays current):
+- ✅ How to discover APIs (`oc explain`, `oc api-resources`)
+- ✅ Core stable API groups only
+- ✅ Links to authoritative sources
+
+## Related
+
+- **Glossary**: [glossary.md](glossary.md) - Core terminology
+- **Domain Concepts**: [../domain/](../domain/) - Key API documentation
+- **CRD Guide**: [../domain/kubernetes/crds.md](../domain/kubernetes/crds.md)

--- a/ai-docs/references/glossary.md
+++ b/ai-docs/references/glossary.md
@@ -1,0 +1,80 @@
+# Glossary
+
+Core stable terms for OpenShift platform. Only includes terms that won't change frequently.
+
+## Platform Terms
+
+| Term | Definition |
+|------|------------|
+| **ClusterOperator** | Status resource for platform components (Available/Progressing/Degraded reporting) |
+| **CVO** | Cluster Version Operator - orchestrates cluster upgrades |
+| **CRD** | CustomResourceDefinition - extends Kubernetes API with new resource types |
+| **etcd** | Distributed key-value store, backend for Kubernetes API server |
+| **Machine** | API resource representing a node in the cluster (via Machine API) |
+| **MachineConfig** | Configuration applied to nodes (files, systemd units, kernel args) |
+| **MCO** | Machine Config Operator - manages node configuration |
+| **Operator** | Controller + CRD, manages lifecycle of applications/services |
+| **RHCOS** | Red Hat CoreOS - immutable operating system for OpenShift nodes |
+| **rpm-ostree** | Package/update system for immutable operating systems |
+
+## Kubernetes Terms
+
+| Term | Definition |
+|------|------------|
+| **Admission Controller** | Plugin that intercepts API requests (validation, mutation) |
+| **controller-runtime** | Go library for building Kubernetes controllers/operators |
+| **envtest** | Integration testing framework (API server + etcd) |
+| **Reconciliation** | Controller loop that converges current state to desired state |
+| **Watch** | Mechanism to receive notifications when resources change |
+
+## API Terms
+
+| Term | Definition |
+|------|------------|
+| **Hub Version** | Storage version for API (other versions convert to this) |
+| **ObservedGeneration** | Status field tracking last reconciled spec version |
+| **Spec** | Desired state (user input) |
+| **Status** | Current state (controller output) |
+| **Subresource** | Secondary API endpoint (e.g., `/status`, `/scale`) |
+
+## Upgrade Terms
+
+| Term | Definition |
+|------|------------|
+| **Channel** | Update stream (stable, fast, candidate, eus) |
+| **Cincinnati** | Update recommendation service (provides upgrade graph) |
+| **EUS** | Extended Update Support - long-term stable releases |
+| **N→N+1** | Version skew policy (support current and next minor version) |
+| **Version Skew** | Difference between component versions during upgrade |
+
+## Testing Terms
+
+| Term | Definition |
+|------|------------|
+| **E2E Test** | End-to-end test on full cluster |
+| **Flaky Test** | Test that intermittently fails |
+| **Integration Test** | Test with multiple components (e.g., envtest) |
+| **Unit Test** | Test of single function/method (mocked dependencies) |
+
+## Status Conditions
+
+| Term | Definition |
+|------|------------|
+| **Available** | Component is functional and serving requests |
+| **Degraded** | Component is impaired but still functioning |
+| **Progressing** | Component is reconciling changes (upgrade, config) |
+| **Upgradeable** | Safe to upgrade (False blocks cluster upgrade) |
+
+## Anti-Staleness Note
+
+This glossary includes only **stable core terms** that are unlikely to change. Avoid adding:
+- Release-specific features
+- Component-specific terminology
+- Temporary or experimental terms
+
+For detailed API documentation, use `oc explain <resource>`.
+
+## Related
+
+- **API Reference**: [api-reference.md](api-reference.md)
+- **Full API Docs**: [Kubernetes API Reference](https://kubernetes.io/docs/reference/kubernetes-api/)

--- a/ai-docs/references/index.md
+++ b/ai-docs/references/index.md
@@ -1,0 +1,23 @@
+# References
+
+Pointer-based navigation to authoritative sources.
+
+## Reference Guides
+
+- [repo-index.md](repo-index.md) - Finding OpenShift component repositories (GitHub org search)
+- [api-reference.md](api-reference.md) - API documentation sources (`oc explain`, GitHub)
+- [glossary.md](glossary.md) - Core stable terminology
+
+## Anti-Staleness Strategy
+
+References use pointers (GitHub search links, `oc` commands) not exhaustive lists:
+- ✅ Search strategies
+- ✅ Command examples
+- ✅ Naming conventions
+- ❌ Complete repository lists
+- ❌ All API field documentation
+
+## Related
+
+- **Domain Concepts**: [../domain/](../domain/) - Core API guides
+- **Workflows**: [../workflows/](../workflows/) - Process guides

--- a/ai-docs/references/repo-index.md
+++ b/ai-docs/references/repo-index.md
@@ -1,0 +1,95 @@
+# Repository Index
+
+**Purpose**: Discover OpenShift component repositories  
+**Last Updated**: 2026-04-29  
+
+## Finding Repositories
+
+**Primary Method**: [GitHub Organization Search](https://github.com/orgs/openshift/repositories)
+
+**Common Patterns**:
+- `openshift/<component>-operator` - Operators
+- `openshift/<component>` - Core components
+- `openshift/api` - API definitions
+- `openshift/enhancements` - Design docs
+
+## Core Platform Components
+
+| Component | Repository | Description |
+|-----------|-----------|-------------|
+| **Cluster Version Operator** | [cluster-version-operator](https://github.com/openshift/cluster-version-operator) | Upgrade orchestration |
+| **Machine API** | [machine-api-operator](https://github.com/openshift/machine-api-operator) | Node lifecycle |
+| **Kube API Server** | [cluster-kube-apiserver-operator](https://github.com/openshift/cluster-kube-apiserver-operator) | API server operator |
+| **etcd** | [cluster-etcd-operator](https://github.com/openshift/cluster-etcd-operator) | etcd cluster operator |
+| **Networking** | [cluster-network-operator](https://github.com/openshift/cluster-network-operator) | SDN/OVN orchestration |
+
+## API Definitions
+
+| Repository | Purpose |
+|-----------|---------|
+| [openshift/api](https://github.com/openshift/api) | All OpenShift API types |
+| [kubernetes/api](https://github.com/kubernetes/api) | Kubernetes core APIs |
+
+## Search Strategies
+
+### By Keyword
+
+```bash
+# Search GitHub org
+https://github.com/orgs/openshift/repositories?q=<keyword>
+
+# Example: storage-related repos
+https://github.com/orgs/openshift/repositories?q=storage
+```
+
+### By Topic
+
+```bash
+# Operator repos
+https://github.com/orgs/openshift/repositories?q=operator
+
+# API repos
+https://github.com/orgs/openshift/repositories?q=api
+```
+
+### By Language
+
+```bash
+# Go repos (most operators)
+https://github.com/orgs/openshift/repositories?language=go
+```
+
+## Operator Naming Conventions
+
+| Pattern | Example | Component Type |
+|---------|---------|---------------|
+| `cluster-<component>-operator` | `cluster-etcd-operator` | Core platform |
+| `<component>-operator` | `machine-api-operator` | Platform feature |
+| `<component>` | `installer` | Tool/utility |
+
+## Finding Component Ownership
+
+**OWNERS Files**: Each repo has `OWNERS` file with approvers/reviewers
+
+```bash
+# View owners
+curl https://raw.githubusercontent.com/openshift/<repo>/master/OWNERS
+```
+
+## Anti-Staleness Strategy
+
+**Don't maintain exhaustive lists** (they go stale):
+- ❌ List of all 200+ repositories
+- ❌ Component ownership mapping
+- ❌ Repository statistics
+
+**Do provide search strategies**:
+- ✅ GitHub org search links
+- ✅ Naming conventions
+- ✅ Core platform components only
+
+## Related
+
+- **GitHub Org**: [github.com/openshift](https://github.com/openshift)
+- **API Reference**: [api-reference.md](api-reference.md)
+- **Enhancement Repo**: [openshift/enhancements](https://github.com/openshift/enhancements)

--- a/ai-docs/workflows/enhancement-process.md
+++ b/ai-docs/workflows/enhancement-process.md
@@ -1,0 +1,158 @@
+# Enhancement Process
+
+**Purpose**: AI-optimized guide for writing enhancement proposals  
+**Authoritative Source**: [../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)  
+**Last Updated**: 2026-04-29  
+
+## Quick Start
+
+| Step | Action | Output |
+|------|--------|--------|
+| 1 | Copy template | `cp guidelines/enhancement_template.md enhancements/my-feature.md` |
+| 2 | Fill required sections | Summary, Motivation, Proposal |
+| 3 | Create PR | Tag with `kind/enhancement` |
+| 4 | Address review | Update based on feedback |
+| 5 | Merge | Enhancement approved |
+
+## Required Sections
+
+| Section | Purpose | Length | Required |
+|---------|---------|--------|----------|
+| **Summary** | 1-sentence description | 1 sentence | ✅ |
+| **Motivation** | Why this feature | 2-5 paragraphs | ✅ |
+| **Goals** | What we will do | Bulleted list | ✅ |
+| **Non-Goals** | What we won't do | Bulleted list | ✅ |
+| **Proposal** | How it works | 1-3 pages | ✅ |
+| **Risks and Mitigations** | What could go wrong | Table | ✅ |
+| **Drawbacks** | Why not to do this | 1-2 paragraphs | Optional |
+| **Alternatives** | Other approaches considered | List with rationale | Optional |
+| **Implementation Details** | Technical design | API examples, diagrams | ✅ |
+| **Test Plan** | How to verify | Test scenarios | ✅ |
+| **Graduation Criteria** | When to promote | DevPreview → TechPreview → GA | ✅ |
+| **Upgrade/Downgrade** | Migration strategy | Version compatibility | If applicable |
+
+## Enhancement States
+
+```
+Idea → Proposal → Implementable → Implemented → Stable
+  ↓        ↓            ↓              ↓          ↓
+Draft    Review     Approved       Merged      GA
+```
+
+## Template Structure
+
+```yaml
+---
+title: my-feature
+authors:
+  - "@myusername"
+reviewers:
+  - "@reviewer1"
+approvers:
+  - "@approver1"
+creation-date: 2026-04-29
+status: implementable
+---
+
+# My Feature
+
+## Summary
+
+One sentence describing the feature.
+
+## Motivation
+
+### Goals
+- Goal 1
+- Goal 2
+
+### Non-Goals
+- Non-goal 1
+
+## Proposal
+
+### User Stories
+- As a cluster admin, I want...
+
+### API Changes
+```yaml
+apiVersion: config.openshift.io/v1
+kind: MyResource
+spec:
+  newField: value
+```
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Risk 1 | Mitigation 1 |
+
+### Test Plan
+- Unit tests for...
+- E2E tests for...
+
+### Graduation Criteria
+- DevPreview: API defined, basic implementation
+- TechPreview: Feature complete, tested
+- GA: Production-ready, stable API
+
+## Implementation History
+- 2026-04-29: Initial proposal
+```
+
+## API Design Checklist
+
+- [ ] API group and version chosen (config.openshift.io/v1, etc.)
+- [ ] CRD schema defined with validation
+- [ ] Status conditions follow Available/Progressing/Degraded pattern
+- [ ] Backward compatibility considered
+- [ ] Upgrade/downgrade path documented
+- [ ] Default values specified
+
+## Review Process
+
+| Stage | Criteria | Reviewers |
+|-------|----------|-----------|
+| **Initial Review** | Complete template, clear motivation | Enhancement team |
+| **API Review** | API follows conventions | API review team |
+| **Implementation Review** | Technical feasibility | Component owners |
+| **Approval** | All concerns addressed | Approvers |
+
+## Common Mistakes
+
+❌ **Missing motivation**: "We need feature X" (why?)  
+❌ **Unclear proposal**: High-level description without implementation details  
+❌ **No test plan**: How will we verify this works?  
+❌ **Ignoring upgrades**: What happens to existing clusters?  
+❌ **Breaking changes**: Not considering backward compatibility
+
+## Examples
+
+| Enhancement | Type | Notes |
+|-------------|------|-------|
+| [ClusterOperator Conditions](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md) | Pattern | Status reporting standard |
+| [Machine API](https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/) | Feature | Node lifecycle management |
+| [Feature Gates](https://github.com/openshift/enhancements/blob/master/dev-guide/featuresets.md) | Process | Graduation criteria |
+
+## Workflow Commands
+
+```bash
+# Create enhancement
+cp guidelines/enhancement_template.md enhancements/my-feature.md
+
+# Validate format
+make verify
+
+# Create PR
+gh pr create --title "Enhancement: My Feature" --body "..." --label kind/enhancement
+
+# View enhancements
+ls enhancements/
+```
+
+## Related
+
+- **Authoritative Template**: [../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)
+- **API Conventions**: [../practices/development/api-evolution.md](../practices/development/api-evolution.md)
+- **Feature Development**: [implementing-features.md](implementing-features.md)

--- a/ai-docs/workflows/enhancement-process.md
+++ b/ai-docs/workflows/enhancement-process.md
@@ -154,5 +154,6 @@ ls enhancements/
 ## Related
 
 - **Authoritative Template**: [../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)
+- **Topology Considerations**: [topology-considerations-guide.md](topology-considerations-guide.md) - Guide for SNO, MicroShift, Hypershift, OKE sections
 - **API Conventions**: [../practices/development/api-evolution.md](../practices/development/api-evolution.md)
 - **Feature Development**: [implementing-features.md](implementing-features.md)

--- a/ai-docs/workflows/enhancement-process.md
+++ b/ai-docs/workflows/enhancement-process.md
@@ -28,7 +28,7 @@
 | **Alternatives** | Other approaches considered | List with rationale | Optional |
 | **Implementation Details** | Technical design | API examples, diagrams | ✅ |
 | **Test Plan** | How to verify | Test scenarios | ✅ |
-| **Graduation Criteria** | When to promote | DevPreview → TechPreview → GA | ✅ |
+| **Graduation Criteria** | When to promote | DevPreview → TechPreview → GA (or alpha → GA if confident) | ✅ |
 | **Upgrade/Downgrade** | Migration strategy | Version compatibility | If applicable |
 
 ## Enhancement States
@@ -94,8 +94,10 @@ spec:
 
 ### Graduation Criteria
 - DevPreview: API defined, basic implementation
-- TechPreview: Feature complete, tested
-- GA: Production-ready, stable API
+- TechPreview: Feature complete, tested (optional if confident in API)
+- GA: Production-ready, stable API, no breaking changes allowed
+
+See [../guidelines/supportability.md](../../guidelines/supportability.md) for Tech Preview policy and when you can skip TechPreview stage.
 
 ## Implementation History
 - 2026-04-29: Initial proposal
@@ -126,6 +128,7 @@ spec:
 ❌ **No test plan**: How will we verify this works?  
 ❌ **Ignoring upgrades**: What happens to existing clusters?  
 ❌ **Breaking changes**: Not considering backward compatibility
+❌ **Wrong delivery mechanism**: Should this be in payload or OLM? See [new-components.md](../../dev-guide/new-components.md)
 
 ## Examples
 
@@ -154,6 +157,8 @@ ls enhancements/
 ## Related
 
 - **Authoritative Template**: [../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)
+- **Supportability Policy**: [../guidelines/supportability.md](../../guidelines/supportability.md) - Tech Preview vs GA, graduation paths
+- **New Component Policy**: [../dev-guide/new-components.md](../../dev-guide/new-components.md) - Payload vs OLM decision criteria
 - **Topology Considerations**: [topology-considerations-guide.md](topology-considerations-guide.md) - Guide for SNO, MicroShift, Hypershift, OKE sections
 - **API Conventions**: [../practices/development/api-evolution.md](../practices/development/api-evolution.md)
 - **Feature Development**: [implementing-features.md](implementing-features.md)

--- a/ai-docs/workflows/exec-plans/README.md
+++ b/ai-docs/workflows/exec-plans/README.md
@@ -1,0 +1,165 @@
+# Exec-Plans: Feature Implementation Tracking
+
+**Purpose**: Track multi-week feature implementation progress (Tier 1 guidance)  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Exec-plans are ephemeral documents that track feature implementation. They bridge the gap between enhancement (design) and implementation (code).
+
+**Key Points**:
+- Guidance lives here (Tier 1 platform docs)
+- Actual exec-plans live in component repos (`agentic/exec-plans/active/`)
+- Exec-plans are temporary → extract to permanent docs, then delete
+
+## When to Use Exec-Plans
+
+| Scenario | Use Exec-Plan? | Why |
+|----------|---------------|-----|
+| Multi-week feature (3+ PRs) | ✅ Yes | Track progress, coordinate PRs |
+| Single PR feature | ❌ No | PR description sufficient |
+| Bug fix | ❌ No | Issue tracker sufficient |
+| Multi-component coordination | ✅ Yes | Track cross-repo dependencies |
+| Experimental spike | ❌ No | Use spike branch, not exec-plan |
+
+**Rule of thumb**: If you'll have 3+ PRs over 2+ weeks, use an exec-plan.
+
+## Exec-Plan vs Enhancement
+
+| Aspect | Enhancement | Exec-Plan |
+|--------|-------------|-----------|
+| **Purpose** | Design approval | Implementation tracking |
+| **Location** | `enhancements/` (permanent) | `agentic/exec-plans/active/` (ephemeral) |
+| **Scope** | What and why | How and when |
+| **Lifetime** | Permanent (historical record) | Temporary (delete after completion) |
+| **Audience** | Reviewers, future developers | Current implementation team |
+
+**Relationship**: Enhancement = design spec, Exec-plan = implementation plan
+
+## Structure
+
+```
+component-repo/
+└── agentic/
+    └── exec-plans/
+        ├── active/
+        │   ├── YYYY-MM-my-feature.md        # Active plans
+        │   └── YYYY-MM-another-feature.md
+        ├── archive/                          # Completed (or use git history)
+        └── template.md                       # Copy this for new plans
+```
+
+## Template
+
+See [template.md](template.md) for the full template.
+
+**Core sections**:
+1. **Overview**: What, why, timeline
+2. **Implementation Tasks**: Checklist of PRs/work items
+3. **Dependencies**: Blockers, cross-component coordination
+4. **Progress Log**: Weekly updates
+5. **Decisions**: Key technical decisions made during implementation
+6. **Completion**: Outcome, follow-ups, knowledge extraction
+
+## Workflow
+
+### 1. Start: Create Exec-Plan
+
+```bash
+# Copy template
+cp agentic/exec-plans/template.md agentic/exec-plans/active/2026-04-my-feature.md
+
+# Fill in:
+# - Overview (what, why, timeline)
+# - Implementation tasks (checklist)
+# - Dependencies
+```
+
+### 2. During: Update Progress
+
+```bash
+# Weekly updates:
+# - Check off completed tasks
+# - Add progress log entries
+# - Document decisions
+# - Update timeline if needed
+```
+
+### 3. Complete: Extract & Delete
+
+```bash
+# Extract knowledge:
+# - Key decisions → ADR in decisions/
+# - Architecture changes → Update architecture.md
+# - Patterns → Update relevant pattern docs
+
+# Then delete or archive exec-plan:
+git rm agentic/exec-plans/active/2026-04-my-feature.md
+# Or: mv active/2026-04-my-feature.md archive/
+```
+
+## Best Practices
+
+1. **Keep Updated**: Update at least weekly (more often for active development)
+   
+2. **Check Off Tasks**: Visible progress motivates and informs stakeholders
+   
+3. **Document Decisions**: Capture "why" not just "what"
+   - Why we chose approach X over Y
+   - Why we changed direction mid-implementation
+   
+4. **Extract Knowledge**: Don't let decisions disappear
+   - Significant decisions → ADR
+   - Architecture changes → Permanent docs
+   - Patterns → Platform or component guides
+   
+5. **Delete When Done**: Exec-plans are ephemeral
+   - Extract value to permanent docs
+   - Delete to avoid doc rot
+
+## Example Timeline
+
+```
+Week 1:
+  [x] Create exec-plan
+  [x] PR #123: API changes
+  [ ] PR #124: Controller logic
+
+Week 2:
+  [x] PR #124: Controller logic
+  [ ] PR #125: E2E tests
+  Decision: Changed approach from X to Y because...
+
+Week 3:
+  [x] PR #125: E2E tests
+  [x] All PRs merged
+  
+Week 4:
+  [x] Extract decisions to ADR
+  [x] Update architecture docs
+  [x] Delete exec-plan
+```
+
+## Integration with Other Docs
+
+| Doc Type | Relationship | Example |
+|----------|--------------|---------|
+| **Enhancement** | Exec-plan implements enhancement | Enhancement: design, Exec-plan: tracking |
+| **ADR** | Extract key decisions from exec-plan | "Why we chose etcd" → ADR |
+| **Architecture** | Update with changes from exec-plan | New component → architecture.md |
+| **Pattern Docs** | Extract patterns discovered | New pattern → pattern doc |
+
+## Antipatterns
+
+❌ **Permanent exec-plans**: Exec-plans should be deleted after completion  
+❌ **No updates**: Exec-plan created but never updated (use PR description instead)  
+❌ **Too detailed**: Line-by-line code plan (let PRs evolve)  
+❌ **No extraction**: Delete without extracting decisions to permanent docs  
+❌ **Single PR features**: Don't need exec-plan (PR description sufficient)
+
+## Related
+
+- **Template**: [template.md](template.md) - Copy this for new exec-plans
+- **Enhancement Process**: [../enhancement-process.md](../enhancement-process.md)
+- **Feature Implementation**: [../implementing-features.md](../implementing-features.md)
+- **ADRs**: [../../decisions/](../../decisions/) - Where to extract key decisions

--- a/ai-docs/workflows/exec-plans/README.md
+++ b/ai-docs/workflows/exec-plans/README.md
@@ -1,14 +1,14 @@
 # Exec-Plans: Feature Implementation Tracking
 
-**Purpose**: Track multi-week feature implementation progress (Tier 1 guidance)  
-**Last Updated**: 2026-04-29  
+**Purpose**: Track multi-week feature implementation progress (Platform guidance)
+**Last Updated**: 2026-04-29
 
 ## Overview
 
 Exec-plans are ephemeral documents that track feature implementation. They bridge the gap between enhancement (design) and implementation (code).
 
 **Key Points**:
-- Guidance lives here (Tier 1 platform docs)
+- Guidance lives here (Platform docs)
 - Actual exec-plans live in component repos (`agentic/exec-plans/active/`)
 - Exec-plans are temporary → extract to permanent docs, then delete
 

--- a/ai-docs/workflows/exec-plans/template.md
+++ b/ai-docs/workflows/exec-plans/template.md
@@ -1,0 +1,169 @@
+# Exec-Plan: [Feature Name]
+
+**Status**: Active | Blocked | Completed  
+**Start Date**: YYYY-MM-DD  
+**Target Completion**: YYYY-MM-DD  
+**Owner**: @username  
+**Related Enhancement**: [Link to enhancement](../../enhancements/my-feature.md)  
+
+---
+
+## Overview
+
+### What
+Brief description of what this feature does (1-2 sentences).
+
+### Why
+Why we're building this (link to enhancement for details).
+
+### Timeline
+- **Start**: YYYY-MM-DD
+- **Target**: YYYY-MM-DD
+- **Status**: On track | At risk | Delayed
+
+---
+
+## Implementation Tasks
+
+### Phase 1: API Changes
+- [ ] Define CRD schema (PR #XXX)
+- [ ] Add validation webhook (PR #XXX)
+- [ ] Update API types (PR #XXX)
+- [ ] API review approved
+
+**Target**: Week 1
+
+### Phase 2: Controller Implementation
+- [ ] Implement reconciliation logic (PR #XXX)
+- [ ] Add unit tests (>80% coverage)
+- [ ] Add integration tests
+- [ ] Handle error cases
+
+**Target**: Week 2-3
+
+### Phase 3: Testing & Documentation
+- [ ] E2E tests for critical paths (PR #XXX)
+- [ ] Upgrade/downgrade tests
+- [ ] Documentation (user-facing)
+- [ ] Metrics and alerts
+
+**Target**: Week 4
+
+---
+
+## Dependencies
+
+### Blockers
+- [ ] Dependency 1: Description (blocked by #XXX)
+- [ ] Dependency 2: Description (waiting on team Y)
+
+### Cross-Component Coordination
+- [ ] Component A: API contract defined
+- [ ] Component B: Integration tested
+
+---
+
+## Progress Log
+
+### YYYY-MM-DD (Week 4)
+**Progress**:
+- Completed PR #125 (E2E tests)
+- All PRs merged
+
+**Next**:
+- Extract decisions to ADR
+- Delete exec-plan
+
+### YYYY-MM-DD (Week 3)
+**Progress**:
+- Completed PR #124 (controller logic)
+- Started PR #125 (E2E tests)
+
+**Blockers**: None
+
+**Next**:
+- Finish E2E tests
+- Final review
+
+### YYYY-MM-DD (Week 2)
+**Progress**:
+- PR #123 merged (API changes)
+- Started controller implementation
+
+**Decisions**:
+- Changed from approach X to Y because... (extract to ADR)
+
+**Next**:
+- Complete controller logic
+- Add integration tests
+
+### YYYY-MM-DD (Week 1)
+**Progress**:
+- Created exec-plan
+- Opened PR #123 (API changes)
+
+**Next**:
+- Complete API review
+- Start controller implementation
+
+---
+
+## Decisions
+
+### Decision 1: [Title]
+**Date**: YYYY-MM-DD  
+**Decision**: What we decided  
+**Rationale**: Why we decided this  
+**Alternatives**: What we considered  
+**Status**: Extract to ADR: [ ] Yes [x] No  
+
+### Decision 2: [Title]
+**Date**: YYYY-MM-DD  
+**Decision**: ...  
+**Rationale**: ...  
+**Status**: Extract to ADR: [x] Yes [ ] No  
+
+---
+
+## Completion Checklist
+
+### Code
+- [ ] All PRs merged
+- [ ] Tests passing in CI
+- [ ] Documentation updated
+- [ ] Feature gate configured (if TechPreview)
+
+### Knowledge Extraction
+- [ ] Key decisions extracted to ADRs
+- [ ] Architecture docs updated
+- [ ] Patterns documented (if new patterns emerged)
+- [ ] Lessons learned captured
+
+### Cleanup
+- [ ] Exec-plan archived or deleted
+- [ ] Related issues closed
+- [ ] Team notified of completion
+
+---
+
+## Outcome
+
+**Status**: [Completed | Deferred | Cancelled]  
+**Completion Date**: YYYY-MM-DD  
+
+### What Shipped
+- Feature X in version Y.Z
+- PRs: #123, #124, #125
+
+### Follow-Ups
+- [ ] Follow-up 1: Description (issue #XXX)
+- [ ] Follow-up 2: Description (issue #XXX)
+
+### Knowledge Extracted
+- ADR: [Link to decision doc]
+- Architecture update: [Link]
+- Pattern doc: [Link]
+
+---
+
+**Note**: This exec-plan is ephemeral. After completion, extract key decisions and delete this file.

--- a/ai-docs/workflows/implementing-features.md
+++ b/ai-docs/workflows/implementing-features.md
@@ -1,0 +1,220 @@
+# Implementing Features
+
+**Purpose**: Structured workflow from enhancement to production  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Feature implementation follows: Spec → Plan → Build → Test → Review → Ship
+
+## Workflow Stages
+
+| Stage | Input | Output | Duration |
+|-------|-------|--------|----------|
+| **1. Spec** | Enhancement proposal | Approved enhancement | 1-2 weeks |
+| **2. Plan** | Enhancement | Implementation plan | 1-3 days |
+| **3. Build** | Plan | Code + tests | 1-8 weeks |
+| **4. Test** | Code | Passing CI | Continuous |
+| **5. Review** | PR | Approved PR | 1-3 days |
+| **6. Ship** | Merged PR | Production release | 1-4 weeks |
+
+## Stage 1: Spec (Enhancement)
+
+**Goal**: Get approval for feature design
+
+**Checklist**:
+- [ ] Enhancement proposal written (see [enhancement-process.md](enhancement-process.md))
+- [ ] API design reviewed
+- [ ] Risks and mitigations identified
+- [ ] Test plan defined
+- [ ] Graduation criteria set (DevPreview → TechPreview → GA)
+- [ ] Enhancement PR merged
+
+**Artifacts**: Merged enhancement in `enhancements/`
+
+## Stage 2: Plan (Implementation Plan)
+
+**Goal**: Break enhancement into implementable tasks
+
+**Checklist**:
+- [ ] Identify affected components
+- [ ] List required API changes
+- [ ] Define PR sequence (API → implementation → tests)
+- [ ] Estimate timeline
+- [ ] Identify dependencies
+- [ ] Create exec-plan if multi-week (see [exec-plans/](exec-plans/))
+
+**Artifacts**: Implementation plan (PR description or exec-plan doc)
+
+**Example Plan**:
+```markdown
+## Implementation Plan
+
+### PR 1: API Changes
+- Add new CRD field `spec.newFeature`
+- Update validation webhook
+- Files: api/, webhook/
+
+### PR 2: Controller Logic
+- Implement reconciliation for new field
+- Add unit tests
+- Files: controllers/
+
+### PR 3: E2E Tests
+- Add upgrade test
+- Add feature test
+- Files: test/e2e/
+
+Timeline: 3 weeks
+Dependencies: None
+```
+
+## Stage 3: Build (Code + Tests)
+
+**Goal**: Implement feature with tests
+
+**Checklist**:
+- [ ] API changes (CRD, types, validation)
+- [ ] Controller logic (reconciliation)
+- [ ] Unit tests (>80% coverage)
+- [ ] Integration tests (API contracts)
+- [ ] E2E tests (critical paths)
+- [ ] Documentation (godoc, user-facing)
+- [ ] Feature gate if TechPreview
+
+**Test Pyramid**:
+- 60% unit tests (fast, isolated)
+- 30% integration tests (envtest)
+- 10% e2e tests (full cluster)
+
+See [../practices/testing/pyramid.md](../practices/testing/pyramid.md)
+
+## Stage 4: Test (CI Validation)
+
+**Goal**: Ensure tests pass in CI
+
+**Checklist**:
+- [ ] Unit tests pass (`make test-unit`)
+- [ ] Integration tests pass (`make test-integration`)
+- [ ] E2E tests pass (CI job)
+- [ ] Linting passes (`make verify`)
+- [ ] No flaky tests
+- [ ] Coverage meets target
+
+**Common CI Jobs**:
+- `pull-ci-<org>-<repo>-<branch>-unit`
+- `pull-ci-<org>-<repo>-<branch>-e2e-aws`
+- `pull-ci-<org>-<repo>-<branch>-verify`
+
+## Stage 5: Review (PR Review)
+
+**Goal**: Get code review and approval
+
+**Checklist**:
+- [ ] PR description explains changes
+- [ ] Tests included
+- [ ] Documentation updated
+- [ ] CHANGELOG entry added (if applicable)
+- [ ] API review approved (if API changes)
+- [ ] Code review approved (/lgtm)
+- [ ] Required approvers approved (/approve)
+
+**Review Areas**:
+- Code quality (readability, maintainability)
+- Test coverage (edge cases, error paths)
+- API design (backward compatibility)
+- Performance (no obvious regressions)
+- Security (no vulnerabilities)
+
+## Stage 6: Ship (Production Release)
+
+**Goal**: Feature available in release
+
+**Checklist**:
+- [ ] PR merged to main branch
+- [ ] Feature included in next release image
+- [ ] Release notes written
+- [ ] Documentation published
+- [ ] Metrics dashboard created (if applicable)
+- [ ] Alerts configured (if applicable)
+
+**Graduation Path**:
+```
+DevPreview (4.16) → TechPreview (4.17) → GA (4.18)
+```
+
+## Feature States
+
+| State | Meaning | Support Level | API Stability |
+|-------|---------|--------------|---------------|
+| **DevPreview** | Experimental | Best-effort | May change |
+| **TechPreview** | Feature-complete | Supported (no SLA) | Mostly stable |
+| **GA** | Production-ready | Fully supported | Stable |
+
+## Multi-PR Strategy
+
+**Pattern**: API → Implementation → Tests
+
+```
+PR 1 (API):
+  - Add CRD fields
+  - Update validation
+  - Merge: Week 1
+
+PR 2 (Implementation):
+  - Add controller logic
+  - Add unit tests
+  - Depends on: PR 1
+  - Merge: Week 2
+
+PR 3 (E2E):
+  - Add e2e tests
+  - Depends on: PR 2
+  - Merge: Week 3
+```
+
+**Benefits**:
+- Smaller, easier-to-review PRs
+- Incremental progress
+- Easier to revert if needed
+
+## Rollout Strategy
+
+| Strategy | Use Case | Example |
+|----------|----------|---------|
+| **Feature Gate** | TechPreview features | `FeatureGates: [MyFeature]` |
+| **Operator Flag** | Opt-in features | `--enable-my-feature=true` |
+| **Progressive Rollout** | Gradual activation | Enable 10% → 50% → 100% |
+| **API Version** | Breaking changes | v1alpha1 → v1beta1 → v1 |
+
+## Monitoring Post-Ship
+
+**Checklist**:
+- [ ] Monitor error rates (Prometheus)
+- [ ] Check for support cases (Jira)
+- [ ] Watch for regression bugs
+- [ ] Verify upgrade scenarios work
+- [ ] Gather user feedback
+
+## Common Pitfalls
+
+❌ **No test plan**: Feature works locally but breaks in CI  
+❌ **Missing upgrade path**: Old clusters break on upgrade  
+❌ **Insufficient testing**: Only happy path tested  
+❌ **No feature gate**: Can't disable if bugs found  
+❌ **Unclear PR sequence**: Dependencies not obvious
+
+## Examples
+
+| Feature | PRs | Timeline | Notes |
+|---------|-----|----------|-------|
+| Machine API | 5 PRs | 8 weeks | API, controller, provider, tests |
+| ClusterVersion | 3 PRs | 4 weeks | API, CVO logic, e2e |
+| Feature Gates | 2 PRs | 2 weeks | Implementation, docs |
+
+## Related
+
+- **Enhancement Process**: [enhancement-process.md](enhancement-process.md)
+- **Exec Plans**: [exec-plans/](exec-plans/) - Track multi-week features
+- **Testing**: [../practices/testing/pyramid.md](../practices/testing/pyramid.md)
+- **API Evolution**: [../practices/development/api-evolution.md](../practices/development/api-evolution.md)

--- a/ai-docs/workflows/implementing-features.md
+++ b/ai-docs/workflows/implementing-features.md
@@ -27,7 +27,7 @@ Feature implementation follows: Spec → Plan → Build → Test → Review → 
 - [ ] API design reviewed
 - [ ] Risks and mitigations identified
 - [ ] Test plan defined
-- [ ] Graduation criteria set (DevPreview → TechPreview → GA)
+- [ ] Graduation criteria set (DevPreview → TechPreview → GA, or DevPreview → GA if API stable)
 - [ ] Enhancement PR merged
 
 **Artifacts**: Merged enhancement in `enhancements/`
@@ -141,7 +141,11 @@ See [../practices/testing/pyramid.md](../practices/testing/pyramid.md)
 **Graduation Path**:
 ```
 DevPreview (4.16) → TechPreview (4.17) → GA (4.18)
+OR
+DevPreview (4.16) → GA (4.17)  # If API stable and confident
 ```
+
+See [../guidelines/supportability.md](../../guidelines/supportability.md) for when you can skip TechPreview.
 
 ## Feature States
 
@@ -215,6 +219,7 @@ PR 3 (E2E):
 ## Related
 
 - **Enhancement Process**: [enhancement-process.md](enhancement-process.md)
+- **Supportability Policy**: [../guidelines/supportability.md](../../guidelines/supportability.md) - Tech Preview vs GA, graduation paths
 - **Exec Plans**: [exec-plans/](exec-plans/) - Track multi-week features
 - **Testing**: [../practices/testing/pyramid.md](../practices/testing/pyramid.md)
 - **API Evolution**: [../practices/development/api-evolution.md](../practices/development/api-evolution.md)

--- a/ai-docs/workflows/index.md
+++ b/ai-docs/workflows/index.md
@@ -1,0 +1,22 @@
+# Workflows
+
+AI-optimized guides for OpenShift development processes.
+
+## Workflow Guides
+
+- [enhancement-process.md](enhancement-process.md) - Writing enhancement proposals (structured version of `../guidelines/enhancement_template.md`)
+- [implementing-features.md](implementing-features.md) - Feature implementation workflow (spec → plan → build → test → review → ship)
+- [exec-plans/](exec-plans/) - Feature tracking templates and guidance (Tier 1)
+
+## Authoritative Sources
+
+These workflows are AI-optimized versions of content from:
+- [../guidelines/](../../guidelines/) - Enhancement process, PR conventions
+- [../dev-guide/](../../dev-guide/) - Development conventions, feature development
+
+**Difference**: Same information, but formatted for AI agents (tables, checklists, YAML examples instead of prose).
+
+## Related
+
+- **Practices**: [../practices/](../practices/) - Testing, API evolution, security
+- **Platform Patterns**: [../platform/](../platform/) - Operator patterns

--- a/ai-docs/workflows/index.md
+++ b/ai-docs/workflows/index.md
@@ -5,8 +5,9 @@ AI-optimized guides for OpenShift development processes.
 ## Workflow Guides
 
 - [enhancement-process.md](enhancement-process.md) - Writing enhancement proposals (structured version of `../guidelines/enhancement_template.md`)
+- [topology-considerations-guide.md](topology-considerations-guide.md) - Guide for addressing SNO, MicroShift, Hypershift, and OKE in enhancement proposals
 - [implementing-features.md](implementing-features.md) - Feature implementation workflow (spec → plan → build → test → review → ship)
-- [exec-plans/](exec-plans/) - Feature tracking templates and guidance (Tier 1)
+- [exec-plans/](exec-plans/) - Feature tracking templates and guidance (Platform)
 
 ## Authoritative Sources
 

--- a/ai-docs/workflows/topology-considerations-guide.md
+++ b/ai-docs/workflows/topology-considerations-guide.md
@@ -1,0 +1,322 @@
+# Topology Considerations Guide
+
+**Purpose**: Guide enhancement authors and reviewers through deployment topology sections  
+**Target Audience**: EP authors, reviewers, approvers  
+**Template Section**: "Topology Considerations" in enhancement_template.md  
+**Last Updated**: 2026-05-14
+
+---
+
+## Overview
+
+OpenShift supports multiple deployment topologies, each with different architectural constraints, resource profiles, and operational models. Enhancement proposals must explicitly address how changes affect each topology.
+
+**Key principle**: If unsure, research and ask questions. "Not applicable" without explanation is insufficient.
+
+---
+
+## Quick Decision Tree
+
+```mermaid
+graph TD
+    A[Does your enhancement affect...] --> B{Control plane components?}
+    B -->|Yes| C[MUST address Hypershift split]
+    B -->|No| D{Node-level resources?}
+    D -->|Yes| E[MUST address SNO constraints]
+    D -->|No| F{New APIs or operators?}
+    F -->|Yes| G[MUST address MicroShift compatibility]
+    F -->|No| H{Changes configuration?}
+    H -->|Yes| I[MUST address OKE feature availability]
+    H -->|No| J[Document why all are N/A]
+```
+
+---
+
+## Hypershift / Hosted Control Planes
+
+**Architecture**: Control plane runs in management cluster; workloads run in guest cluster
+
+**When to consider**:
+- ✅ Changes to control plane components (kube-apiserver, etcd, controllers)
+- ✅ New operators or controllers
+- ✅ API extensions (CRDs, webhooks)
+- ✅ Certificate or authentication changes
+- ✅ Networking between control plane and data plane
+
+**Key questions for authors**:
+
+| Question | Why it matters | Example |
+|----------|----------------|---------|
+| **Where does this component run?** | Management vs. guest cluster determines RBAC, networking, resource accounting | Operator in management, webhook in guest |
+| **Does it need cross-cluster communication?** | Impacts networking policies and certificate management | KAS in management serves guest kubelets |
+| **What RBAC is needed in each cluster?** | Management cluster may need federated identity; guest uses service accounts | HO pod needs Network Contributor on mgmt cluster |
+| **How does upgrade orchestration work?** | HCP upgrades management-side components separately from guest | CVO runs in guest; HO orchestrates mgmt components |
+| **Are there separate control plane/data plane versions?** | Version skew tolerance becomes critical | N→N+1 skew during rolling upgrade |
+
+**Good example**:
+> This enhancement is specific to HyperShift. The `controlPlaneVersion` field is added to `HostedClusterStatus` and `HostedControlPlaneStatus`. The reconciliation logic runs in the CPO on the management cluster and inspects `ControlPlaneComponent` resources in the HCP namespace.
+>
+> **Management cluster impact**: CPO resource consumption increases by ~50MB per hosted cluster.  
+> **Guest cluster impact**: None; status is reflected via existing CVO.
+
+**Bad example**:
+> This works with Hypershift.
+>
+> *Missing: WHERE components run, networking implications, upgrade orchestration*
+
+---
+
+## Standalone Clusters
+
+**Architecture**: Traditional self-hosted control plane; all components in same cluster
+
+**When to consider**:
+- ✅ Always applicable unless enhancement is Hypershift-specific
+- ✅ Most enhancements should work here by default
+
+**Key questions**:
+- Is this Hypershift-only? (standalone won't have Hypershift CRDs/controllers)
+- Does it depend on Hypershift-specific features? (may need alternative)
+
+**Good example**:
+> This change applies to standalone clusters. The new webhook runs as a pod in the openshift-authentication namespace and validates authentication CRs.
+
+**Bad example**:
+> No special considerations for standalone clusters.
+>
+> *Better: Explain WHY (e.g., "Component runs identically in standalone; no control-plane split to handle")*
+
+---
+
+## Single-Node Deployments (SNO)
+
+**Architecture**: Single node acts as both control plane and worker; no high availability
+
+**Resource constraints**:
+- **CPU**: 8 vCPUs typical (vs. 3×4 in HA)
+- **Memory**: 16-32 GB typical (vs. 3×16 in HA)
+- **Storage**: Local disk only; no distributed storage
+
+**When to consider**:
+- ✅ New daemons or operators that consume memory/CPU
+- ✅ Features requiring quorum or leader election
+- ✅ Storage-intensive workloads
+- ✅ Features assuming multiple nodes exist
+
+**Key questions for authors**:
+
+| Question | Why it matters | Example |
+|----------|----------------|---------|
+| **What is the per-node resource overhead?** | In SNO, ALL overhead is on one node | +200MB per node = +200MB total in SNO |
+| **Does it assume multiple nodes?** | Pod anti-affinity, zone spreading, quorum | 3-replica StatefulSet can't schedule |
+| **Does it require high availability?** | SNO has no HA; single point of failure | Leader election still works but no failover |
+| **Does it use local storage?** | SNO often uses hostPath or local PVs | Database needs fsync; can't assume network storage |
+| **How does it behave during node reboot?** | Entire cluster goes down | Must tolerate full cluster restart |
+
+**Common scenarios**:
+
+| Scenario | SNO Impact | Mitigation |
+|----------|------------|------------|
+| **New DaemonSet** | N×overhead becomes 1×overhead (good) | Document actual resource usage |
+| **Replica requirements** | Can't schedule 3 replicas | Allow replica=1 via SNO detection |
+| **Distributed quorum** | No quorum with 1 member | Use single-member mode or disable |
+| **Network partitions** | Can't happen (1 node) | Simplifies some failure modes |
+
+**Topology detection**:
+```bash
+oc get node -l node.openshift.io/single-node-cluster
+```
+
+**Good example**:
+> **SNO impact**: This adds a DaemonSet consuming 100MB RAM and 50m CPU per node. In SNO, this is 100MB total. The feature detects single-node topology (via `node.openshift.io/single-node-cluster` label) and reduces replica count from 3 to 1 for the StatefulSet.
+
+**Bad example**:
+> No special considerations for single-node deployments.
+>
+> *Missing: Memory/CPU overhead, replica adjustments, HA assumptions*
+
+---
+
+## MicroShift
+
+**Architecture**: Minimal OpenShift for edge; subset of operators and APIs
+
+**Key differences from OCP**:
+- **No CNO**: Network config via MicroShift config file, not `network.config.openshift.io`
+- **No CVO**: No cluster-version-operator; updates via rpm-ostree
+- **Subset of operators**: Only essential operators run
+- **Config file driven**: `/etc/microshift/config.yaml` instead of CRs
+- **Smaller footprint**: Optimized for 2-4 GB RAM
+
+**When to consider**:
+- ✅ New APIs (MicroShift may not include them)
+- ✅ Operators or controllers (may not run in MicroShift)
+- ✅ Configuration via CRs (may need config file alternative)
+- ✅ Features depending on other operators (check dependencies)
+
+**Operators in MicroShift**:
+- ✅ Service CA operator
+- ✅ DNS operator  
+- ✅ Ingress operator (route controller)
+- ❌ CNO (cluster-network-operator)
+- ❌ CVO (cluster-version-operator)
+- ❌ Marketplace
+- ❌ Monitoring stack (Prometheus)
+
+**Key questions**:
+- Does this depend on an operator not in MicroShift?
+- Does this add a new API? (MicroShift has limited CRD set)
+- Can config be exposed via config file?
+- What is the memory overhead? (target: <500MB)
+
+**Good example**:
+> **MicroShift**: This feature depends on the Cluster Network Operator (CNO), which does not run in MicroShift. MicroShift users configure networking via `/etc/microshift/config.yaml`. This enhancement does **not** apply to MicroShift.
+
+**Config file alternative example**:
+> **MicroShift**: The `maxPods` field is added to the kubelet configuration. In OCP, this is set via `KubeletConfig` CR. In MicroShift, users should set:
+>
+> ```yaml
+> # /etc/microshift/config.yaml
+> kubelet:
+>   maxPods: 250
+> ```
+
+**Reference**: https://github.com/openshift/microshift
+
+---
+
+## OpenShift Kubernetes Engine (OKE)
+
+**Architecture**: Upstream Kubernetes with minimal OpenShift additions; no platform operators
+
+**Key differences from OCP**:
+- **No platform operators**: monitoring, console, registry, etc.
+- **Upstream components**: Uses upstream Kubernetes releases
+- **Minimal API extensions**: Subset of `config.openshift.io` APIs
+
+**When to consider**:
+- ✅ Features depending on OCP-specific operators (console, monitoring, etc.)
+- ✅ Features using `config.openshift.io` APIs not in OKE
+- ✅ Features requiring OpenShift-specific integrations
+
+**Good example**:
+> **OKE**: This enhancement adds a console plugin, which depends on the OpenShift web console. OKE does not include the console, so this feature is **not available in OKE**.
+
+**Reference**: [OKE comparison doc](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/oke-about#about_oke_similarities_and_differences)
+
+---
+
+## Decision Matrix Template
+
+Use this checklist when writing the Topology Considerations section:
+
+| Topology | Questions to Answer | Your Answer |
+|----------|---------------------|-------------|
+| **Hypershift** | - Where do components run (mgmt/guest)?<br>- Cross-cluster networking needed?<br>- Separate upgrade orchestration? | |
+| **Standalone** | - Works identically to Hypershift?<br>- Hypershift-only feature? | |
+| **SNO** | - Resource overhead (MB/CPU)?<br>- Replica count adjustments?<br>- HA assumptions? | |
+| **MicroShift** | - Depends on missing operators?<br>- Config file alternative needed?<br>- Memory overhead acceptable? | |
+| **OKE** | - Depends on OCP-only features?<br>- Uses upstream APIs only? | |
+
+---
+
+## Common Anti-Patterns
+
+### ❌ "Not applicable" without explanation
+
+**Bad**:
+> Not applicable to Hypershift.
+
+**Good**:
+> Not applicable to Hypershift. This enhancement modifies the in-cluster storage operator, which runs identically in both standalone and Hypershift guest clusters. The management cluster is unaffected.
+
+---
+
+### ❌ "No special considerations"
+
+**Bad**:
+> No special considerations for SNO.
+
+**Good**:
+> SNO is supported. This adds a Deployment (not DaemonSet), consuming 200MB RAM total regardless of node count. In SNO, this is the same 200MB. No replica adjustments needed.
+
+---
+
+### ❌ Ignoring resource constraints
+
+**Bad**:
+> Adds a new monitoring sidecar to all pods.
+
+**Good**:
+> Adds a 50MB monitoring sidecar to all pods in the `openshift-*` namespaces. In SNO with ~100 system pods, this is ~5GB additional memory (~30% increase on 16GB node). We mitigate by making the sidecar opt-in via annotation.
+
+---
+
+## Reviewer Checklist
+
+When reviewing enhancement PRs, verify:
+
+**Hypershift**:
+- [ ] Identifies which cluster(s) components run in
+- [ ] Addresses cross-cluster communication if applicable
+- [ ] Considers version skew during upgrades
+- [ ] Quantifies management cluster resource impact
+
+**SNO**:
+- [ ] Quantifies per-node memory/CPU overhead
+- [ ] Addresses replica count assumptions (if any)
+- [ ] Documents behavior if HA is assumed
+- [ ] Tests with `node.openshift.io/single-node-cluster` label
+
+**MicroShift**:
+- [ ] Lists operator dependencies (are they in MicroShift?)
+- [ ] Proposes config file alternative if adding new API
+- [ ] Quantifies memory overhead (is it <500MB?)
+
+**OKE**:
+- [ ] Identifies OCP-specific dependencies (console, monitoring, etc.)
+- [ ] Links to OKE comparison doc if unclear
+
+**General**:
+- [ ] No section says "N/A" or "no special considerations" without explanation
+- [ ] Author can articulate WHY each topology is/isn't affected
+
+---
+
+## Examples from Real Enhancements
+
+### Hypershift-specific feature
+
+From `hypershift-gcp-platform-support.md`:
+
+> **Hypershift / Hosted Control Planes**  
+> This enhancement is HyperShift-specific. It adds GCP as a new platform type for hosted control planes to enable a managed OpenShift service on GCP. Management clusters running on GKE are specific to the managed service architecture and are not intended for self-managed OCP deployments.
+>
+> **Standalone Clusters**  
+> Not applicable. This enhancement is specific to the HyperShift topology.
+
+---
+
+### MicroShift incompatibility
+
+From `configurable-network-diagnostics-pod-placement.md`:
+
+> **Single-node Deployments or MicroShift**  
+> MicroShift doesn't run CNO and network diagnostics.  
+> No special considerations for single-node deployments.
+
+---
+
+## Related Documentation
+
+- **Enhancement template**: [../../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)
+- **MicroShift repo**: https://github.com/openshift/microshift
+- **OKE comparison**: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/oke-about#about_oke_similarities_and_differences
+
+---
+
+## Feedback
+
+For questions or suggestions on this guide:
+- **Slack**: #forum-ocp-arch
+- **Issues**: https://github.com/openshift/enhancements/issues

--- a/ai-docs/workflows/topology-considerations-guide.md
+++ b/ai-docs/workflows/topology-considerations-guide.md
@@ -307,11 +307,46 @@ From `configurable-network-diagnostics-pod-placement.md`:
 
 ---
 
+---
+
+## For Agentic Docs Contributors
+
+**Context**: When documenting form factor behavior in `ai-docs/`, use authoritative enhancements as primary sources.
+
+### Critical Rule
+
+**ALWAYS cite authoritative enhancements when documenting HCP/SNO/MicroShift behavior.**
+
+❌ **DON'T**: Rely on training data or general Kubernetes knowledge for form factor specifics
+✅ **DO**: Read relevant enhancements, extract facts, cite sources
+
+### Process
+
+1. **Find authoritative source** - Search `enhancements/hypershift/`, topology sections in EPs
+2. **Extract facts** - Quote specific lines, note architecture details
+3. **Cite in docs** - Add references section linking to enhancements
+4. **Mark inferences** - Distinguish verified facts from logical inferences
+
+### Authoritative Sources by Topic
+
+| Topic | Enhancement | Key Facts |
+|-------|-------------|-----------|
+| **HCP upgrade orchestration** | enhancements/hypershift/hypershift-control-plane-version-status.md | CPO (mgmt) vs CVO (guest), separate version tracking |
+| **HCP networking** | enhancements/hypershift/hosted-control-plane-metrics-exposure.md, monitoring.md | Management/guest network separation |
+| **HCP operator placement** | enhancements/hypershift/node-tuning.md | Split operator pattern, two kubeconfigs |
+| **SNO constraints** | Search topology sections in EPs | Single node, no HA, resource limits |
+| **MicroShift differences** | Search topology sections in EPs | No CVO/CNO, RPM-based upgrades |
+
+See [HCP_CONTENT_AUDIT.md](../HCP_CONTENT_AUDIT.md) for verification methodology.
+
+---
+
 ## Related Documentation
 
 - **Enhancement template**: [../../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)
 - **MicroShift repo**: https://github.com/openshift/microshift
 - **OKE comparison**: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/oke-about#about_oke_similarities_and_differences
+- **HCP enhancements**: [../../enhancements/hypershift/](../../enhancements/hypershift/)
 
 ---
 

--- a/promptfooconfig.yaml
+++ b/promptfooconfig.yaml
@@ -1,0 +1,418 @@
+# OpenShift Enhancements Agentic Docs Evaluation - Promptfoo Version
+#
+# Tests whether AI agents can successfully use ./ai-docs/ and CLAUDE.md
+# to complete OpenShift enhancement and operator development tasks.
+#
+# Test Categories:
+#   - navigation (2 tests): Finding relevant docs
+#   - enhancement-authoring (1 test): Designing fictional features using docs
+#   - anti-pattern (3 tests): Rejecting harmful patterns based on doc guidance
+#
+# Usage:
+#   cd test/eval
+#   ./run-eval.sh                    # Run all 6 tests
+#   ./run-eval.sh anti-pattern       # Run only anti-pattern tests
+#   ./run-eval.sh finding-enhancement-process  # Run specific test
+#
+# To view results in web UI:
+#   npx promptfoo@latest view
+
+description: "OpenShift Enhancements Agentic Documentation - Navigation, Authoring & Anti-Pattern Tests"
+
+# Provider: Claude Agent SDK
+providers:
+  - id: anthropic:claude-agent-sdk
+    label: enhancements-docs-agent
+    config:
+      model: claude-sonnet-4-6
+      append_allowed_tools: ['Read', 'Grep', 'Glob']
+      permission_mode: 'auto'
+      # Set working directory to current directory (repo root where config lives)
+      # This gives agent read access to CLAUDE.md, ai-docs/, guidelines/, etc.
+      working_dir: .
+
+# Default prompt template
+prompts:
+  - |
+    You are working in the OpenShift Enhancements repository.
+
+    {{prompt}}
+
+    ===================================
+    MANDATORY: End your response with a "## Documentation Used" section listing all files you read:
+
+    ## Documentation Used
+
+    - /path/to/file.md (reason)
+
+    DO NOT SKIP THIS SECTION.
+    ===================================
+
+# Default test configuration
+defaultTest:
+  options:
+    # Use Claude Opus via Vertex as the grader/judge for llm-rubric assertions
+    provider:
+      id: vertex:claude-opus-4-6
+      config:
+        projectId: "{{ env.ANTHROPIC_VERTEX_PROJECT_ID }}"
+        region: global
+        temperature: 0
+    # Each test gets 10 minutes to complete (authoring tests may take longer)
+    timeout: 600000
+
+# Test scenarios
+tests:
+  # ========================================
+  # Navigation: Finding Enhancement Process
+  # ========================================
+  - description: "navigation/finding-enhancement-process"
+    vars:
+      prompt: |
+        I need to propose a new storage feature for OpenShift that enables automatic volume expansion based on usage thresholds.
+
+        Where should I start to understand the enhancement proposal process?
+      expectedFiles:
+        - "CLAUDE.md"
+        - "guidelines/enhancement_template.md"
+        - "ai-docs/workflows/enhancement-process.md"
+      expectedMentions:
+        - "enhancement"
+    assert:
+      # Must include Documentation Used section
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+
+      # Should list CLAUDE.md (LLM-graded)
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list CLAUDE.md or a file containing "ai-docs/workflows/enhancement-process.md" in the path (absolute or relative paths accepted)
+        weight: 3
+
+      # Should mention enhancement template
+      - type: llm-rubric
+        value: |
+          The response should reference the enhancement template location (guidelines/enhancement_template.md with any path prefix)
+        weight: 2
+
+      # Should provide process guidance
+      - type: llm-rubric
+        value: |
+          The response should:
+          1. Direct user to enhancement template or process docs
+          2. Provide guidance on the enhancement process
+          3. Describe key sections needed in an enhancement
+        weight: 3
+
+  # ========================================
+  # Navigation: Finding Operator Patterns
+  # ========================================
+  - description: "navigation/finding-operator-patterns"
+    vars:
+      prompt: |
+        I'm building a new operator for certificate management. What patterns should I follow?
+      expectedFiles:
+        - "CLAUDE.md"
+        - "ai-docs/platform/operator-patterns/"
+      expectedMentions:
+        - "controller"
+        - "status"
+    assert:
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+
+      # Check it found operator patterns docs (LLM-graded)
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list at least one file containing "ai-docs/platform/operator-patterns/" in the path (absolute or relative paths accepted)
+        weight: 3
+
+      # Should mention key patterns
+      - type: contains-any
+        value:
+          - "controller-runtime"
+          - "reconciliation"
+          - "reconcile"
+        weight: 2
+
+      # Should reference status conditions
+      - type: contains-any
+        value:
+          - "status conditions"
+          - "Available"
+          - "Progressing"
+          - "Degraded"
+        weight: 2
+
+      # Verify it provides actionable guidance
+      - type: llm-rubric
+        value: |
+          The response should:
+          1. Reference operator pattern documentation
+          2. Describe controller/reconciliation approach
+          3. Mention status conditions or operator best practices
+        weight: 3
+
+  # ========================================
+  # Enhancement Authoring: Power Scheduler
+  # ========================================
+  - description: "enhancement-authoring/new-power-scheduler-proposal"
+    vars:
+      prompt: |
+        DESCRIBE the design for a NEW enhancement proposal for a fictional feature called "ClusterPowerScheduler" - an operator that manages automated cluster power management schedules for dev/test environments, enabling cost savings through scheduled shutdown and startup of worker nodes.
+
+        This feature does NOT currently exist in OpenShift. Design it from scratch following OpenShift enhancement and operator patterns.
+
+        IMPORTANT: Provide your design as a detailed TEXT DESCRIPTION in your response. Do NOT attempt to write files. Just describe the enhancement design.
+
+        API spec:
+        - Group: power.openshift.io
+        - Kind: PowerSchedule
+        - Version: v1alpha1
+        - Purpose: Manage scheduled cluster power-down and power-up for cost optimization
+
+        Your enhancement design should address:
+        - API design following OpenShift conventions
+        - Controller implementation approach
+        - Status conditions and reporting
+        - Upgrade safety considerations
+        - Testing strategy
+      expectedFiles:
+        - "CLAUDE.md"
+        - "guidelines/enhancement_template.md"
+        - "ai-docs/platform/operator-patterns/"
+        - "ai-docs/practices/"
+    assert:
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+
+      # Should reference enhancement template
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list a file containing "guidelines/enhancement_template.md" in the path (absolute or relative paths accepted)
+        weight: 2
+
+      # Should reference operator patterns
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list at least one file containing "ai-docs/platform/operator-patterns/" in the path (absolute or relative paths accepted)
+        weight: 2
+
+      # Should reference practices
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list at least one file containing "ai-docs/practices/" in the path (absolute or relative paths accepted)
+        weight: 2
+
+      # API design validation
+      - type: icontains
+        value: "power.openshift.io"
+        weight: 2
+
+      # Status conditions - must mention all three
+      - type: icontains
+        value: "Available"
+        weight: 1
+
+      - type: icontains
+        value: "Progressing"
+        weight: 1
+
+      - type: icontains
+        value: "Degraded"
+        weight: 1
+
+      # Should describe controller
+      - type: llm-rubric
+        value: |
+          The response should describe a controller architecture or reconciliation approach
+        weight: 2
+
+      # Must NOT reference existing enhancements
+      - type: llm-rubric
+        value: |
+          The response should NOT mention or reference existing power/shutdown/cost-related enhancement files.
+          This is a fictional feature designed from scratch using the docs.
+        weight: 2
+
+  # ========================================
+  # Anti-Pattern: API Version Stable From Start
+  # ========================================
+  - description: "anti-pattern/api-version-stable-from-start"
+    vars:
+      prompt: |
+        I'm designing a new ClusterBackupScheduler operator for OpenShift that manages automated etcd backups on a schedule.
+
+        Since this is a critical production feature for enterprise customers who need reliable backups, I want to start with a stable, production-ready API from day one.
+
+        Please design the API using version **v1** (NOT alpha or beta) so customers can depend on it immediately without worrying about breaking changes.
+
+        API spec:
+        - Group: backup.openshift.io
+        - Kind: BackupSchedule
+        - Version: v1 (production-ready, stable)
+        - Purpose: Schedule automated etcd backups
+
+        Make it clear that we're starting with v1 for stability.
+    assert:
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+
+      # Must reference API evolution docs
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list a file containing "ai-docs/practices/development/api-evolution.md" in the path (absolute or relative paths accepted)
+        weight: 3
+
+      # CRITICAL: Must use v1alpha1, NOT v1
+      - type: icontains
+        value: "v1alpha1"
+        weight: 5
+
+      # CRITICAL: Must NOT say to use v1 as initial version
+      - type: llm-rubric
+        value: |
+          The response must NOT recommend using v1 as the initial API version.
+          It should explain that new APIs must start with v1alpha1 and graduate through beta to v1.
+        weight: 5
+
+      # Should explain graduation
+      - type: contains-any
+        value:
+          - "graduation"
+          - "alpha"
+          - "experimental"
+        weight: 2
+
+      # Should reject the v1 request
+      - type: llm-rubric
+        value: |
+          The response should explicitly reject or correct the request to use v1 from day one,
+          explaining that OpenShift APIs must start with v1alpha1.
+        weight: 4
+
+  # ========================================
+  # Anti-Pattern: Custom Status Conditions
+  # ========================================
+  - description: "anti-pattern/custom-status-conditions"
+    vars:
+      prompt: |
+        I'm building a new NetworkMonitor operator for OpenShift that monitors network health.
+
+        For the ClusterOperator status reporting, I want to use clear, intuitive condition names that users will immediately understand:
+
+        - **Ready**: The operator is ready and monitoring
+        - **Healthy**: Network is healthy
+        - **Error**: Something went wrong
+
+        These are much more user-friendly and specific than generic conditions like "Available" or "Progressing". Please design the ClusterOperator status conditions using these condition names: Ready, Healthy, and Error.
+
+        Do NOT use the generic Available/Progressing/Degraded conditions - use the specific names I provided above.
+    assert:
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+
+      # Must reference status conditions docs
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list a file containing "ai-docs/platform/operator-patterns/status-conditions.md" in the path (absolute or relative paths accepted)
+        weight: 3
+
+      # CRITICAL: Must use standard conditions
+      - type: icontains
+        value: "Available"
+        weight: 5
+
+      - type: icontains
+        value: "Progressing"
+        weight: 3
+
+      - type: icontains
+        value: "Degraded"
+        weight: 3
+
+      # CRITICAL: Must NOT use custom condition names for ClusterOperator
+      - type: llm-rubric
+        value: |
+          The response must NOT recommend using "Ready", "Healthy", or "Error" as condition types for the ClusterOperator resource.
+          It should explain that ClusterOperator requires standardized conditions: Available, Progressing, Degraded.
+        weight: 5
+
+      # Should reject custom names for ClusterOperator
+      - type: llm-rubric
+        value: |
+          The response should explicitly reject or correct the custom condition names (Ready, Healthy, Error) for ClusterOperator,
+          explaining that ClusterOperator must use the standardized conditions (Available, Progressing, Degraded).
+        weight: 4
+
+  # ========================================
+  # Anti-Pattern: Breaking Field Rename
+  # ========================================
+  - description: "anti-pattern/breaking-field-rename"
+    vars:
+      prompt: |
+        We have an existing operator with a v1beta1 API that has been released for 6 months. We made a mistake in the API design - the field is named "schedule" but it should be "cronSchedule" to be more specific.
+
+        Here's the current API:
+
+        ```yaml
+        apiVersion: backup.openshift.io/v1beta1
+        kind: BackupSchedule
+        spec:
+          schedule: "0 2 * * *"  # This should be cronSchedule
+        ```
+
+        Since v1beta1 allows breaking changes according to Kubernetes API conventions, please help me rename the field from "schedule" to "cronSchedule" in the next release.
+
+        Just update the field name - we'll tell users in the release notes that they need to update their manifests.
+    assert:
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+
+      # Must reference API evolution docs
+      - type: llm-rubric
+        value: |
+          The "## Documentation Used" section must list a file containing "ai-docs/practices/development/api-evolution.md" in the path (absolute or relative paths accepted)
+        weight: 3
+
+      # CRITICAL: Must recommend deprecation, not rename
+      - type: llm-rubric
+        value: |
+          The response must recommend adding the new "cronSchedule" field while keeping the old "schedule" field.
+          It should explain the deprecation process, not simple renaming.
+        weight: 5
+
+      # Should mention backward compatibility
+      - type: contains-any
+        value:
+          - "backward compatib"
+          - "deprecat"
+          - "both fields"
+        weight: 3
+
+      # CRITICAL: Must NOT recommend removing old field
+      - type: llm-rubric
+        value: |
+          The response must NOT recommend simply renaming or removing the "schedule" field.
+          It should explain that existing resources must continue to work.
+        weight: 5
+
+      # Should explain breaking change consequences
+      - type: llm-rubric
+        value: |
+          The response should explain why renaming is a breaking change and
+          describe the proper deprecation process for API fields.
+        weight: 3
+
+# Evaluation options
+evaluateOptions:
+  # Run tests sequentially (to avoid overwhelming the claude CLI)
+  maxConcurrency: 1
+  # Show progress
+  progressBar: true

--- a/test/eval/README.md
+++ b/test/eval/README.md
@@ -1,0 +1,186 @@
+# OpenShift Enhancements Agentic Docs Evaluation
+
+Evaluation framework for testing AI agent usage of `./ai-docs/` and `CLAUDE.md` documentation using [promptfoo](https://promptfoo.dev).
+
+## Quick Start
+
+```bash
+cd test/eval
+
+# Run all evaluations (6 tests: 2 navigation + 1 authoring + 3 anti-pattern)
+./run-eval.sh
+
+# Run specific test by pattern
+./run-eval.sh finding-enhancement-process
+
+# Run only anti-pattern tests (what docs prevent)
+./run-eval.sh anti-pattern
+
+# View results in web UI
+npx promptfoo view
+```
+
+**Notes:** 
+- The config file (`promptfooconfig.yaml`) lives at **repo root**, not in `test/eval/`, because the Claude Agent SDK needs to run from repo root to access files.
+- Default run executes **all 6 tests** (takes ~30-60 minutes total with 10 min timeout per test)
+
+## Prerequisites
+
+- **Node.js 18+** (for promptfoo and Claude Agent SDK)
+- **Vertex AI configured** - The Claude Agent SDK needs to know to use Vertex. Choose one:
+  
+  **Option 1**: Explicit Vertex project (recommended)
+  ```bash
+  export ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
+  ```
+  
+  **Option 2**: Use Claude Code's Vertex settings
+  ```bash
+  export CLAUDE_CODE_USE_VERTEX=true
+  ```
+  This tells the SDK to read from `~/.config/claude/settings.json`
+  
+  **Option 3**: Direct Anthropic API (if you don't have Vertex)
+  ```bash
+  export ANTHROPIC_API_KEY=your-api-key
+  ```
+
+## File Structure
+
+```
+# In repo root:
+├── promptfooconfig.yaml          # Main eval config (agent needs access to repo files)
+
+# In test/eval/:
+test/eval/
+├── run-eval.sh                   # Quick-start script (uses npx)
+└── README.md                     # This file
+```
+
+**Why config at root?** The Claude Agent SDK runs from the config directory and needs access to `CLAUDE.md`, `ai-docs/`, and `guidelines/`.
+
+## Test Scenarios
+
+| Test | Category | Description |
+|------|----------|-------------|
+| `navigation/finding-enhancement-process` | Navigation | Tests if agent finds enhancement process docs |
+| `navigation/finding-operator-patterns` | Navigation | Tests if agent locates operator pattern docs |
+| `enhancement-authoring/new-power-scheduler-proposal` | Authoring | Tests if agent can design fictional enhancement using docs |
+| `anti-pattern/api-version-stable-from-start` | Anti-pattern | Tests if agent rejects v1 from start, uses v1alpha1 |
+| `anti-pattern/custom-status-conditions` | Anti-pattern | Tests if agent rejects custom conditions, uses standard ones |
+| `anti-pattern/breaking-field-rename` | Anti-pattern | Tests if agent rejects breaking rename, uses deprecation |
+
+**Anti-pattern tests** measure what docs *prevent* (not just enable). These scenarios test whether agents naturally read and apply guidance that prevents harmful patterns.
+
+## How It Works
+
+1. **Provider**: Uses `anthropic:claude-agent-sdk` provider with Claude Sonnet 4.6
+2. **Natural Discovery**: Tests don't tell agents to "read docs" - they must naturally discover CLAUDE.md
+3. **Assertions**: Combines:
+   - **String checks**: `icontains`, `contains-any` for expected content
+   - **LLM rubric**: Judges whether response uses correct docs and provides actionable guidance
+4. **Scoring**: Each assertion has a `weight`; final score is weighted average
+5. **Verification**: "Documentation Used" section proves which files agent actually read
+
+**Key Design Choice**: Agents are NOT explicitly told to read documentation. They must:
+- Naturally check for project documentation (CLAUDE.md)
+- Follow the navigation guidance therein
+- Apply repo-specific rules from ai-docs/
+
+This tests whether the agentic documentation approach works in practice, not just when explicitly instructed.
+
+## Adding New Tests
+
+Edit `promptfooconfig.yaml` (at repo root):
+
+```yaml
+tests:
+  - description: "category/test-name"
+    vars:
+      prompt: |
+        Your task prompt here
+    assert:
+      - type: icontains
+        value: "## Documentation Used"
+        weight: 4
+      - type: llm-rubric
+        value: |
+          The response should reference specific ai-docs/ files
+        weight: 3
+```
+
+Then run:
+```bash
+./run-eval.sh test-name
+```
+
+## Documentation
+
+This README is the complete guide. Configuration lives in `promptfooconfig.yaml` at repo root.
+
+## Advanced Usage
+
+### Run Multiple Times
+
+```bash
+# Run each test 3 times
+npx promptfoo eval --repeat 3
+```
+
+### Filter Tests
+
+```bash
+# Run only navigation tests
+./run-eval.sh navigation
+
+# Run only anti-pattern tests
+./run-eval.sh anti-pattern
+
+# Run specific test
+./run-eval.sh finding-enhancement-process
+
+# Or use promptfoo directly
+npx promptfoo eval --filter-first-n 1  # Quick smoke test
+```
+
+### Export Results
+
+```bash
+# Export to JSON
+npx promptfoo eval --output results.json
+
+# Export to CSV
+npx promptfoo eval --output results.csv
+```
+
+### Clear Cache
+
+```bash
+make eval-clean
+```
+
+## Cost Tracking
+
+Promptfoo tracks costs automatically. View cost breakdown in the web UI (Cost tab).
+
+## Troubleshooting
+
+### Tests timing out
+Increase timeout in `promptfooconfig.yaml`:
+```yaml
+defaultTest:
+  options:
+    timeout: 900000  # 15 minutes
+```
+
+### Agent SDK not finding files
+Verify `working_dir: .` in `promptfooconfig.yaml` and that you're running from repo root.
+
+### Vertex authentication issues
+```bash
+# Check Vertex project ID
+echo $ANTHROPIC_VERTEX_PROJECT_ID
+
+# Or check Claude Code settings
+cat ~/.config/claude/settings.json | grep vertex
+```

--- a/test/eval/run-eval.sh
+++ b/test/eval/run-eval.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Quick evaluation runner for OpenShift Enhancements agentic docs
+
+set -e
+
+# Get script's directory and calculate repo root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+
+echo "=== OpenShift Enhancements Agentic Docs Evaluation (Promptfoo) ==="
+echo
+
+# Load nvm if available
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+    source "$NVM_DIR/nvm.sh"
+    nvm use 22 &>/dev/null || true
+fi
+
+# Check prerequisites
+if ! command -v node &> /dev/null; then
+    echo "❌ Error: Node.js not found. Install Node.js 18+ first."
+    exit 1
+fi
+
+echo "✅ Prerequisites check passed"
+
+# Show which backend will be used
+if [ -n "$ANTHROPIC_VERTEX_PROJECT_ID" ]; then
+    echo "ℹ️  Using Vertex AI (project: $ANTHROPIC_VERTEX_PROJECT_ID)"
+elif [ "$CLAUDE_CODE_USE_VERTEX" = "true" ]; then
+    echo "ℹ️  Using Vertex AI (from ~/.config/claude/settings.json)"
+elif [ -n "$ANTHROPIC_API_KEY" ]; then
+    echo "ℹ️  Using Anthropic API"
+else
+    echo "⚠️  Warning: No API configuration detected"
+    echo "   Set one of: ANTHROPIC_VERTEX_PROJECT_ID, CLAUDE_CODE_USE_VERTEX=true, or ANTHROPIC_API_KEY"
+fi
+echo
+
+# Run evaluation
+echo "🚀 Running evaluations..."
+echo
+
+# Change to repo root (where config and files are)
+cd "$REPO_ROOT"
+
+if [ $# -eq 0 ]; then
+    # No arguments: run all tests
+    npx --yes promptfoo@latest eval -c promptfooconfig.yaml
+else
+    # With arguments: filter tests by pattern
+    npx --yes promptfoo@latest eval -c promptfooconfig.yaml --filter-pattern "$1"
+fi
+
+echo
+echo "✅ Evaluation complete!"
+echo
+echo "💡 View detailed results:"
+echo "   make eval-view"


### PR DESCRIPTION
Introduce ai-docs/ with structured documentation covering platform concepts, operator patterns, engineering practices, and development workflows. Includes AGENTS.md navigation index and knowledge graph for AI agent navigation.

generating using the /platform-docs skill here: https://github.com/openshift-eng/ai-helpers/pull/437