### PR TITLE
NO-JIRA: Clarify the secretref datakey structure reason

### DIFF
--- a/enhancements/kube-apiserver/kms-encryption-foundations.md
+++ b/enhancements/kube-apiserver/kms-encryption-foundations.md
@@ -94,6 +94,8 @@ Encryption controllers split the KMS configuration API into multiple parts store
 3. `kms-secret-{key}-{keyID}` — individual keys from the referenced Secret are stored as separate entries (e.g., `kms-secret-id-1`, `kms-secret-login-1`, `kms-secret-password-1` for Vault approle credentials)
 4. `kms-configmap-{key}-{keyID}` — individual keys from the referenced ConfigMap are stored as separate entries (e.g., `kms-configmap-ca-1` for CA bundles)
 
+   Credentials are stored as individual top-level keys rather than a single nested blob because the installer controller writes each `.data` key as a separate file on disk and the KMS plugin sidecar — a third-party binary — consumes credentials as individual files. Bundling them into one entry would require the sidecar to parse and extract them, which it cannot do.
+
    For example, an encryption-configuration secret with this layout:
    ```yaml
    apiVersion: v1


### PR DESCRIPTION
We decided to store the SecretRef content as separate data keys in the key Secret and the encryption-config Secret, rather than using a single structured data key for each keyID.

This PR documents the rationale in the EP. So I stop forgetting it and suggesting the nested structure idea over and over again.