### PR TITLE
NE-2732: Design proposal for Gateway API CRD management mode

### DIFF
--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -5,15 +5,14 @@ authors:
 reviewers:
   - "@Miciah"
   - "@gcs278"
-  - "@knobunc"
   - "@everettraven"
 approvers:
-  - "@knobunc"
+  - "@Miciah"
 api-approvers:
   - "@everettraven"
 creation-date: 2026-05-26
-last-updated: 2026-05-28
-status: provisional
+last-updated: 2026-06-12
+status: implementable
 tracking-link:
   - https://redhat.atlassian.net/browse/NE-2733
 see-also:

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -568,10 +568,19 @@ When CRDs are non-compliant, CIO reports the mismatch in the
 `GatewayAPICRDsCompliant` condition message, including expected vs. actual
 versions and where to obtain valid manifests. Valid CRD manifests
 are available from:
-- The `gateway-api` container image in the OpenShift release
-  payload at `/manifests/gateway-api/`.
+- The `cluster-ingress-operator` container image in the OpenShift
+  release payload, at `/gateway-api-manifests/` (see Support
+  Procedures for an extraction example).
 - The upstream Gateway API release at
   `https://github.com/kubernetes-sigs/gateway-api/releases`.
+
+#### Dockerfile Change to Bundle CRD Manifests
+
+The `cluster-ingress-operator` Dockerfile must be updated to copy
+the Gateway API CRD manifests into `/gateway-api-manifests/` in
+the built image, so that the exact CRD manifests CIO expects can
+be retrieved directly from the release payload (see Support
+Procedures) instead of only from the upstream Gateway API release.
 
 #### Mode Transition Ordering
 
@@ -879,9 +888,10 @@ Check the condition message for the expected and actual versions.
 
 **Resolution**: Either upgrade the CRDs to the expected version or
 remove them and let CIO reinstall them. Valid CRD manifests can be
-obtained from the `gateway-api` container image in the OpenShift
-release payload at `/manifests/gateway-api/`, or from the upstream
-Gateway API release at
+extracted from the `cluster-ingress-operator` container image in
+the cluster's current release payload (Gateway API CRD manifests
+are bundled at `/gateway-api-manifests/` in that image), or
+obtained from the upstream Gateway API release at
 `https://github.com/kubernetes-sigs/gateway-api/releases` matching
 the expected version shown in the condition message.
 
@@ -891,8 +901,24 @@ oc get ingress.operator.openshift.io cluster \
   -o jsonpath='{.status.conditions}' | \
   jq '.[] | select(.type=="GatewayAPICRDsCompliant")'
 
-# Remove CRDs to let CIO reinstall (WARNING: this deletes
-# all Gateway, HTTPRoute, and other Gateway API resources)
+# Authenticate to the release image registry using the cluster's
+# pull secret
+oc get secret/pull-secret -n openshift-config \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > pull-secret.json
+
+# Extract the Gateway API CRD manifests from the
+# cluster-ingress-operator image in the cluster's current
+# release payload
+CIO_IMAGE=$(oc adm release info --image-for=cluster-ingress-operator \
+  --registry-config=pull-secret.json)
+oc image extract "${CIO_IMAGE}" --registry-config=pull-secret.json \
+  --path /gateway-api-manifests/:./gateway-api-manifests --confirm
+
+# Apply the extracted CRDs to upgrade to the expected version
+oc apply -f ./gateway-api-manifests/
+
+# Alternatively, remove CRDs to let CIO reinstall (WARNING: this
+# deletes all Gateway, HTTPRoute, and other Gateway API resources)
 oc delete crd \
   gatewayclasses.gateway.networking.k8s.io \
   gateways.gateway.networking.k8s.io \

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -27,21 +27,34 @@ see-also:
 ## Summary
 
 This enhancement introduces a new `gatewayAPI` configuration struct
-on the `IngressController` API (`operator.openshift.io/v1`) that
-contains a `crdManagementMode` enum field controlling how the
-Cluster Ingress Operator (CIO) manages Gateway API Custom Resource
-Definitions (CRDs) and the associated Gateway controller stack
-(the Istio instance deployed by CIO, GatewayClass, Gateway
-resources). The enum exposes three modes -- `Managed`, `Unmanaged`,
-and `ExternalCRDs` -- enabling cluster administrators and
-third-party products to choose whether CIO fully owns the Gateway
-API CRDs and controller, delegates CRD ownership entirely to an
-external entity, or runs the OpenShift Gateway controller against
+on the cluster-scoped `Ingress` configuration resource
+(`ingress.config.openshift.io/cluster`) that contains a
+`crdManagementMode` enum field controlling how the Cluster Ingress
+Operator (CIO) manages Gateway API Custom Resource Definitions
+(CRDs) and the associated Gateway controller stack (the Istio
+instance deployed by CIO, GatewayClass, Gateway resources). The
+enum exposes three modes -- `Managed`, `Unmanaged`, and
+`ExternalCRDs` -- enabling cluster administrators and third-party
+products to choose whether CIO fully owns the Gateway API CRDs and
+controller, delegates CRD ownership entirely to an external entity,
+or runs the OpenShift Gateway controller against
 externally-provided CRDs. The `gatewayAPI` struct is designed to be
 extended in the future with additional Gateway API-related
-configuration fields. This gives customers the flexibility they
-need while preserving a clear, observable ownership model that CIO
-and support teams can reason about.
+configuration fields.
+
+The `ingress.config.openshift.io` API is the correct home for this
+setting because Gateway API CRD management is a cluster-wide,
+platform-level concern. CRDs are cluster-scoped resources, and the
+management mode must apply uniformly across the platform rather
+than being a per-IngressController decision. The
+`ingress.config.openshift.io/cluster` resource already serves as
+the authoritative source of platform-wide ingress configuration
+(base domain, load balancer platform defaults, HSTS policies) that
+the Cluster Ingress Operator watches and consumes to configure
+individual IngressControllers. Adding the Gateway API CRD
+management mode here follows the same established pattern and
+avoids the risk of conflicting configurations from multiple
+IngressController resources.
 
 ## Motivation
 
@@ -119,13 +132,14 @@ As a cluster administrator using the default configuration, I want
 OpenShift to continue automatically upgrading Gateway API CRDs during
 cluster upgrades so that I do not need to manage CRD versions myself,
 and I want the ownership state to be clearly reported in the
-IngressController status.
+`ingress.config.openshift.io/cluster` status.
 
 ### Goals
 
-1. Provide an explicit API field on the IngressController that
-   controls Gateway API CRD ownership with three modes: `Managed`,
-   `Unmanaged`, and `ExternalCRDs`.
+1. Provide an explicit API field on
+   `ingress.config.openshift.io/cluster` that controls Gateway API
+   CRD ownership with three modes: `Managed`, `Unmanaged`, and
+   `ExternalCRDs`.
 2. Enable customers and third-party products to take full control of
    Gateway API CRDs when needed, without fighting CIO's reconciler
    or VAP protections.
@@ -166,14 +180,21 @@ IngressController status.
 
 ## Proposal
 
-Add a new `gatewayAPI` struct field to the `IngressControllerSpec`
-that serves as a namespace for all Gateway API-related configuration.
-Initially, this struct contains a single `crdManagementMode` enum
-field with three values: `Managed` (default), `Unmanaged`, and
-`ExternalCRDs`. The struct is intentionally designed to be extensible so
-that future Gateway API configuration fields can be added without
-further API restructuring. The CIO will use the `crdManagementMode`
-field to determine its behavior regarding Gateway API CRD lifecycle
+Add a new `gatewayAPI` struct field to the `IngressSpec` of the
+cluster-scoped `Ingress` configuration resource
+(`ingress.config.openshift.io/cluster`). This struct serves as a
+namespace for all Gateway API-related platform configuration.
+Initially, it contains a single `crdManagementMode` enum field
+with three values: `Managed` (default), `Unmanaged`, and
+`ExternalCRDs`. The struct is intentionally designed to be
+extensible so that future Gateway API configuration fields can be
+added without further API restructuring.
+
+The Cluster Ingress Operator already watches the
+`ingress.config.openshift.io/cluster` resource and reconciles all
+IngressControllers when it changes. CIO will read the
+`spec.gatewayAPI.crdManagementMode` field from this resource to
+determine its behavior regarding Gateway API CRD lifecycle
 management and the Gateway controller stack (the Istio instance
 deployed by CIO, GatewayClass, Gateway resources).
 
@@ -212,7 +233,7 @@ IngressController resources and manages Gateway API components.
 #### Workflow 1: Default Managed Mode (No Action Required)
 
 1. The cluster administrator installs or upgrades OpenShift.
-2. CIO reads the `default` IngressController and observes that
+2. CIO reads the `ingress.config.openshift.io/cluster` resource and observes that
    `spec.gatewayAPI.crdManagementMode` is unset (defaults to
    `Managed`).
 3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
@@ -228,7 +249,7 @@ IngressController resources and manages Gateway API components.
 
 1. The cluster administrator decides to use a third-party Gateway
    API implementation.
-2. The cluster administrator edits the `default` IngressController:
+2. The cluster administrator edits the `ingress.config.openshift.io/cluster` resource:
    ```yaml
    spec:
      gatewayAPI:
@@ -252,7 +273,7 @@ IngressController resources and manages Gateway API components.
 
 1. The cluster administrator or developer wants to test with newer
    Gateway API CRDs while using the OpenShift Gateway controller.
-2. The cluster administrator edits the `default` IngressController:
+2. The cluster administrator edits the `ingress.config.openshift.io/cluster` resource:
    ```yaml
    spec:
      gatewayAPI:
@@ -279,7 +300,7 @@ IngressController resources and manages Gateway API components.
    configuration.
 2. The cluster administrator ensures the existing Gateway API CRDs
    match the version CIO expects, or removes them entirely.
-3. The cluster administrator edits the `default` IngressController:
+3. The cluster administrator edits the `ingress.config.openshift.io/cluster` resource:
    ```yaml
    spec:
      gatewayAPI:
@@ -299,13 +320,13 @@ IngressController resources and manages Gateway API components.
 ```mermaid
 sequenceDiagram
     participant Admin as Cluster Admin
-    participant IC as IngressController
+    participant IC as ingress.config.openshift.io/cluster
     participant CIO as Cluster Ingress Operator
     participant CRDs as Gateway API CRDs
     participant GW as Gateway Stack<br/>(CIO Istio/GatewayClass/Gateway)
 
     Note over Admin,GW: Workflow: Mode Transition
-    Admin->>IC: Set gatewayAPI.crdManagementMode
+    Admin->>IC: Set spec.gatewayAPI.crdManagementMode
 
     alt Managed (default)
         CIO->>CRDs: Install/upgrade CRDs + VAP
@@ -325,13 +346,34 @@ sequenceDiagram
 
 ### API Extensions
 
-This enhancement modifies the existing `IngressController` CRD
-(`operator.openshift.io/v1`) by adding new fields to the spec and
-new conditions to the status. No new CRDs, admission webhooks,
-conversion webhooks, aggregated API servers, or finalizers are
-introduced.
+This enhancement modifies the existing cluster-scoped `Ingress`
+resource (`ingress.config.openshift.io/cluster`, defined in
+`config/v1/types_ingress.go` in the `openshift/api` repository) by
+adding new fields to `IngressSpec` and `IngressStatus`. No new
+CRDs, admission webhooks, conversion webhooks, aggregated API
+servers, or finalizers are introduced.
 
-The proposed Go types are:
+**Why `ingress.config.openshift.io` instead of
+`operator.openshift.io` IngressController:**
+
+The `ingress.config.openshift.io/cluster` resource is the
+cluster-scoped singleton that holds platform-wide ingress
+configuration. It already contains settings that apply uniformly
+across the platform (base domain, load balancer platform defaults,
+HSTS policies) and is watched by CIO to configure individual
+IngressControllers. Gateway API CRD management is a cluster-wide
+concern because:
+
+1. CRDs are cluster-scoped Kubernetes resources -- there is exactly
+   one set of Gateway API CRDs per cluster.
+2. The management mode must be consistent across the platform. If
+   it lived on IngressController, multiple IngressControllers could
+   specify conflicting modes, creating undefined behavior.
+3. The `ingress.config.openshift.io/cluster` resource is already
+   the authoritative source that CIO watches for platform-level
+   ingress decisions, making it the natural integration point.
+
+The proposed Go types are (in `config/v1/types_ingress.go`):
 
 ```go
 // GatewayAPICRDManagementMode describes how the Cluster Ingress
@@ -364,11 +406,11 @@ const (
 	ExternalCRDsGatewayAPICRDs GatewayAPICRDManagementMode = "ExternalCRDs"
 )
 
-// GatewayAPIConfig holds configuration for Gateway API integration
-// in the Cluster Ingress Operator. This struct is designed to be
-// extended with additional Gateway API-related configuration
-// fields in the future.
-type GatewayAPIConfig struct {
+// GatewayAPIIngressConfig holds configuration for Gateway API
+// integration in the Cluster Ingress Operator. This struct is
+// designed to be extended with additional Gateway API-related
+// configuration fields in the future.
+type GatewayAPIIngressConfig struct {
 	// crdManagementMode specifies how the Cluster Ingress
 	// Operator manages Gateway API Custom Resource Definitions
 	// (CRDs) and the associated Gateway controller stack.
@@ -399,15 +441,15 @@ type GatewayAPIConfig struct {
 }
 ```
 
-The `GatewayAPIConfig` struct is added to the
-`IngressControllerSpec` as a value type (not a pointer). The field
-is mandatory and defaults to `Managed` mode. Once set, the
-administrator must change the mode to a different value rather than
-removing the field entirely:
+The `GatewayAPIIngressConfig` struct is added to `IngressSpec` as a
+value type (not a pointer). The field is mandatory and defaults to
+`Managed` mode. Once set, the administrator must change the mode
+to a different value rather than removing the field entirely:
 
 ```go
-type IngressControllerSpec struct {
-	// ... existing fields ...
+type IngressSpec struct {
+	// ... existing fields (domain, appsDomain, componentRoutes,
+	//     requiredHSTSPolicies, loadBalancer) ...
 
 	// gatewayAPI holds configuration for Gateway API integration,
 	// including how the Cluster Ingress Operator manages Gateway
@@ -417,7 +459,7 @@ type IngressControllerSpec struct {
 	//
 	// +required
 	// +openshift:enable:FeatureGate=GatewayAPICRDManagementMode
-	GatewayAPI GatewayAPIConfig `json:"gatewayAPI"`
+	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI"`
 }
 ```
 
@@ -431,20 +473,20 @@ This nesting under the `gatewayAPI` struct allows future fields
 such as `spec.gatewayAPI.someOtherSetting` to be added without
 further API restructuring.
 
-A new `gatewayAPI` struct is added to `IngressControllerStatus` to
-namespace all Gateway API-related status, mirroring the spec-side
-`gatewayAPI` struct. This keeps Gateway API conditions separate from
-the IngressController's top-level conditions and makes it easy for
+A new `gatewayAPI` struct is added to `IngressStatus` to namespace
+all Gateway API-related status, mirroring the spec-side `gatewayAPI`
+struct. This keeps Gateway API conditions separate from the
+Ingress resource's existing status fields and makes it easy for
 consumers to find all Gateway API state in one place.
 
 ```go
-// GatewayAPIStatus holds status information for Gateway API
+// GatewayAPIIngressStatus holds status information for Gateway API
 // integration managed by the Cluster Ingress Operator.
-type GatewayAPIStatus struct {
+type GatewayAPIIngressStatus struct {
 	// conditions is a list of conditions related to Gateway API
 	// CRD management and the Gateway controller stack. These
 	// conditions are scoped to Gateway API concerns and are
-	// separate from the IngressController's top-level conditions.
+	// separate from the Ingress resource's top-level status.
 	//
 	// Supported condition types are:
 	// * CRDsManaged - whether CIO is actively managing CRDs
@@ -458,19 +500,18 @@ type GatewayAPIStatus struct {
 }
 ```
 
-The `GatewayAPIStatus` struct is added to the
-`IngressControllerStatus`:
+The `GatewayAPIIngressStatus` struct is added to `IngressStatus`:
 
 ```go
-type IngressControllerStatus struct {
-	// ... existing fields ...
+type IngressStatus struct {
+	// ... existing fields (componentRoutes, defaultPlacement) ...
 
 	// gatewayAPI holds status information for Gateway API
 	// integration, including conditions related to CRD management
 	// and the Gateway controller stack.
 	//
 	// +optional
-	GatewayAPI GatewayAPIStatus `json:"gatewayAPI,omitempty"`
+	GatewayAPI GatewayAPIIngressStatus `json:"gatewayAPI,omitempty"`
 }
 ```
 
@@ -501,6 +542,10 @@ Since these conditions live under `status.gatewayAPI.conditions`,
 the `GatewayAPICRDs` prefix is no longer needed on the condition
 type names — the namespace is provided by the struct itself.
 
+Note that CIO already has the machinery to write to the
+`ingress.config.openshift.io/cluster` status subresource -- this is
+the same pattern used for `status.componentRoutes`.
+
 ### Topology Considerations
 
 #### Hypershift / Hosted Control Planes
@@ -508,9 +553,9 @@ type names — the namespace is provided by the struct itself.
 This enhancement applies to Hypershift with the same semantics as
 standalone clusters. The Ingress Operator runs on the management
 cluster but manages resources on the guest cluster via kubeconfig.
-The `gatewayAPI.crdManagementMode` field on the IngressController
-in the guest cluster's `openshift-ingress-operator` namespace
-controls CRD management on the guest cluster.
+The `spec.gatewayAPI.crdManagementMode` field on the
+`ingress.config.openshift.io/cluster` resource in the guest
+cluster controls CRD management on that guest cluster.
 
 No management-cluster-side changes are required. The mode
 configuration is per-guest-cluster and does not affect the
@@ -557,7 +602,7 @@ requires a new feature gate. The proposed feature gate name is
 https://github.com/openshift/api/blob/master/features/features.go
 with the `TechPreviewNoUpgrade` feature set initially.
 
-The `gatewayAPI` field on IngressControllerSpec must use the
+The `gatewayAPI` field on `IngressSpec` must use the
 `+openshift:enable:FeatureGate=GatewayAPICRDManagementMode` marker
 to ensure the field is only present in CRDs for feature sets where
 the feature gate is enabled.
@@ -704,7 +749,8 @@ incompatibility.
 
 **Mitigation**: The `ExternalCRDs` mode will be clearly documented as
 unsupported. CIO will set a persistent unsupported warning condition
-on the IngressController status. The condition message will include
+on the `ingress.config.openshift.io/cluster` status. The condition
+message will include
 explicit language that this configuration is not supported.
 Additionally, telemetry can capture the management mode to help
 support engineers quickly identify clusters using unsupported
@@ -771,12 +817,11 @@ disabling the VAP manually and using `unsupportedConfigOverrides`).
 
 ## Open Questions
 
-1. **Field placement**: Should `gatewayAPI` live on the `default`
-   IngressController only, or should it be allowed on any
-   IngressController? Given that Gateway API CRD management is a
-   cluster-wide concern (CRDs are cluster-scoped), it may make
-   sense to restrict this to the `default` IngressController to
-   avoid conflicting configurations from multiple IngressControllers.
+1. ~~**Field placement**: Resolved. The field lives on
+   `ingress.config.openshift.io/cluster` (not on IngressController)
+   because Gateway API CRDs are cluster-scoped and the management
+   mode is a platform-wide decision that must not conflict across
+   multiple IngressControllers.~~
 
 2. **ExternalCRDs mode scope**: Should the `ExternalCRDs` mode
    perform any compatibility pre-checks before starting the
@@ -917,7 +962,8 @@ mechanism. Backporting gives customers the ability to set
 ensuring a smooth transition.
 
 The backport scope includes:
-- The `gatewayAPI` spec and status structs on IngressController.
+- The `gatewayAPI` spec and status structs on
+  `ingress.config.openshift.io`.
 - The `crdManagementMode` enum with all three values.
 - The `status.gatewayAPI.conditions` reporting.
 - The feature gate `GatewayAPICRDManagementMode` (behind
@@ -945,8 +991,9 @@ upgrading from 4.18 to 4.19 with the backport applied):
   behavior. No action is required from the cluster administrator.
 - Existing clusters with CIO-managed CRDs continue to work
   identically.
-- The new status conditions are added to the IngressController
-  status on the first reconciliation after upgrade.
+- The new status conditions are added to the
+  `ingress.config.openshift.io/cluster` status on the first
+  reconciliation after upgrade.
 
 When upgrading a cluster that has a non-default mode set (e.g.,
 upgrading from 4.19 to 4.20+ with mode already configured):
@@ -988,8 +1035,8 @@ pre-downgrade step.
 ## Version Skew Strategy
 
 During an upgrade, there may be a brief period where the new CIO
-binary is running but the IngressController CRD has not yet been
-updated to include the `gatewayAPI` field. During this period, CIO
+binary is running but the `ingress.config.openshift.io` CRD has
+not yet been updated to include the `gatewayAPI` field. During this period, CIO
 will treat the absence of the field as `Managed` mode (the default),
 which is the existing behavior. No version skew issues are expected.
 
@@ -999,12 +1046,13 @@ plane.
 
 ## Operational Aspects of API Extensions
 
-This enhancement adds new fields to the existing IngressController
-CRD and new status conditions. The operational impact is minimal:
+This enhancement adds new fields to the existing
+`ingress.config.openshift.io` CRD and new status conditions. The
+operational impact is minimal:
 
 - **API throughput**: No measurable impact. The new field is read
   by CIO during reconciliation, which already reads the full
-  IngressController spec. The additional status conditions add a
+  `Ingress` spec. The additional status conditions add a
   small amount of data to status updates.
 
 - **SLIs**: The new status conditions themselves serve as SLIs for
@@ -1035,16 +1083,14 @@ CRD and new status conditions. The operational impact is minimal:
 ### Detecting the Current Mode
 
 ```bash
-oc get ingresscontroller default \
-  -n openshift-ingress-operator \
+oc get ingress.config.openshift.io cluster \
   -o jsonpath='{.spec.gatewayAPI.crdManagementMode}'
 ```
 
 ### Checking CRD Management Status
 
 ```bash
-oc get ingresscontroller default \
-  -n openshift-ingress-operator \
+oc get ingress.config.openshift.io cluster \
   -o jsonpath='{.status.gatewayAPI.conditions}' | \
   jq '.[]'
 ```
@@ -1067,8 +1113,7 @@ the expected version shown in the condition message.
 
 ```bash
 # Check expected version from condition message
-oc get ingresscontroller default \
-  -n openshift-ingress-operator \
+oc get ingress.config.openshift.io cluster \
   -o jsonpath='{.status.gatewayAPI.conditions}' | \
   jq '.[] | select(.type=="CRDsCompliant")'
 
@@ -1109,7 +1154,8 @@ conventions prohibit boolean fields in CRDs.
 
 ### Alternative 2: Annotation-Based Configuration
 
-Using annotations on the IngressController to control CRD management
+Using annotations on the `ingress.config.openshift.io/cluster`
+resource to control CRD management
 mode would avoid an API change but would lack validation,
 defaulting, and discoverability. Annotations are also not visible
 in `oc describe` output as structured fields and cannot have
@@ -1120,9 +1166,9 @@ kubebuilder validation applied.
 Creating a new `GatewayAPIConfig` CRD would provide a clean
 separation of concerns but adds operational complexity (a new
 resource to manage, new RBAC rules, a new controller to reconcile).
-Given that CRD management mode is directly related to
-IngressController behavior, placing it on the IngressController
-spec is more natural and discoverable.
+Given that CRD management mode is a platform-wide ingress concern,
+placing it on the `ingress.config.openshift.io/cluster` spec is
+more natural and discoverable.
 
 ### Alternative 4: Per-CRD Management Granularity
 

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -166,7 +166,7 @@ the OpenShift cluster and configuring ingress.
 2. CIO reads the Ingress (`operator.openshift.io/v1alpha1`) `cluster`
    resource and observes that `spec.gatewayAPI.managementMode`
    is unset (defaults to `Managed`).
-3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
+3. CIO deploys Gateway API CRDs, VAP, the CIO-managed Istio
    instance, GatewayClass, and Gateway resources as per the existing
    behavior.
 4. CIO sets the following conditions in `status.conditions`:
@@ -199,6 +199,8 @@ the OpenShift cluster and configuring ingress.
       managed by a third-party gateway controller. The cluster
       administrator is responsible for cleaning up these resources
       if desired.
+   d. Leaves proxy pods created as the result of a `Gateway` provisioning 
+      around, not causing traffic disruption.
 4. CIO sets the following conditions in `status.conditions`:
    - `GatewayAPICRDsManaged=False` (reason: `Unmanaged`)
    - `GatewayAPICRDsPresent=True/False` (observational)
@@ -213,6 +215,9 @@ the OpenShift cluster and configuring ingress.
    OpenShift Gateway API implementation. They should adjust their
    behavior accordingly (e.g., not relying on specific CRD
    versions or fields).
+7. The resources previously created by CIO Gateway API controllers (like DNSRecord  
+   and NetworkPolicy for a once managed Gateway) are not removed, unless the parent
+   Gateway is also removed.
 
 #### Workflow 3: Returning to Managed Mode
 
@@ -484,7 +489,8 @@ disabling the CIO-managed Istio instance and CIO Gateway API
 controllers to reclaim resources.
 
 **MicroShift**: Not affected. MicroShift does not use CIO (see
-[MicroShift Gateway API Support](../microshift/gateway-api-support.md)).
+[MicroShift Gateway API Support](../microshift/gateway-api-support.md)) and
+the new ingress operator CRD should not be installed on it.
 
 #### OpenShift Kubernetes Engine
 
@@ -633,6 +639,10 @@ These are out of scope for this enhancement.
 
 Switching to `Unmanaged` leaves GatewayClass, Gateway, and
 HTTPRoute resources without a managing controller.
+
+Additionally, child resources created as a result of a once managed Gateway creation,
+like Deployment, DNSRecord and NetworkPolicy are not removed and must be cleaned by 
+the user. Deleting the parent Gateway may also remove these resources.
 
 **Mitigation**: CIO preserves all Gateway API resources during
 transitions to avoid disruption. The administrator is responsible

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -11,7 +11,7 @@ approvers:
 api-approvers:
   - "@everettraven"
 creation-date: 2026-05-26
-last-updated: 2026-06-18
+last-updated: 2026-09-17
 status: implementable
 tracking-link:
   - https://redhat.atlassian.net/browse/NE-2733
@@ -124,9 +124,6 @@ Introduce a new cluster-scoped singleton API resource in the
 - **Resource**: `ingresses`
 - **Scope**: Cluster (non-namespaced)
 - **Singleton name**: `cluster`
-- **Pattern**: Same as `DNS` in
-  `operator.openshift.io/v1` -- embeds
-  `OperatorSpec`/`OperatorStatus` inline.
 
 The spec contains a `gatewayAPI` struct with a
 `managementMode` enum.
@@ -195,12 +192,16 @@ the OpenShift cluster and configuring ingress.
    b. Removes the VAP protecting Gateway API CRDs.
    c. Does **not** remove the GatewayClass, Gateway resources, or
       Gateway API CRDs. Removing these resources could cause
-      disruptions to existing workloads for gateways that are being
-      managed by a third-party gateway controller. The cluster
-      administrator is responsible for cleaning up these resources
-      if desired.
-   d. Leaves proxy pods created as the result of a `Gateway` provisioning 
-      around, not causing traffic disruption.
+      disruptions to existing workloads served by these Gateways.
+      The cluster administrator is responsible for cleaning up
+      these resources if desired, for example once a third-party
+      Gateway controller has taken over management.
+   d. Leaves any proxy pods created as a result of Gateway
+      provisioning in place, avoiding traffic disruption.
+   e. Leaves resources previously created by CIO Gateway API
+      controllers (like DNSRecord and NetworkPolicy for a
+      previously managed Gateway) in place, unless the parent
+      Gateway is also removed.
 4. CIO sets the following conditions in `status.conditions`:
    - `GatewayAPICRDsManaged=False` (reason: `Unmanaged`)
    - `GatewayAPICRDsPresent=True/False` (observational)
@@ -215,9 +216,6 @@ the OpenShift cluster and configuring ingress.
    OpenShift Gateway API implementation. They should adjust their
    behavior accordingly (e.g., not relying on specific CRD
    versions or fields).
-7. The resources previously created by CIO Gateway API controllers (like DNSRecord  
-   and NetworkPolicy for a once managed Gateway) are not removed, unless the parent
-   Gateway is also removed.
 
 #### Workflow 3: Returning to Managed Mode
 
@@ -332,10 +330,6 @@ type Ingress struct {
 }
 
 type IngressSpec struct {
-	// Inline OperatorSpec for standard operator fields
-	// (managementState, logLevel, etc.)
-	OperatorSpec `json:",inline"`
-
 	// gatewayAPI holds configuration for Gateway API
 	// integration, including how the ingress operator manages
 	// Gateway API CRDs, the Istio instance it deploys, and its
@@ -347,11 +341,13 @@ type IngressSpec struct {
 }
 
 type IngressStatus struct {
-	// Inline OperatorStatus for standard operator status fields
-	// (conditions, version, observedGeneration, etc.).
-	// conditions holds a list of conditions representing the
-	// operator's current state. Gateway API CRD management
-	// conditions are reported here with the "GatewayAPI" prefix:
+	// observedGeneration is the last generation change you've dealt with
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// conditions is a list of conditions and their status.
+	// Gateway API CRD management conditions are reported here
+	// with the "GatewayAPI" prefix:
 	//
 	// "GatewayAPICRDsManaged" indicates whether the ingress operator is
 	// actively managing Gateway API CRDs:
@@ -379,7 +375,10 @@ type IngressStatus struct {
 	//     CRDs do not match the expected version. The message
 	//     includes expected and actual versions and a pointer
 	//     to where valid manifests can be obtained.
-	OperatorStatus `json:",inline"`
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []OperatorCondition `json:"conditions,omitempty"`
 }
 ```
 
@@ -448,7 +447,7 @@ status.conditions
 ```
 
 The following Gateway API conditions are set within
-`status.conditions` (inherited from `OperatorStatus`):
+`status.conditions`:
 
 | Condition Type | Status | Reason | Description |
 |---|---|---|---|
@@ -489,8 +488,9 @@ disabling the CIO-managed Istio instance and CIO Gateway API
 controllers to reclaim resources.
 
 **MicroShift**: Not affected. MicroShift does not use CIO (see
-[MicroShift Gateway API Support](../microshift/gateway-api-support.md)) and
-the new ingress operator CRD should not be installed on it.
+[MicroShift Gateway API Support](../microshift/gateway-api-support.md)),
+and the new `Ingress` (`operator.openshift.io/v1alpha1`) resource
+should not be installed on it.
 
 #### OpenShift Kubernetes Engine
 
@@ -622,14 +622,13 @@ to accommodate future configuration beyond `managementMode`:
    parameters. This would replace the current model where only a
    single default GatewayClass is created by CIO.
 
-2. **Operator and operand logging levels**: The Ingress resource
-   embeds `OperatorSpec`, which includes `logLevel` (for operands)
-   and `operatorLogLevel` (for the operator) fields. These can be
-   used to implement the logging level controls originally proposed
-   in
-   [ingress-operator-operand-logging-level](ingress-operator-operand-logging-level.md),
-   providing a supported API for adjusting CIO and Gateway
-   controller verbosity.
+2. **Operator and operand logging levels**: `OperatorSpec` (which
+   includes `logLevel` for operands and `operatorLogLevel` for the
+   operator) is not embedded in `IngressSpec` today, but could be
+   added if the logging level controls originally proposed in
+   [ingress-operator-operand-logging-level](ingress-operator-operand-logging-level.md)
+   are implemented on this resource, providing a supported API for
+   adjusting CIO and Gateway controller verbosity.
 
 These are out of scope for this enhancement.
 
@@ -640,9 +639,14 @@ These are out of scope for this enhancement.
 Switching to `Unmanaged` leaves GatewayClass, Gateway, and
 HTTPRoute resources without a managing controller.
 
-Additionally, child resources created as a result of a once managed Gateway creation,
-like Deployment, DNSRecord and NetworkPolicy are not removed and must be cleaned by 
-the user. Deleting the parent Gateway may also remove these resources.
+Additionally, child resources created as a result of a previously
+managed Gateway (such as Deployment, DNSRecord, and NetworkPolicy)
+are not removed and must be cleaned up by the user. Deleting the
+parent Gateway will cascade-delete any of these resources that
+carry an `ownerReference` back to the Gateway or one of its
+subresources (e.g., DNSRecord is owned by the Service created for
+the Gateway, which is itself owned by the Gateway), via standard
+Kubernetes garbage collection.
 
 **Mitigation**: CIO preserves all Gateway API resources during
 transitions to avoid disruption. The administrator is responsible

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -230,16 +230,24 @@ IngressController resources and manages Gateway API components.
      gatewayAPI:
        managementMode: Managed
    ```
-4. CIO detects the mode change:
+4. CIO detects the mode change and begins transition.
+   `GatewayAPICRDsManaged` remains `False` until CIO successfully
+   takes ownership:
    a. If CRDs are absent, CIO installs them.
    b. If CRDs are present and match the expected version, CIO takes
-      ownership (adds labels, deploys VAP).
+      ownership (adds labels, deploys VAP) and sets
+      `GatewayAPICRDsManaged=True`.
    c. If CRDs are present but do not match the expected version, CIO
       sets `GatewayAPICRDsCompliant=False` (in `status.conditions`)
-      and does NOT overwrite them. The administrator must resolve
-      the mismatch.
-5. CIO deploys the full Gateway controller stack if not already
-   running.
+      and does NOT overwrite them. `GatewayAPICRDsManaged` stays
+      `False`. The administrator must resolve the mismatch before
+      CIO can take ownership.
+5. Once `GatewayAPICRDsManaged=True`, `GatewayAPICRDsPresent=True`,
+   and `GatewayAPICRDsCompliant=True`, CIO starts the CIO-managed
+   Istio instance, GatewayClass, and Gateway resources. If any of
+   these conditions is not `True`, the Gateway controller stack is
+   not started but the cluster is not marked as degraded and
+   upgrades are not blocked.
 
 ```mermaid
 sequenceDiagram
@@ -288,9 +296,7 @@ the `openshift/api` repository (e.g.,
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 //
-// Ingress holds cluster-wide configuration for Gateway API
-// integration managed by the Cluster Ingress Operator. The
-// canonical name is `cluster`.
+// Ingress contains configuration options specific to the Ingress Operator itself.
 //
 // Compatibility level 4: No compatibility is provided, the API
 // can change at any point for any reason. These capabilities
@@ -485,7 +491,7 @@ Both modes are available on OKE. However, Gateway API support on
 OKE depends on the
 [gateway-api-without-olm](gateway-api-without-olm.md) enhancement
 which eliminates OSSM licensing concerns. Given the desire to
-backport this management mode feature to OCP 4.19, OKE enablement
+backport this management mode feature to OCP 4.18, OKE enablement
 depends on whether `gateway-api-without-olm` is also backported
 to the same version. If that enhancement is not backported, OKE
 support for this feature is limited to the OCP version where
@@ -520,6 +526,24 @@ Affected controllers:
 | GatewayClass | Active | Disabled |
 | Gateway | Active | Disabled |
 | Status | Report conditions | Report conditions |
+
+#### Gateway Controller Stack Start Condition
+
+CIO starts the CIO-managed Istio instance, GatewayClass, and Gateway
+resources only when all three of the following conditions are `True`
+in `status.conditions`:
+
+- `GatewayAPICRDsManaged=True`
+- `GatewayAPICRDsPresent=True`
+- `GatewayAPICRDsCompliant=True`
+
+If any of these conditions is not `True` (e.g., during a transition
+back to `Managed` where CRDs are non-compliant, or while CIO is
+installing CRDs), the Gateway controller stack is not started. This
+is not a degraded state: these conditions do not contribute to the
+operator's `Degraded` status condition and do not block cluster
+upgrades. They are informational signals about Gateway API CRD
+readiness.
 
 #### VAP Management
 
@@ -631,31 +655,14 @@ fighting the VAP and CRD reconciler.
 
 ## Open Questions
 
-1. **CRD cleanup on Unmanaged transition**: Should CIO offer an
-   option to remove CRDs when transitioning to `Unmanaged`? This
-   would delete all Gateway/HTTPRoute resources. The current
-   proposal preserves CRDs during transitions.
+1. **Telemetry**: What telemetry should be collected? At minimum
+   the configured mode, CRDVersion and OSSM Version. 
+   Should CIO also report metrics for CRD compliance and mode transitions?
 
-2. **Interaction with `unsupportedConfigOverrides`**: The CRD
-   lifecycle management enhancement uses an "unsupported config
-   override" mechanism to bypass CRD succession checks. Should
-   `managementMode` replace this mechanism or coexist with it?
-
-3. **Telemetry**: What telemetry should be collected? At minimum
-   the configured mode. Should CIO also report metrics for CRD
-   compliance and mode transitions?
-
-4. **Singleton creation**: Should the `cluster` singleton instance
+2. **Singleton creation**: Should the `cluster` singleton instance
    be created by CVO (via a manifest in the release payload) or
    by CIO on first startup? This affects upgrade behavior and
    needs alignment with the operator pattern used by DNS/Console.
-
-5. **Kind name collision**: The proposed Kind `Ingress` in
-   `operator.openshift.io/v1alpha1` shares a name with the well-known
-   `networking.k8s.io/v1` Ingress. While API groups disambiguate,
-   this may cause user confusion with `oc get ingress`. The short
-   name and resource disambiguation strategy should be decided
-   during API review.
 
 ## Test Plan
 
@@ -746,18 +753,13 @@ dev-guide/feature-zero-to-hero.md:
 - Sufficient time for customer feedback (at least one minor
   release in Tech Preview).
 
-### Backport to OCP 4.19
+### Backport to OCP 4.18
 
-The official backport target is OCP 4.19. Without this backport,
-customers on 4.19 with third-party Gateway API CRDs face CRD
+The official backport target is OCP 4.18. Without this backport,
+customers on 4.18 with third-party Gateway API CRDs face CRD
 succession conflicts when upgrading, because CIO enforces
 ownership with no opt-out. Backporting lets customers set
 `Unmanaged` before upgrading.
-
-> **Note**: There is also a desire to backport to OCP 4.18, as the
-> lack of this feature is currently blocking 4.18 upgrades for
-> customers with third-party CRDs. This requires the same SBAR
-> exception process and is subject to architect approval.
 
 **SBAR exception process**: Backporting a new CRD to a released
 version requires SBAR (Situation, Background, Assessment,
@@ -769,8 +771,8 @@ Backport scope:
 - Ingress CRD manifest for `operator.openshift.io/v1alpha1` (CVO).
 - `gatewayAPI` spec/status structs with both enum values.
 - `status.conditions` Gateway API condition reporting.
-- Feature gate `GatewayAPIManagementMode` (behind
-  `TechPreviewNoUpgrade`).
+- Feature gate `GatewayAPIManagementMode` (initially behind
+  `TechPreviewNoUpgrade`, then `GA` once the E2E requirements pass).
 - CIO controller changes.
 
 **E2E requirements**: 95%+ pass rate, 7 runs/week on supported
@@ -790,7 +792,7 @@ Not applicable. This enhancement adds new functionality.
 
 When upgrading from a version that does not have the Ingress
 (`operator.openshift.io/v1alpha1`) resource to one that does (e.g.,
-upgrading from 4.18 to 4.19 with the backport applied):
+upgrading from 4.17 to 4.18 with the backport applied):
 
 - CVO installs the new Ingress CRD. The `cluster` singleton is
   created with `spec.gatewayAPI.managementMode` defaulting to
@@ -935,7 +937,7 @@ Lacks validation, defaulting, and discoverability. Not visible in
 
 ### Alternative 5: Separate `GatewayAPIConfig` CRD
 
-Adds unnecessary complexity. CRD management is an ingress concern,
+Adds unnecessary complexity. CRD management is an ingress operator configuration,
 so the Ingress resource in `operator.openshift.io/v1alpha1` is a more
 natural home.
 

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -1,0 +1,1137 @@
+---
+title: gateway-api-crd-management-mode
+authors:
+  - "@rikatz"
+reviewers:
+  - "@Miciah" 
+  - "@gcs278" 
+  - "@knobunc" 
+approvers:
+  - TBD
+api-approvers:
+  - TBD
+creation-date: 2026-05-26
+last-updated: 2026-05-26
+status: provisional
+tracking-link:
+  - TBD
+see-also:
+  - "/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md"
+  - "/enhancements/ingress/gateway-api-crd-life-cycle-management.md"
+  - "/enhancements/ingress/gateway-api-without-olm.md"
+  - "/enhancements/ingress/add-dns-and-loadbalancer-conditions-to-managed-gateway.md"
+---
+
+# Gateway API CRD Management Mode
+
+## Summary
+
+This enhancement introduces a new `gatewayAPI` configuration struct
+on the `IngressController` API (`operator.openshift.io/v1`) that
+contains a `crdManagementMode` enum field controlling how the
+Cluster Ingress Operator (CIO) manages Gateway API Custom Resource
+Definitions (CRDs) and the associated Gateway controller stack
+(the Istio instance deployed by CIO, GatewayClass, Gateway
+resources). The enum exposes three modes -- `Managed`, `Unmanaged`,
+and `ExternalCRDs` -- enabling cluster administrators and
+third-party products to choose whether CIO fully owns the Gateway
+API CRDs and controller, delegates CRD ownership entirely to an
+external entity, or runs the OpenShift Gateway controller against
+externally-provided CRDs. The `gatewayAPI` struct is designed to be
+extended in the future with additional Gateway API-related
+configuration fields. This gives customers the flexibility they
+need while preserving a clear, observable ownership model that CIO
+and support teams can reason about.
+
+## Motivation
+
+The current Gateway API integration in OpenShift, as established by
+the
+[gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md)
+and
+[gateway-api-without-olm](gateway-api-without-olm.md)
+enhancements, treats Gateway API CRDs as a core platform API. CIO
+owns the CRDs, pins them to a specific version, protects them with
+Validating Admission Policies (VAPs), and upgrades them automatically
+during cluster upgrades. This is the right default for most customers.
+
+However, this "CIO owns everything" model creates friction for several
+legitimate use cases:
+
+1. **Third-party Gateway API implementations**: Customers who want to
+   use a non-OpenShift Gateway API controller (e.g., Envoy Gateway,
+   Traefik, Kong) cannot do so cleanly because CIO installs and
+   protects its own CRD versions. The third-party controller may
+   require a different CRD version or schema.
+
+2. **Development and testing**: Platform engineers and advanced users
+   sometimes need to test with newer CRD versions or experimental
+   fields. Today, this requires fighting the VAP and the CIO
+   reconciler.
+
+3. **Supportability and observability**: When CRDs are modified
+   outside the expected flow (e.g., by bypassing the VAP), there is
+   no explicit API-level signal that tells support or monitoring
+   who is supposed to own the CRDs and whether the current state is
+   intentional.
+
+This enhancement addresses these gaps by providing an explicit,
+API-level knob that makes CRD ownership a first-class configuration
+choice rather than an implicit assumption.
+
+### User Stories
+
+#### Story 1: Third-Party Gateway Controller
+
+As a cluster administrator, I want to disable OpenShift's Gateway API
+CRD management and Gateway controller so that I can install and use a
+third-party Gateway API implementation (such as Envoy Gateway or Kong)
+without conflicts with CIO's CRD ownership or VAP protections.
+
+#### Story 2: Development and Testing with External CRDs
+
+As a platform engineer, I want to use externally-provided Gateway API
+CRDs while keeping the OpenShift Gateway controller running so that I
+can test with newer CRD versions or experimental fields in a
+development environment, understanding that this configuration is
+unsupported.
+
+#### Story 3: Determining CRD Ownership State
+
+As a support engineer responding to a customer escalation, I want to
+quickly determine who owns the Gateway API CRDs on a cluster and
+whether the current CRD state matches the configured ownership mode
+so that I can diagnose issues without needing to inspect labels,
+annotations, and controller logs manually.
+
+#### Story 4: Operational Monitoring at Scale
+
+As a fleet administrator managing hundreds of OpenShift clusters, I
+want to monitor the Gateway API CRD ownership state via standard
+OpenShift status conditions and metrics so that I can detect clusters
+where CRD ownership is misconfigured or where CRDs have drifted from
+the expected state, enabling proactive remediation before users are
+affected.
+
+#### Story 5: Automatic CRD Upgrades
+
+As a cluster administrator using the default configuration, I want
+OpenShift to continue automatically upgrading Gateway API CRDs during
+cluster upgrades so that I do not need to manage CRD versions myself,
+and I want the ownership state to be clearly reported in the
+IngressController status.
+
+### Goals
+
+1. Provide an explicit API field on the IngressController that
+   controls Gateway API CRD ownership with three modes: `Managed`,
+   `Unmanaged`, and `ExternalCRDs`.
+2. Enable customers and third-party products to take full control of
+   Gateway API CRDs when needed, without fighting CIO's reconciler
+   or VAP protections.
+3. Expose clear, observable status conditions that report the current
+   CRD ownership mode, CRD presence, and CRD compliance with the
+   expected version.
+4. Signal via status conditions the CRD management state so that
+   external consumers can determine the platform's Gateway API
+   posture.
+5. Preserve the current fully-managed behavior as the default,
+   requiring no action from existing customers.
+6. Define clear upgrade and downgrade semantics for transitioning
+   between modes.
+
+### Non-Goals
+
+1. **Unknown field management**: Handling fields in CRDs that are not
+   recognized by the current controller version is a long-term goal
+   that will build on top of this work. This enhancement mentions it
+   for context but does not define the solution. See
+   [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624)
+   for upstream tracking.
+2. **CRD version ranges**: Allowing a configurable range of acceptable
+   CRD versions rather than pinning to one specific version. This is
+   future work that depends on resolving the unknown fields problem.
+3. **Automatic migration of third-party CRDs**: When switching from
+   `Unmanaged` to `Managed`, CIO will not attempt to reconcile or
+   migrate third-party CRDs automatically. The administrator must
+   ensure the cluster state is compatible before changing modes.
+4. **MicroShift support**: MicroShift does not use CIO and has its own
+   Gateway API design. This enhancement does not affect MicroShift.
+5. **Istio CRD management mode**: This enhancement controls only
+   Gateway API CRDs (`gateway.networking.k8s.io` group). Istio CRD
+   management (the `networking.istio.io`, `security.istio.io`, etc.
+   groups) is handled separately by the sail-operator library as
+   described in
+   [gateway-api-without-olm](gateway-api-without-olm.md).
+
+## Proposal
+
+Add a new `gatewayAPI` struct field to the `IngressControllerSpec`
+that serves as a namespace for all Gateway API-related configuration.
+Initially, this struct contains a single `crdManagementMode` enum
+field with three values: `Managed` (default), `Unmanaged`, and
+`ExternalCRDs`. The struct is intentionally designed to be extensible so
+that future Gateway API configuration fields can be added without
+further API restructuring. The CIO will use the `crdManagementMode`
+field to determine its behavior regarding Gateway API CRD lifecycle
+management and the Gateway controller stack (the Istio instance
+deployed by CIO, GatewayClass, Gateway resources).
+
+The three modes are:
+
+- **Managed** (default): CIO maintains the Gateway API CRDs, protects
+  them via VAPs, upgrades them during cluster upgrades, and runs the
+  full Gateway controller stack (the Istio instance deployed by CIO,
+  GatewayClass, Gateway). This is the current behavior and the only
+  fully supported configuration.
+
+- **Unmanaged**: CIO does NOT install Gateway API CRDs and does NOT
+  deploy the Gateway controller stack. The customer or a third-party
+  product brings their own CRDs and Gateway controller. CIO's
+  Gateway-related controllers are disabled entirely. CIO reports
+  observational status (CRD presence, version) but takes no
+  management action.
+
+- **ExternalCRDs**: CIO does NOT manage Gateway API CRDs (no install,
+  no upgrade, no VAP protection) but DOES run the OpenShift Gateway
+  controller stack (the Istio instance deployed by CIO, GatewayClass,
+  Gateway). The customer
+  brings their own CRDs. This is explicitly marked as an
+  **unsupported** configuration, useful for development, testing, or
+  advanced users who need newer CRD versions. CIO reports status
+  including a persistent unsupported warning.
+
+### Workflow Description
+
+**Cluster administrator** is a human user responsible for managing
+the OpenShift cluster and configuring ingress.
+
+**CIO (Cluster Ingress Operator)** is the operator that reconciles
+IngressController resources and manages Gateway API components.
+
+#### Workflow 1: Default Managed Mode (No Action Required)
+
+1. The cluster administrator installs or upgrades OpenShift.
+2. CIO reads the `default` IngressController and observes that
+   `spec.gatewayAPI.crdManagementMode` is unset (defaults to
+   `Managed`).
+3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
+   instance, GatewayClass, and Gateway resources as per the existing
+   behavior.
+4. CIO sets `status.gatewayAPI.conditions`:
+   - `CRDsManaged=True` (reason: `ManagedByCIO`)
+   - `CRDsPresent=True`
+   - `CRDsCompliant=True`
+5. External consumers observe the conditions and proceed normally.
+
+#### Workflow 2: Switching to Unmanaged Mode
+
+1. The cluster administrator decides to use a third-party Gateway
+   API implementation.
+2. The cluster administrator edits the `default` IngressController:
+   ```yaml
+   spec:
+     gatewayAPI:
+       crdManagementMode: Unmanaged
+   ```
+3. CIO detects the mode change and begins transition:
+   a. Shuts down the CIO-managed Istio instance.
+   b. Removes the VAP protecting Gateway API CRDs.
+   c. Does **not** remove the GatewayClass, Gateway resources, or
+      Gateway API CRDs. Removing these resources could cause
+      disruptions to existing workloads. The cluster administrator
+      is responsible for cleaning up these resources if desired.
+4. CIO sets `status.gatewayAPI.conditions`:
+   - `CRDsManaged=False` (reason: `Unmanaged`)
+   - `CRDsPresent=True/False` (observational)
+   - `CRDsCompliant=Unknown` (not applicable in this mode)
+5. The cluster administrator installs their third-party Gateway
+   controller and optionally their own CRD version.
+
+#### Workflow 3: Switching to ExternalCRDs Mode
+
+1. The cluster administrator or developer wants to test with newer
+   Gateway API CRDs while using the OpenShift Gateway controller.
+2. The cluster administrator edits the `default` IngressController:
+   ```yaml
+   spec:
+     gatewayAPI:
+       crdManagementMode: ExternalCRDs
+   ```
+3. CIO detects the mode change:
+   a. Removes the VAP protecting Gateway API CRDs.
+   b. Stops managing (installing/upgrading) Gateway API CRDs.
+   c. Keeps the CIO-managed Istio instance, GatewayClass, and
+      Gateway resources running.
+4. CIO sets `status.gatewayAPI.conditions`:
+   - `CRDsManaged=False` (reason: `ExternalCRDs`,
+     message includes unsupported warning)
+   - `CRDsPresent=True/False` (observational)
+   - `CRDsCompliant=True/False` (whether existing CRDs
+     match the expected version)
+5. The cluster administrator installs their own CRD version.
+6. If the CRDs are incompatible with the CIO-managed Istio
+   instance, CIO reports degraded status but continues running.
+
+#### Workflow 4: Returning to Managed Mode
+
+1. The cluster administrator wants to return to the fully managed
+   configuration.
+2. The cluster administrator ensures the existing Gateway API CRDs
+   match the version CIO expects, or removes them entirely.
+3. The cluster administrator edits the `default` IngressController:
+   ```yaml
+   spec:
+     gatewayAPI:
+       crdManagementMode: Managed
+   ```
+4. CIO detects the mode change:
+   a. If CRDs are absent, CIO installs them.
+   b. If CRDs are present and match the expected version, CIO takes
+      ownership (adds labels, deploys VAP).
+   c. If CRDs are present but do not match the expected version, CIO
+      sets `CRDsCompliant=False` (in `status.gatewayAPI.conditions`)
+      and does NOT overwrite
+      them. The administrator must resolve the mismatch.
+5. CIO deploys the full Gateway controller stack if not already
+   running.
+
+```mermaid
+sequenceDiagram
+    participant Admin as Cluster Admin
+    participant IC as IngressController
+    participant CIO as Cluster Ingress Operator
+    participant CRDs as Gateway API CRDs
+    participant GW as Gateway Stack<br/>(CIO Istio/GatewayClass/Gateway)
+
+    Note over Admin,GW: Workflow: Mode Transition
+    Admin->>IC: Set gatewayAPI.crdManagementMode
+
+    alt Managed (default)
+        CIO->>CRDs: Install/upgrade CRDs + VAP
+        CIO->>GW: Deploy CIO Istio, GatewayClass, Gateway
+        CIO->>IC: Set status: Managed=True,<br/>Present=True, Compliant=True
+    else Unmanaged
+        CIO->>GW: Shutdown CIO Istio instance
+        CIO->>CRDs: Remove VAP, stop managing
+        Note over GW: GatewayClass/Gateway left for<br/>admin cleanup to avoid disruption
+        CIO->>IC: Set status: Managed=False (Unmanaged),<br/>Present=observed
+    else ExternalCRDs (unsupported)
+        CIO->>CRDs: Remove VAP, stop managing
+        CIO->>GW: Keep running
+        CIO->>IC: Set status: Managed=False (ExternalCRDs),<br/>Present=observed, Compliant=observed,<br/>UNSUPPORTED
+    end
+```
+
+### API Extensions
+
+This enhancement modifies the existing `IngressController` CRD
+(`operator.openshift.io/v1`) by adding new fields to the spec and
+new conditions to the status. No new CRDs, admission webhooks,
+conversion webhooks, aggregated API servers, or finalizers are
+introduced.
+
+The proposed Go types are:
+
+```go
+// GatewayAPICRDManagementMode describes how the Cluster Ingress
+// Operator manages Gateway API Custom Resource Definitions.
+//
+// +kubebuilder:validation:Enum=Managed;Unmanaged;ExternalCRDs
+type GatewayAPICRDManagementMode string
+
+const (
+	// ManagedGatewayAPICRDs means CIO installs, owns, protects
+	// (via VAP), and upgrades the Gateway API CRDs. CIO also
+	// deploys the full Gateway controller stack (the Istio
+	// instance deployed by CIO, GatewayClass, Gateway). This is
+	// the default mode and the only fully supported configuration.
+	ManagedGatewayAPICRDs GatewayAPICRDManagementMode = "Managed"
+
+	// UnmanagedGatewayAPICRDs means CIO does NOT install or
+	// manage Gateway API CRDs and does NOT deploy the Gateway
+	// controller stack. The customer or a third-party product is
+	// responsible for bringing their own CRDs and Gateway
+	// controller. CIO reports observational status only.
+	UnmanagedGatewayAPICRDs GatewayAPICRDManagementMode = "Unmanaged"
+
+	// ExternalCRDsGatewayAPICRDs means CIO does NOT manage Gateway
+	// API CRDs but DOES deploy the OpenShift Gateway controller
+	// stack (the Istio instance deployed by CIO, GatewayClass,
+	// Gateway). The customer brings their own CRDs. This is an
+	// UNSUPPORTED configuration useful for development, testing,
+	// or advanced users.
+	ExternalCRDsGatewayAPICRDs GatewayAPICRDManagementMode = "ExternalCRDs"
+)
+
+// GatewayAPIConfig holds configuration for Gateway API integration
+// in the Cluster Ingress Operator. This struct is designed to be
+// extended with additional Gateway API-related configuration
+// fields in the future.
+type GatewayAPIConfig struct {
+	// crdManagementMode specifies how the Cluster Ingress
+	// Operator manages Gateway API Custom Resource Definitions
+	// (CRDs) and the associated Gateway controller stack.
+	//
+	// When set to "Managed" (the default), CIO installs, owns,
+	// and upgrades the Gateway API CRDs, protects them with a
+	// Validating Admission Policy, and deploys the full Gateway
+	// controller stack (the Istio instance deployed by CIO,
+	// GatewayClass, Gateway resources). This is the only fully
+	// supported configuration.
+	//
+	// When set to "Unmanaged", CIO does not install or manage
+	// Gateway API CRDs and does not deploy the Gateway controller
+	// stack. The cluster administrator or a third-party product
+	// is responsible for providing their own CRDs and Gateway
+	// controller. CIO reports observational status only.
+	//
+	// When set to "ExternalCRDs", CIO does not manage Gateway API
+	// CRDs but does deploy the OpenShift Gateway controller stack.
+	// The cluster administrator brings their own CRDs. This is an
+	// unsupported configuration intended for development and
+	// testing.
+	//
+	// +kubebuilder:default:="Managed"
+	// +default="Managed"
+	// +required
+	CRDManagementMode GatewayAPICRDManagementMode `json:"crdManagementMode"`
+}
+```
+
+The `GatewayAPIConfig` struct is added to the
+`IngressControllerSpec` as a value type (not a pointer). The field
+is mandatory and defaults to `Managed` mode. Once set, the
+administrator must change the mode to a different value rather than
+removing the field entirely:
+
+```go
+type IngressControllerSpec struct {
+	// ... existing fields ...
+
+	// gatewayAPI holds configuration for Gateway API integration,
+	// including how the Cluster Ingress Operator manages Gateway
+	// API CRDs and the Gateway controller stack. This struct is
+	// designed to accommodate additional Gateway API configuration
+	// fields in future releases.
+	//
+	// +required
+	// +openshift:enable:FeatureGate=GatewayAPICRDManagementMode
+	GatewayAPI GatewayAPIConfig `json:"gatewayAPI"`
+}
+```
+
+The field path for the CRD management mode is:
+
+```
+spec.gatewayAPI.crdManagementMode
+```
+
+This nesting under the `gatewayAPI` struct allows future fields
+such as `spec.gatewayAPI.someOtherSetting` to be added without
+further API restructuring.
+
+A new `gatewayAPI` struct is added to `IngressControllerStatus` to
+namespace all Gateway API-related status, mirroring the spec-side
+`gatewayAPI` struct. This keeps Gateway API conditions separate from
+the IngressController's top-level conditions and makes it easy for
+consumers to find all Gateway API state in one place.
+
+```go
+// GatewayAPIStatus holds status information for Gateway API
+// integration managed by the Cluster Ingress Operator.
+type GatewayAPIStatus struct {
+	// conditions is a list of conditions related to Gateway API
+	// CRD management and the Gateway controller stack. These
+	// conditions are scoped to Gateway API concerns and are
+	// separate from the IngressController's top-level conditions.
+	//
+	// Supported condition types are:
+	// * CRDsManaged - whether CIO is actively managing CRDs
+	// * CRDsPresent - whether Gateway API CRDs exist on the cluster
+	// * CRDsCompliant - whether installed CRDs match the expected version
+	//
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+```
+
+The `GatewayAPIStatus` struct is added to the
+`IngressControllerStatus`:
+
+```go
+type IngressControllerStatus struct {
+	// ... existing fields ...
+
+	// gatewayAPI holds status information for Gateway API
+	// integration, including conditions related to CRD management
+	// and the Gateway controller stack.
+	//
+	// +optional
+	GatewayAPI GatewayAPIStatus `json:"gatewayAPI,omitempty"`
+}
+```
+
+The status field path for Gateway API conditions is:
+
+```
+status.gatewayAPI.conditions
+```
+
+The following conditions are set within
+`status.gatewayAPI.conditions`. These conditions follow the
+standard Kubernetes condition semantics with `type`, `status`,
+`reason`, `message`, `lastTransitionTime`, and
+`observedGeneration` fields:
+
+| Condition Type | Status | Reason | Description |
+|---|---|---|---|
+| `CRDsManaged` | `True` | `ManagedByCIO` | CIO is actively managing CRDs |
+| `CRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
+| `CRDsManaged` | `False` | `ExternalCRDs` | Administrator chose ExternalCRDs mode (unsupported) |
+| `CRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
+| `CRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
+| `CRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
+| `CRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
+| `CRDsCompliant` | `Unknown` | `NotApplicable` | Compliance check is not applicable (e.g., Unmanaged mode with no CRDs present) |
+
+Since these conditions live under `status.gatewayAPI.conditions`,
+the `GatewayAPICRDs` prefix is no longer needed on the condition
+type names — the namespace is provided by the struct itself.
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+This enhancement applies to Hypershift with the same semantics as
+standalone clusters. The Ingress Operator runs on the management
+cluster but manages resources on the guest cluster via kubeconfig.
+The `gatewayAPI.crdManagementMode` field on the IngressController
+in the guest cluster's `openshift-ingress-operator` namespace
+controls CRD management on the guest cluster.
+
+No management-cluster-side changes are required. The mode
+configuration is per-guest-cluster and does not affect the
+management cluster or other guest clusters.
+
+#### Standalone Clusters
+
+This is the primary topology for this enhancement. All three modes
+are fully applicable to standalone clusters with no special
+considerations.
+
+#### Single-node Deployments or MicroShift
+
+**Single-node OpenShift (SNO)**: This enhancement applies to SNO
+with no additional resource consumption concerns beyond what the
+existing Gateway API feature already introduces. The `Unmanaged`
+mode may be particularly useful for SNO deployments with constrained
+resources, as it allows disabling the Gateway controller stack
+entirely (the CIO-managed Istio instance, Envoy proxies) to reclaim
+CPU and memory.
+
+**MicroShift**: MicroShift does not use the Cluster Ingress Operator
+and has its own Gateway API design (see the
+[MicroShift Gateway API Support Enhancement](../microshift/gateway-api-support.md)).
+This enhancement does not affect MicroShift.
+
+#### OpenShift Kubernetes Engine
+
+This enhancement is fully applicable to OKE. Since the
+[gateway-api-without-olm](gateway-api-without-olm.md) enhancement
+enables Gateway API on OKE by eliminating OSSM licensing concerns,
+all three CRD management modes are available on OKE clusters.
+
+The `Unmanaged` mode may be particularly relevant for OKE customers
+who prefer to use their own Gateway API implementation.
+
+### Implementation Details/Notes/Constraints
+
+#### Feature Gate
+
+Per the OpenShift feature development process, this enhancement
+requires a new feature gate. The proposed feature gate name is
+`GatewayAPICRDManagementMode`. The feature gate must be added to
+https://github.com/openshift/api/blob/master/features/features.go
+with the `TechPreviewNoUpgrade` feature set initially.
+
+The `gatewayAPI` field on IngressControllerSpec must use the
+`+openshift:enable:FeatureGate=GatewayAPICRDManagementMode` marker
+to ensure the field is only present in CRDs for feature sets where
+the feature gate is enabled.
+
+The `ExternalCRDs` enum value should use the
+`+openshift:validation:FeatureGateAwareEnum` marker if the intent
+is to gate the unsupported mode separately from the other two modes.
+
+#### Interaction with the GatewayAPI Feature Gate
+
+The existing `GatewayAPI` feature gate controls whether CIO's
+Gateway API controllers are enabled at all. The new
+`GatewayAPICRDManagementMode` feature gate and the
+`crdManagementMode` field only take effect when the `GatewayAPI`
+feature gate is also enabled. When `GatewayAPI` is disabled, the
+`crdManagementMode` field is ignored and CIO does not manage any
+Gateway API resources regardless of the mode.
+
+#### CIO Controller Changes
+
+The following controllers in CIO are affected:
+
+1. **GatewayClass controller**: Must respect the management mode.
+   In `Unmanaged` mode, this controller must be fully disabled. In
+   `Managed` and `ExternalCRDs` modes, it operates as today.
+
+2. **CRD management controller**: Must respect the management mode.
+   In `Managed` mode, it installs, upgrades, and protects CRDs. In
+   `Unmanaged` and `ExternalCRDs` modes, it does not install or manage
+   CRDs but does observe their presence and compliance.
+
+3. **Gateway controller**: Must respect the management mode. In
+   `Unmanaged` mode, this controller is disabled. In `Managed` and
+   `ExternalCRDs` modes, it operates as today.
+
+4. **Status controller**: A new or extended controller that computes
+   the `CRDsManaged`, `CRDsPresent`, and `CRDsCompliant`
+   conditions in `status.gatewayAPI.conditions` based on the
+   configured
+   mode and the observed cluster state.
+
+#### VAP Management
+
+In `Managed` mode, the VAP that protects Gateway API CRDs from
+unauthorized modification is deployed as today. In `Unmanaged` and
+`ExternalCRDs` modes, the VAP must be removed to allow the cluster
+administrator or third-party products to modify the CRDs.
+
+The transition from `Managed` to `Unmanaged` or `ExternalCRDs` must
+remove the VAP before CIO stops managing the CRDs, to avoid
+leaving the cluster in a state where CRDs cannot be modified by
+anyone.
+
+#### CRD Validity Definition
+
+A Gateway API CRD is considered **valid** (compliant) when it meets
+the following criteria:
+
+1. **Strict version match**: The CRD must be the exact version that
+   the current CIO release expects. CIO pins to a specific Gateway
+   API release version (e.g., `v1.2.1`). The CRD's
+   `gateway.networking.k8s.io/bundle-version` label must match this
+   pinned version exactly. Version ranges are not supported in this
+   enhancement (see Non-Goals regarding future CRD version range
+   support).
+
+2. **Checksum verification** (future iteration): As a subsequent
+   improvement within this enhancement's scope, CIO will compute a
+   SHA-256 checksum of the CRD's OpenAPI schema and compare it
+   against the expected checksum embedded in the CIO binary. This
+   ensures that even if the version label matches, the actual schema
+   has not been tampered with or partially modified. Until checksum
+   verification is implemented, version label matching is the
+   primary compliance check.
+
+When CRDs are found to be non-compliant (in any mode), CIO will
+report the mismatch in the `CRDsCompliant` condition (under
+`status.gatewayAPI.conditions`)
+message, including:
+- The expected version and (when available) checksum.
+- The actual version and (when available) checksum found on the
+  cluster.
+- A pointer to where the administrator can obtain the correct CRD
+  manifests. The valid CRD manifests can be obtained from the
+  `gateway-api` container image shipped in the OpenShift release
+  payload at the path `/manifests/gateway-api/`. Alternatively,
+  they can be extracted from the upstream Gateway API release at
+  `https://github.com/kubernetes-sigs/gateway-api/releases` matching
+  the expected version.
+
+#### Mode Transition Ordering
+
+When transitioning between modes, CIO must follow a specific order
+to avoid leaving the cluster in an inconsistent state:
+
+- **Managed to Unmanaged**: Remove VAP, stop CRD management,
+  shutdown CIO-managed Istio instance. GatewayClass and Gateway
+  resources are left in place; administrator is responsible for
+  cleanup.
+- **Managed to ExternalCRDs**: Remove VAP, stop CRD management,
+  keep CIO-managed Istio instance, GatewayClass, and Gateway
+  running.
+- **Unmanaged to Managed**: Verify CRDs match expected version (or
+  are absent), install CRDs if absent, deploy VAP, start
+  CIO-managed Istio instance, GatewayClass, and Gateway.
+- **Unmanaged to ExternalCRDs**: Start CIO-managed Istio instance,
+  GatewayClass, and Gateway (CRDs must already be present or
+  controller will wait).
+- **ExternalCRDs to Managed**: Verify CRDs match expected version,
+  take ownership, deploy VAP.
+- **ExternalCRDs to Unmanaged**: Shutdown CIO-managed Istio
+  instance. GatewayClass and Gateway resources are left in place.
+
+#### Long-Term: Unknown Field Management
+
+As mentioned in
+[gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md),
+the "unknown fields" (or "dead fields") problem is being tracked
+upstream in
+[gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
+The `ExternalCRDs` mode is particularly susceptible to this problem because
+the CRDs may contain fields that the OpenShift Gateway controller
+does not recognize.
+
+This enhancement establishes the foundation for future work on
+unknown field management by providing the management mode
+infrastructure. Future enhancements can build on this to add:
+
+- CRD version range support (allowing a set of compatible versions
+  rather than a single pinned version).
+- Unknown field detection and warning mechanisms.
+- Automated compatibility checks between CRDs and the controller
+  version.
+
+This future work is out of scope for this enhancement.
+
+### Risks and Mitigations
+
+#### Risk: Unsupported ExternalCRDs Mode Misuse
+
+**Description**: Customers may use the `ExternalCRDs` mode in production
+and then file support tickets when things break due to CRD
+incompatibility.
+
+**Mitigation**: The `ExternalCRDs` mode will be clearly documented as
+unsupported. CIO will set a persistent unsupported warning condition
+on the IngressController status. The condition message will include
+explicit language that this configuration is not supported.
+Additionally, telemetry can capture the management mode to help
+support engineers quickly identify clusters using unsupported
+configurations.
+
+#### Risk: Orphaned Resources During Mode Transition
+
+**Description**: Switching from `Managed` to `Unmanaged` leaves
+GatewayClass, Gateway, and HTTPRoute resources on the cluster
+without a managing controller, which may confuse administrators.
+
+**Mitigation**: CIO intentionally does NOT remove Gateway API CRDs,
+GatewayClass, or Gateway resources when transitioning to `Unmanaged`
+mode to avoid disrupting existing workloads. The CIO-managed Istio
+instance is shut down, but all Gateway API resources are preserved.
+The cluster administrator is responsible for cleaning up these
+resources if desired. Documentation must clearly state that
+resources are preserved during mode transitions and that the
+administrator must handle cleanup.
+
+#### Risk: Incompatible Mode Transition
+
+**Description**: Switching from `Unmanaged` or `ExternalCRDs` to `Managed`
+may fail if the existing CRDs do not match the expected version.
+
+**Mitigation**: CIO will verify CRD compliance before taking
+ownership. If CRDs are incompatible, CIO will set
+`CRDsCompliant=False` (in `status.gatewayAPI.conditions`) and will
+NOT overwrite the CRDs.
+The administrator must resolve the mismatch (by upgrading or
+removing the CRDs) before the transition can complete. This
+prevents accidental data loss or breaking existing configurations.
+
+#### Risk: Security Implications of Removing VAP
+
+**Description**: In `Unmanaged` and `ExternalCRDs` modes, the VAP is
+removed, allowing any actor with sufficient RBAC to modify the
+Gateway API CRDs.
+
+**Mitigation**: This is an explicit trade-off of these modes.
+Documentation must clearly state that the VAP protection is
+removed in non-Managed modes. Customers who choose these modes
+are accepting responsibility for CRD integrity. Standard
+Kubernetes RBAC still applies to CRD modifications.
+
+### Drawbacks
+
+The primary drawback is increased complexity in CIO. The operator
+must now handle three distinct behavioral modes, each with its own
+set of controllers to enable/disable and status conditions to
+compute. This increases the testing surface and the potential for
+edge-case bugs during mode transitions.
+
+However, this complexity is justified by the clear customer demand
+for CRD ownership flexibility and the fact that the alternative --
+customers fighting the VAP and CRD reconciler -- is worse for both
+customers and support.
+
+Another drawback is the `ExternalCRDs` mode, which introduces an explicitly
+unsupported configuration. While this creates a risk of support
+confusion, the alternative of not providing this mode would push
+advanced users toward even more unsupported workarounds (e.g.,
+disabling the VAP manually and using `unsupportedConfigOverrides`).
+
+## Open Questions
+
+1. **Field placement**: Should `gatewayAPI` live on the `default`
+   IngressController only, or should it be allowed on any
+   IngressController? Given that Gateway API CRD management is a
+   cluster-wide concern (CRDs are cluster-scoped), it may make
+   sense to restrict this to the `default` IngressController to
+   avoid conflicting configurations from multiple IngressControllers.
+
+2. **ExternalCRDs mode scope**: Should the `ExternalCRDs` mode
+   perform any compatibility pre-checks before starting the
+   CIO-managed Istio instance, or should it always attempt to start
+   and report incompatibility via status conditions after the fact?
+
+3. **CRD cleanup on Unmanaged transition**: Should CIO offer an
+   option to remove the CRDs when transitioning to `Unmanaged`?
+   This is dangerous (it would delete all Gateway/HTTPRoute
+   resources) but some customers may want a clean slate. The
+   current proposal preserves CRDs during transitions.
+
+4. **Interaction with `unsupportedConfigOverrides`**: The existing
+   CRD lifecycle management enhancement mentions
+   `unsupportedConfigOverrides` as a mechanism for bypassing CRD
+   succession checks. Should the new `crdManagementMode` field
+   replace this mechanism, or should they coexist?
+
+5. **Telemetry**: What telemetry should be collected for the
+   management mode? At minimum, the configured mode should be
+   reported. Should CIO also report metrics for CRD compliance
+   state and mode transition events?
+
+## Test Plan
+
+<!-- TODO: Tests must include the following labels per
+dev-guide/feature-zero-to-hero.md:
+- [OCPFeatureGate:GatewayAPICRDManagementMode] for the feature gate
+- [Jira:"Networking / ingress"] for the component
+- Appropriate test type labels: [Serial], [Slow], [Disruptive]
+  as needed
+- Reference dev-guide/test-conventions.md for details -->
+
+Testing strategy covers unit tests, integration tests, and e2e tests
+for each management mode and mode transitions.
+
+### Unit Tests
+
+- Validation of the `crdManagementMode` field (valid enum values,
+  defaulting behavior).
+- Status condition computation logic for each mode.
+- Controller enable/disable logic based on mode.
+
+### Integration Tests
+
+- CRD management controller behavior in each mode.
+- VAP deployment and removal during mode transitions.
+- Status condition updates during mode transitions.
+
+### E2E Tests
+
+The following e2e test scenarios are required:
+
+1. **Managed mode (default)**: Verify that a new cluster has CRDs
+   installed, VAP deployed, and the Gateway controller stack
+   running. Verify status conditions report `Managed`.
+
+2. **Transition to Unmanaged**: Set mode to `Unmanaged`. Verify
+   that the CIO-managed Istio instance is shut down, the VAP is
+   removed, and CRDs, GatewayClass, and Gateway resources are
+   preserved. Verify status conditions report `Unmanaged`. Verify
+   a third-party GatewayClass can be created.
+
+3. **Transition to ExternalCRDs**: Set mode to `ExternalCRDs`. Verify that the
+   VAP is removed, CRDs are no longer managed, but the Gateway
+   controller stack remains running. Verify the unsupported warning
+   condition.
+
+4. **Return to Managed**: From `Unmanaged` or `ExternalCRDs`, return to
+   `Managed`. Verify CIO takes ownership of compatible CRDs, or
+   reports incompatibility for mismatched CRDs.
+
+5. **Unmanaged mode with absent CRDs**: Set mode to `Unmanaged` on
+   a cluster with no Gateway API CRDs. Verify CIO does not install
+   CRDs and reports `CRDsNotFound`.
+
+6. **ExternalCRDs mode with incompatible CRDs**: Set mode to `ExternalCRDs` and
+   install CRDs that do not match the expected version. Verify CIO
+   reports compliance failure but continues running the Gateway
+   controller stack.
+
+7. **Upgrade with non-default mode**: Upgrade a cluster that has
+   `Unmanaged` or `ExternalCRDs` mode set. Verify the mode is preserved
+   and CIO does not attempt to take over CRDs during upgrade.
+
+## Graduation Criteria
+
+<!-- TODO: Promotion requirements per
+dev-guide/feature-zero-to-hero.md:
+- Minimum 5 tests
+- 7 runs per week
+- 14 runs per supported platform
+- 95% pass rate
+- Tests running on all supported platforms
+  (AWS, Azure, GCP, vSphere, Baremetal with IPv4/IPv6/Dual) -->
+
+### Dev Preview -> Tech Preview
+
+- Feature gate `GatewayAPICRDManagementMode` added to
+  `TechPreviewNoUpgrade` feature set.
+- `Managed` and `Unmanaged` modes fully functional.
+- `ExternalCRDs` mode functional with unsupported warning.
+- Status conditions implemented and observable.
+- Unit and integration tests passing.
+- Initial e2e tests for basic mode transitions.
+- End user documentation for Tech Preview.
+
+### Tech Preview -> GA
+
+- All e2e test scenarios passing consistently (95%+ pass rate).
+- Upgrade and downgrade testing with mode transitions validated.
+- Mode transition edge cases tested (e.g., incompatible CRDs,
+  missing CRDs).
+- Telemetry for management mode implemented and reporting.
+- Load testing with mode transitions under concurrent operations.
+- User-facing documentation created in
+  [openshift-docs](https://github.com/openshift/openshift-docs/).
+- Feature gate promoted to `Default` feature set.
+- Sufficient time for customer feedback (at least one minor
+  release in Tech Preview).
+
+### Backport to OCP 4.19
+
+There is a desire to backport this feature all the way back to
+OpenShift OCP 4.19. The motivation is to allow customers who are
+already running 4.19 with third-party Gateway API controllers (or
+who need to opt out of CIO's CRD management) to do so cleanly,
+and to ensure that customers upgrading from 4.19 through later
+releases have a consistent, supported upgrade path with the CRD
+management mode available at every step.
+
+Without the backport, customers on 4.19 who have installed
+third-party Gateway API CRDs would face CRD succession conflicts
+during upgrade to a version that includes this knob, because the
+older 4.19 CIO would still enforce CRD ownership with no opt-out
+mechanism. Backporting gives customers the ability to set
+`Unmanaged` or `ExternalCRDs` mode on 4.19 before upgrading,
+ensuring a smooth transition.
+
+The backport scope includes:
+- The `gatewayAPI` spec and status structs on IngressController.
+- The `crdManagementMode` enum with all three values.
+- The `status.gatewayAPI.conditions` reporting.
+- The feature gate `GatewayAPICRDManagementMode` (behind
+  `TechPreviewNoUpgrade` on 4.19).
+
+The backport does NOT require changes to the CRD succession logic
+already present in 4.19 (from
+[gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md)).
+Instead, it adds the opt-out mechanism on top of the existing
+behavior.
+
+### Removing a deprecated feature
+
+Not applicable. This enhancement adds new functionality.
+
+## Upgrade / Downgrade Strategy
+
+### Upgrade
+
+When upgrading from a version that does not have the
+`gatewayAPI.crdManagementMode` field to one that does (e.g.,
+upgrading from 4.18 to 4.19 with the backport applied):
+
+- The field defaults to `Managed`, which preserves the existing
+  behavior. No action is required from the cluster administrator.
+- Existing clusters with CIO-managed CRDs continue to work
+  identically.
+- The new status conditions are added to the IngressController
+  status on the first reconciliation after upgrade.
+
+When upgrading a cluster that has a non-default mode set (e.g.,
+upgrading from 4.19 to 4.20+ with mode already configured):
+
+- **Unmanaged mode**: CIO does not attempt to install or manage
+  CRDs during the upgrade. The administrator's third-party CRDs
+  are preserved.
+- **ExternalCRDs mode**: CIO does not upgrade CRDs but does upgrade
+  the CIO-managed Istio instance. If the new Istio version is
+  incompatible with the existing CRDs, CIO reports degraded status.
+  The administrator is responsible for updating the CRDs.
+
+### Downgrade
+
+When downgrading from a version that has the
+`gatewayAPI.crdManagementMode` field to one that does not:
+
+- The older CIO version does not recognize the `gatewayAPI` field
+  and ignores it (standard Kubernetes API behavior for unknown
+  fields -- the field is simply pruned on the next write).
+- The older CIO version will behave as if the mode is `Managed`
+  (its only behavior), which means it will attempt to install and
+  manage CRDs.
+- **If the cluster was in `Unmanaged` mode**: The downgraded CIO
+  will attempt to install CRDs and deploy the Gateway controller
+  stack. If third-party CRDs are present, the existing CRD
+  management succession logic (from
+  [gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md))
+  applies.
+- **If the cluster was in `ExternalCRDs` mode**: The downgraded CIO will
+  attempt to take ownership of the CRDs. If they do not match the
+  expected version, the operator reports `Degraded`.
+
+**Recommendation**: Before downgrading, the administrator should
+set the mode to `Managed` and ensure CRDs are compatible with the
+target version. Documentation must include this as a required
+pre-downgrade step.
+
+## Version Skew Strategy
+
+During an upgrade, there may be a brief period where the new CIO
+binary is running but the IngressController CRD has not yet been
+updated to include the `gatewayAPI` field. During this period, CIO
+will treat the absence of the field as `Managed` mode (the default),
+which is the existing behavior. No version skew issues are expected.
+
+The `gatewayAPI` field is consumed only by CIO and does not require
+coordination with any other component on the node or in the control
+plane.
+
+## Operational Aspects of API Extensions
+
+This enhancement adds new fields to the existing IngressController
+CRD and new status conditions. The operational impact is minimal:
+
+- **API throughput**: No measurable impact. The new field is read
+  by CIO during reconciliation, which already reads the full
+  IngressController spec. The additional status conditions add a
+  small amount of data to status updates.
+
+- **SLIs**: The new status conditions themselves serve as SLIs for
+  Gateway API CRD management health. Administrators and monitoring
+  systems can watch for:
+  - `status.gatewayAPI.conditions` `CRDsManaged=False` with
+    unexpected reasons
+  - `status.gatewayAPI.conditions` `CRDsCompliant=False` indicating
+    CRD drift
+  - `status.gatewayAPI.conditions` `CRDsPresent=False` in modes
+    that expect CRDs
+
+- **Failure modes**:
+  - If CIO fails to remove the VAP during a mode transition, CRDs
+    remain protected and the administrator cannot modify them. CIO
+    should retry VAP removal and report the failure in status.
+  - If CIO fails to deploy the Gateway controller stack in
+    `ExternalCRDs` mode because CRDs are absent, CIO should report the
+    failure and retry when CRDs become available.
+
+- **Escalation**: Issues with CRD management mode should be
+  escalated to the Networking / Ingress team (NID). For issues
+  involving Istio CRD interactions, the OSSM team should be
+  consulted.
+
+## Support Procedures
+
+### Detecting the Current Mode
+
+```bash
+oc get ingresscontroller default \
+  -n openshift-ingress-operator \
+  -o jsonpath='{.spec.gatewayAPI.crdManagementMode}'
+```
+
+### Checking CRD Management Status
+
+```bash
+oc get ingresscontroller default \
+  -n openshift-ingress-operator \
+  -o jsonpath='{.status.gatewayAPI.conditions}' | \
+  jq '.[]'
+```
+
+### Common Issues
+
+**Symptom**: `CRDsCompliant=False` in `status.gatewayAPI.conditions`
+after switching to `Managed` mode.
+
+**Diagnosis**: The existing CRDs do not match the expected version.
+Check the condition message for the expected and actual versions.
+
+**Resolution**: Either upgrade the CRDs to the expected version or
+remove them and let CIO reinstall them. Valid CRD manifests can be
+obtained from the `gateway-api` container image in the OpenShift
+release payload at `/manifests/gateway-api/`, or from the upstream
+Gateway API release at
+`https://github.com/kubernetes-sigs/gateway-api/releases` matching
+the expected version shown in the condition message.
+
+```bash
+# Check expected version from condition message
+oc get ingresscontroller default \
+  -n openshift-ingress-operator \
+  -o jsonpath='{.status.gatewayAPI.conditions}' | \
+  jq '.[] | select(.type=="CRDsCompliant")'
+
+# Remove CRDs to let CIO reinstall (WARNING: this deletes
+# all Gateway, HTTPRoute, and other Gateway API resources)
+oc delete crd \
+  gatewayclasses.gateway.networking.k8s.io \
+  gateways.gateway.networking.k8s.io \
+  httproutes.gateway.networking.k8s.io \
+  referencegrants.gateway.networking.k8s.io \
+  grpcroutes.gateway.networking.k8s.io
+```
+
+**Symptom**: Gateway controller stack not starting in `ExternalCRDs` mode.
+
+**Diagnosis**: Gateway API CRDs are absent. The controller cannot
+create GatewayClass/Gateway resources without the CRDs.
+
+**Resolution**: Install Gateway API CRDs. CIO will detect their
+presence and start the controller stack.
+
+**Symptom**: `CRDsManaged=False` with reason `ExternalCRDs` and an
+unsupported warning in `status.gatewayAPI.conditions`.
+
+**Diagnosis**: This is expected behavior for `ExternalCRDs` mode. Verify
+with the customer that they intentionally chose this mode. If this
+is a production cluster, recommend switching to `Managed` mode.
+
+## Alternatives (Not Implemented)
+
+### Alternative 1: Boolean Gateway API Disable Switch
+
+A simpler approach would be a boolean field to enable/disable
+Gateway API entirely. However, this does not address the use case
+where customers want to bring their own CRDs while using the
+OpenShift Gateway controller. Additionally, OpenShift API
+conventions prohibit boolean fields in CRDs.
+
+### Alternative 2: Annotation-Based Configuration
+
+Using annotations on the IngressController to control CRD management
+mode would avoid an API change but would lack validation,
+defaulting, and discoverability. Annotations are also not visible
+in `oc describe` output as structured fields and cannot have
+kubebuilder validation applied.
+
+### Alternative 3: Separate CRD for Gateway API Configuration
+
+Creating a new `GatewayAPIConfig` CRD would provide a clean
+separation of concerns but adds operational complexity (a new
+resource to manage, new RBAC rules, a new controller to reconcile).
+Given that CRD management mode is directly related to
+IngressController behavior, placing it on the IngressController
+spec is more natural and discoverable.
+
+### Alternative 4: Per-CRD Management Granularity
+
+Instead of a single mode for all Gateway API CRDs, each CRD could
+have its own management mode (e.g., manage GatewayClass CRD but not
+HTTPRoute CRD). This would provide maximum flexibility but adds
+significant complexity for minimal benefit. In practice, CRDs are
+either managed as a cohesive set or not managed at all.
+
+## Infrastructure Needed
+
+No new infrastructure is required for this enhancement.

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -924,7 +924,8 @@ oc delete crd \
   gateways.gateway.networking.k8s.io \
   httproutes.gateway.networking.k8s.io \
   referencegrants.gateway.networking.k8s.io \
-  grpcroutes.gateway.networking.k8s.io
+  grpcroutes.gateway.networking.k8s.io \
+  backendtlspolicies.gateway.networking.k8s.io
 ```
 
 ## Alternatives (Not Implemented)

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -28,21 +28,19 @@ see-also:
 
 This enhancement introduces a new cluster-scoped singleton API
 resource, `Ingress` (resource `ingresses`, singleton named
-`cluster`), in the `operator.openshift.io/v1alpha1` group. The
-resource exposes a `spec.gatewayAPI.managementMode` enum
-field that controls how the Cluster Ingress Operator (CIO)
-manages Gateway API CRDs and the associated Gateway controller
-stack (CIO-managed Istio, GatewayClass, Gateway). Two modes
-are provided: `Managed` (default -- CIO owns everything) and
-`Unmanaged` (CIO stops managing, reports observational status only).
+`cluster`), in the `operator.openshift.io/v1alpha1` group.
 
-The field lives on a new resource rather than on
-`IngressController` (where multiple instances could conflict) or
-`ingress.config.openshift.io/cluster` (which is owned by
-`config-operator` for install-time configuration). The
-`operator.openshift.io` group already has cluster-scoped
-singletons (`DNS`, `Console`) and is the natural home for
-operator-managed behavior.
+The resource exposes a `spec.gatewayAPI.managementMode` enum
+field that controls how the Cluster Ingress Operator (CIO)
+manages Gateway API CRDs, the CIO-managed Istio installation,
+and the associated CIO Gateway API controllers (`gatewayapi`,
+`gatewayclass`, `gateway-labeler`, `gateway-network-policy`,
+`gateway-service-dns`, `gateway-status`, and other controllers
+that may be added in the future).
+
+Two modes are provided: `Managed` (default -- CIO owns everything,
+controllers are enabled) and `Unmanaged` (CIO stops managing,
+reports observational status only).
 
 ## Motivation
 
@@ -105,18 +103,14 @@ drifted from the expected state.
 
 ### Non-Goals
 
-1. **Unknown field management**: Future work tracked upstream in
-   [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
-   This enhancement mentions it for context but does not define the
-   solution.
-2. **CRD version ranges**: Future work that depends on resolving
-   the unknown fields problem.
-3. **Automatic migration of third-party CRDs**: When switching from
+1. **CRD version ranges**: Each OCP version supports a specific
+   Gateway API CRD version, not a version within a range.
+2. **Automatic migration of third-party CRDs**: When switching from
    `Unmanaged` to `Managed`, CIO will not migrate third-party CRDs.
    The administrator must ensure compatibility before changing modes.
-4. **MicroShift support**: MicroShift does not use CIO and is
+3. **MicroShift support**: MicroShift does not use CIO and is
    unaffected by this enhancement.
-5. **Istio CRD management**: This enhancement controls only Gateway
+4. **Istio CRD management**: This enhancement controls only Gateway
    API CRDs (`gateway.networking.k8s.io`). Istio CRDs are handled
    by the sail-operator library as described in
    [gateway-api-without-olm](gateway-api-without-olm.md).
@@ -130,7 +124,7 @@ Introduce a new cluster-scoped singleton API resource in the
 - **Resource**: `ingresses`
 - **Scope**: Cluster (non-namespaced)
 - **Singleton name**: `cluster`
-- **Pattern**: Same as `DNS` and `Console` in
+- **Pattern**: Same as `DNS` in
   `operator.openshift.io/v1` -- embeds
   `OperatorSpec`/`OperatorStatus` inline.
 
@@ -141,13 +135,18 @@ CIO watches this resource and reads
 `spec.gatewayAPI.managementMode` to determine its behavior:
 
 - **Managed** (default): CIO installs, protects (via VAP), and
-  upgrades Gateway API CRDs. CIO runs the full Gateway controller
-  stack (CIO-managed Istio, GatewayClass, Gateway). This is the
-  current behavior and the only fully supported configuration.
+  upgrades Gateway API CRDs, runs the CIO-managed Istio instance,
+  and runs the CIO Gateway API controllers (`gatewayapi`,
+  `gatewayclass`, `gateway-labeler`, `gateway-network-policy`,
+  `gateway-service-dns`, `gateway-status`, and others). This is
+  the current behavior and the only fully supported configuration.
 
-- **Unmanaged**: CIO does not install CRDs and does not deploy
-  the Gateway controller stack. The customer or a third-party
-  product owns the CRDs and Gateway controller. CIO reports
+- **Unmanaged**: CIO does not install CRDs, does not run the
+  CIO-managed Istio instance, and does not run the CIO Gateway
+  API controllers (`gatewayapi`, `gatewayclass`, `gateway-labeler`,
+  `gateway-network-policy`, `gateway-service-dns`, `gateway-status`,
+  and others). The customer or a third-party product owns the
+  CRDs and Gateway controller. CIO reports
   observational status only. This mode also serves as a signal
   to layered products that the installed CRDs may not be the
   ones supported by the OpenShift Gateway API implementation,
@@ -159,7 +158,7 @@ CIO watches this resource and reads
 the OpenShift cluster and configuring ingress.
 
 **CIO (Cluster Ingress Operator)** is the operator that reconciles
-IngressController resources and manages Gateway API components.
+`ingresses.operator.openshift.io` resources and manages Gateway API components.
 
 #### Workflow 1: Default Managed Mode (No Action Required)
 
@@ -196,14 +195,16 @@ IngressController resources and manages Gateway API components.
    b. Removes the VAP protecting Gateway API CRDs.
    c. Does **not** remove the GatewayClass, Gateway resources, or
       Gateway API CRDs. Removing these resources could cause
-      disruptions to existing workloads. The cluster administrator
-      is responsible for cleaning up these resources if desired.
+      disruptions to existing workloads for gateways that are being
+      managed by a third-party gateway controller. The cluster
+      administrator is responsible for cleaning up these resources
+      if desired.
 4. CIO sets the following conditions in `status.conditions`:
    - `GatewayAPICRDsManaged=False` (reason: `Unmanaged`)
    - `GatewayAPICRDsPresent=True/False` (observational)
-   - `GatewayAPICRDsCompliant=True/False/Unknown` (whether the
+   - `GatewayAPICRDsCompliant=True/False` (whether the
      installed CRDs match the version expected by the ingress
-     operator; `Unknown` if no Gateway API CRDs are present)
+     operator)
 5. The cluster administrator installs their third-party Gateway
    controller and optionally their own CRD version.
 6. Layered products observe the `GatewayAPICRDsManaged=False`
@@ -244,10 +245,12 @@ IngressController resources and manages Gateway API components.
       CIO can take ownership.
 5. Once `GatewayAPICRDsManaged=True`, `GatewayAPICRDsPresent=True`,
    and `GatewayAPICRDsCompliant=True`, CIO starts the CIO-managed
-   Istio instance, GatewayClass, and Gateway resources. If any of
-   these conditions is not `True`, the Gateway controller stack is
-   not started but the cluster is not marked as degraded and
-   upgrades are not blocked.
+   Istio instance and the CIO Gateway API controllers (`gatewayapi`,
+   `gatewayclass`, `gateway-labeler`, `gateway-network-policy`,
+   `gateway-service-dns`, `gateway-status`, and others). If any of
+   these conditions is not `True`, the Istio instance and the CIO
+   Gateway API controllers are not started, but the cluster is not
+   marked as degraded and upgrades are not blocked.
 
 ```mermaid
 sequenceDiagram
@@ -255,14 +258,14 @@ sequenceDiagram
     participant IC as Ingress (operator.openshift.io/v1alpha1)
     participant CIO as Cluster Ingress Operator
     participant CRDs as Gateway API CRDs
-    participant GW as Gateway Stack<br/>(CIO Istio/GatewayClass/Gateway)
+    participant GW as CIO Istio Instance &<br/>Gateway API Controllers
 
     Note over Admin,GW: Workflow: Mode Transition
     Admin->>IC: Set spec.gatewayAPI.managementMode
 
     alt Managed (default)
         CIO->>CRDs: Install/upgrade CRDs + VAP
-        CIO->>GW: Deploy CIO Istio, GatewayClass, Gateway
+        CIO->>GW: Start CIO Istio instance and Gateway API controllers
         CIO->>IC: Set status.conditions: GatewayAPICRDsManaged=True,<br/>GatewayAPICRDsPresent=True, GatewayAPICRDsCompliant=True
     else Unmanaged
         CIO->>GW: Stop CIO Istio instance
@@ -275,21 +278,21 @@ sequenceDiagram
 ### API Extensions
 
 This enhancement introduces a **new CRD** in the
-`operator.openshift.io/v1alpha1` group. The new resource follows the
-same pattern as the existing `DNS` and `Console` cluster-scoped
-singletons in `operator.openshift.io/v1`.
+`operator.openshift.io/v1alpha1` group. The new resource follows a
+singleton approach similar to the existing `DNS` cluster-scoped
+singleton in `operator.openshift.io/v1`.
 
 **Why a new resource** (see also Alternatives section):
 `IngressController` is namespaced and multi-instance, so it
 cannot hold a cluster-wide setting without conflicts.
 `ingress.config.openshift.io` is owned by `config-operator` for
 install-time configuration. A dedicated singleton in
-`operator.openshift.io` follows the DNS/Console pattern and
-provides a clean extension point.
+`operator.openshift.io` follows the DNS pattern and provides a
+clean extension point.
 
 The proposed Go types are in a new file in `operator/v1alpha1/` in
 the `openshift/api` repository (e.g.,
-`types_ingress_gateway.go`):
+`types_ingress.go`):
 
 ```go
 // +genclient
@@ -329,8 +332,9 @@ type IngressSpec struct {
 	OperatorSpec `json:",inline"`
 
 	// gatewayAPI holds configuration for Gateway API
-	// integration, including how the Cluster Ingress Operator
-	// manages Gateway API CRDs and the Gateway controller stack.
+	// integration, including how the ingress operator manages
+	// Gateway API CRDs, the Istio instance it deploys, and its
+	// Gateway API controllers.
 	//
 	// +required
 	// +openshift:enable:FeatureGate=GatewayAPIManagementMode
@@ -350,8 +354,10 @@ type IngressStatus struct {
 	//     ingress operator is installing, protecting (via VAP), and
 	//     upgrading CRDs.
 	//   - status: False, reason: "Unmanaged" — the administrator
-	//     chose Unmanaged mode; the ingress operator does not manage
-	//     CRDs or the Gateway controller stack.
+	//     chose Unmanaged mode, or a conflict prevents the ingress
+	//     operator from taking control of the CRDs; the ingress
+	//     operator does not manage CRDs or run the OpenShift
+	//     Gateway API implementation.
 	//
 	// "GatewayAPICRDsPresent" indicates whether Gateway API CRDs
 	// exist on the cluster:
@@ -368,9 +374,6 @@ type IngressStatus struct {
 	//     CRDs do not match the expected version. The message
 	//     includes expected and actual versions and a pointer
 	//     to where valid manifests can be obtained.
-	//   - status: Unknown, reason: "Unknown" — compliance
-	//     check is not applicable (e.g., no Gateway API CRDs
-	//     are present on the cluster).
 	OperatorStatus `json:",inline"`
 }
 ```
@@ -387,15 +390,15 @@ type GatewayAPIManagementMode string
 const (
 	// GatewayAPIManagementModeManaged means the ingress operator
 	// installs, owns, protects (via VAP), and upgrades the Gateway
-	// API CRDs. The ingress operator also deploys the full Gateway
-	// controller stack (the Istio instance deployed by the ingress
-	// operator, GatewayClass, Gateway). This is the default mode
-	// and the only fully supported configuration.
+	// API CRDs, deploys the OpenShift Gateway API implementation,
+	// and runs its Gateway API controllers. This is the default
+	// mode and the only fully supported configuration.
 	GatewayAPIManagementModeManaged GatewayAPIManagementMode = "Managed"
 
 	// GatewayAPIManagementModeUnmanaged means the ingress operator
-	// does NOT install or manage Gateway API CRDs and does NOT
-	// deploy the Gateway controller stack. The customer or a
+	// does NOT install or manage Gateway API CRDs, does NOT
+	// deploy the OpenShift Gateway API implementation, and does
+	// NOT run its Gateway API controllers. The customer or a
 	// third-party product is responsible for bringing their own
 	// CRDs and Gateway controller. The ingress operator reports
 	// observational status only. This mode signals to layered
@@ -409,23 +412,21 @@ const (
 type GatewayAPIIngressConfig struct {
 	// managementMode specifies how the Cluster Ingress
 	// Operator manages Gateway API Custom Resource Definitions
-	// (CRDs) and the associated Gateway controller stack.
+	// (CRDs), the OpenShift Gateway API implementation, and its
+	// Gateway API controllers.
 	//
 	// When set to "Managed" (the default), the ingress operator
 	// installs, owns, and upgrades the Gateway API CRDs, protects
 	// them with a Validating Admission Policy, and deploys the
-	// full Gateway controller stack (the Istio instance deployed
-	// by the ingress operator, GatewayClass, Gateway resources).
-	// This is the only fully supported configuration.
+	// OpenShift Gateway API implementation and its Gateway API
+	// controllers. This is the only fully supported configuration.
 	//
 	// When set to "Unmanaged", the ingress operator does not
 	// install or manage Gateway API CRDs and does not deploy the
-	// Gateway controller stack. The cluster administrator or a
-	// third-party product is responsible for providing their own
-	// CRDs and Gateway controller. The ingress operator reports
-	// observational status only. This mode also serves as a signal
-	// to layered products that the installed CRDs may not be the
-	// ones supported by the OpenShift Gateway API implementation.
+	// OpenShift Gateway API implementation or its Gateway API
+	// controllers. The cluster administrator or a third-party
+	// product is responsible for providing their own CRDs and
+	// Gateway controller.
 	//
 	// +kubebuilder:default:="Managed"
 	// +default="Managed"
@@ -447,12 +448,11 @@ The following Gateway API conditions are set within
 | Condition Type | Status | Reason | Description |
 |---|---|---|---|
 | `GatewayAPICRDsManaged` | `True` | `ManagedByIngressOperator` | Ingress operator is actively managing CRDs |
-| `GatewayAPICRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
+| `GatewayAPICRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode, or a conflict prevents the ingress operator from taking control of the CRDs |
 | `GatewayAPICRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
 | `GatewayAPICRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
 | `GatewayAPICRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
 | `GatewayAPICRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
-| `GatewayAPICRDsCompliant` | `Unknown` | `Unknown` | Compliance check is not applicable (e.g., no Gateway API CRDs are present on the cluster) |
 
 **API versioning note:** As a net-new API, this resource is
 introduced at `v1alpha1` (`operator.openshift.io/v1alpha1`). It
@@ -480,7 +480,8 @@ Primary topology. Both modes apply with no special considerations.
 #### Single-node Deployments or MicroShift
 
 **SNO**: No additional resource concerns. `Unmanaged` mode allows
-disabling the Gateway controller stack to reclaim resources.
+disabling the CIO-managed Istio instance and CIO Gateway API
+controllers to reclaim resources.
 
 **MicroShift**: Not affected. MicroShift does not use CIO (see
 [MicroShift Gateway API Support](../microshift/gateway-api-support.md)).
@@ -511,27 +512,25 @@ so it only appears in CRDs when the gate is enabled.
 
 #### Interaction with the GatewayAPI Feature Gate
 
-The `managementMode` field only takes effect when the existing
-`GatewayAPI` feature gate is also enabled. When `GatewayAPI` is
-disabled, CIO does not manage any Gateway API resources regardless
-of the mode setting.
+The `managementMode` field only takes effect when Gateway API is
+enabled. On OCP versions before 4.22, Gateway API controllers are
+gated behind the `GatewayAPI` feature gate, so `managementMode`
+also requires that gate to be enabled. Starting with OCP 4.22,
+Gateway API is available by default and this requirement no
+longer applies.
 
 #### CIO Controller Changes
 
-Affected controllers:
+The CIO controllers that manage the Gateway API feature (`gatewayapi`,
+`gatewayclass`, `gateway-labeler`, `gateway-network-policy`,
+`gateway-service-dns`, `gateway-status`, and others) are deactivated
+in `Unmanaged` mode.
 
-| Controller | Managed | Unmanaged |
-|---|---|---|
-| CRD management | Install, upgrade, protect (VAP) | Observe only |
-| GatewayClass | Active | Disabled |
-| Gateway | Active | Disabled |
-| Status | Report conditions | Report conditions |
+#### Istio and Gateway API Controllers Start Condition
 
-#### Gateway Controller Stack Start Condition
-
-CIO starts the CIO-managed Istio instance, GatewayClass, and Gateway
-resources only when all three of the following conditions are `True`
-in `status.conditions`:
+CIO starts the CIO-managed Istio instance and the CIO Gateway API
+controllers only when all three of the following conditions are
+`True` in `status.conditions`:
 
 - `GatewayAPICRDsManaged=True`
 - `GatewayAPICRDsPresent=True`
@@ -539,8 +538,9 @@ in `status.conditions`:
 
 If any of these conditions is not `True` (e.g., during a transition
 back to `Managed` where CRDs are non-compliant, or while CIO is
-installing CRDs), the Gateway controller stack is not started. This
-is not a degraded state: these conditions do not contribute to the
+installing CRDs), the Istio instance and CIO Gateway API
+controllers are not started. This is not a degraded state: these
+conditions do not contribute to the
 operator's `Degraded` status condition and do not block cluster
 upgrades. They are informational signals about Gateway API CRD
 readiness.
@@ -560,9 +560,9 @@ A Gateway API CRD is considered **compliant** when:
    the exact Gateway API version that CIO expects (e.g.,
    `v1.2.1`). Version ranges are not supported (see Non-Goals).
 
-2. **Checksum verification** (future iteration): SHA-256 checksum
-   of the CRD's OpenAPI schema compared against the expected
-   checksum embedded in the CIO binary.
+2. **Semantic verification**: The CRDs are compared against the
+   expected schema using
+   `"k8s.io/apimachinery/pkg/api/equality".Semantic.DeepEqual`.
 
 When CRDs are non-compliant, CIO reports the mismatch in the
 `GatewayAPICRDsCompliant` condition message, including expected vs. actual
@@ -578,13 +578,13 @@ are available from:
 When transitioning between modes, CIO must follow a specific order
 to avoid leaving the cluster in an inconsistent state:
 
-- **Managed to Unmanaged**: Remove VAP, stop CRD management,
-  shut down CIO-managed Istio instance. GatewayClass and Gateway
-  resources are left in place; administrator is responsible for
-  cleanup.
+- **Managed to Unmanaged**: Remove VAP, stop CRD management, shut
+  down the CIO-managed Istio instance and the CIO Gateway API
+  controllers. GatewayClass and Gateway resources are left in
+  place; administrator is responsible for cleanup.
 - **Unmanaged to Managed**: Verify CRDs match expected version (or
-  are absent), install CRDs if absent, deploy VAP, start
-  CIO-managed Istio instance, GatewayClass, and Gateway.
+  are absent), install CRDs if absent, deploy VAP, start the
+  CIO-managed Istio instance and the CIO Gateway API controllers.
 
 #### Long-Term: Unknown Field Management
 
@@ -592,8 +592,8 @@ The "unknown fields" problem (CRDs containing fields the controller
 does not recognize) is tracked upstream in
 [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
 This enhancement provides the management mode infrastructure that future
-work (version ranges, unknown field detection, compatibility
-checks) can build on. See Non-Goals for scope.
+work (unknown field detection, compatibility checks) can build on.
+Unknown field management is out of scope for this enhancement.
 
 #### Future Work on the Ingress Resource
 
@@ -695,9 +695,9 @@ for each management mode and mode transitions.
 The following e2e test scenarios are required:
 
 1. **Managed mode (default)**: Verify that a new cluster has CRDs
-   installed, VAP deployed, and the Gateway controller stack
-   running. Verify `GatewayAPICRDsManaged=True`,
-   `GatewayAPICRDsPresent=True`, and
+   installed, VAP deployed, and the CIO-managed Istio instance
+   and CIO Gateway API controllers running. Verify
+   `GatewayAPICRDsManaged=True`, `GatewayAPICRDsPresent=True`, and
    `GatewayAPICRDsCompliant=True`.
 
 2. **Transition to Unmanaged**: Set mode to `Unmanaged`. Verify
@@ -821,9 +821,9 @@ When downgrading from a version that has the Ingress
 - The older CIO behaves as `Managed` (its only behavior) and
   attempts to install and manage Gateway API CRDs.
 - **If the cluster was in `Unmanaged` mode**: The downgraded CIO
-  will attempt to install CRDs and deploy the Gateway controller
-  stack. If third-party CRDs are present, the existing CRD
-  management succession logic (from
+  will attempt to install CRDs and deploy the Istio instance and
+  Gateway API controllers. If third-party CRDs are present, the
+  existing CRD management succession logic (from
   [gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md))
   applies.
 
@@ -906,11 +906,11 @@ oc delete crd \
 ### Alternative 1: ControllersOnly Mode (Controller without CRD Management)
 
 A third mode, `ControllersOnly`, was considered where CIO would not
-manage Gateway API CRDs but would still deploy the OpenShift Gateway
-controller stack (CIO-managed Istio, GatewayClass, Gateway). The
-customer would bring their own CRDs. This would have been an
-explicitly unsupported configuration intended for development and
-testing with newer CRD versions.
+manage Gateway API CRDs but would still run the CIO-managed Istio
+instance and CIO Gateway API controllers. The customer would bring
+their own CRDs. This would have been an explicitly unsupported
+configuration intended for development and testing with newer CRD
+versions.
 
 This mode was removed from the proposal due to a lack of evidence
 that it would be used in practice. The primary customer need is to

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -30,13 +30,13 @@ see-also:
 This enhancement introduces a new cluster-scoped singleton API
 resource, `Ingress` (resource `ingresses`, singleton named
 `cluster`), in the `operator.openshift.io/v1` group. The
-resource exposes a `spec.gatewayAPI.crdManagementMode` enum
+resource exposes a `spec.gatewayAPI.managementMode` enum
 field that controls how the Cluster Ingress Operator (CIO)
 manages Gateway API CRDs and the associated Gateway controller
 stack (CIO-managed Istio, GatewayClass, Gateway). Three modes
 are provided: `Managed` (default -- CIO owns everything),
 `Unmanaged` (CIO does nothing, external entity takes over), and
-`ExternalCRDs` (CIO runs the Gateway controller against
+`ControllersOnly` (CIO runs the Gateway controller against
 externally-provided CRDs, unsupported configuration).
 
 The field lives on a new resource rather than on
@@ -103,9 +103,9 @@ drifted from the expected state.
 
 ### Goals
 
-1. Provide a `crdManagementMode` enum field on a new Ingress
+1. Provide a `managementMode` enum field on a new Ingress
    (`operator.openshift.io/v1`) singleton with three modes:
-   `Managed`, `Unmanaged`, and `ExternalCRDs`.
+   `Managed`, `Unmanaged`, and `ControllersOnly`.
 2. Allow customers and third-party products to take full control of
    Gateway API CRDs without fighting CIO's reconciler or VAP.
 3. Expose status conditions reporting CRD ownership mode, presence,
@@ -146,11 +146,11 @@ Introduce a new cluster-scoped singleton API resource in the
   `OperatorSpec`/`OperatorStatus` inline.
 
 The spec contains a `gatewayAPI` struct with a
-`crdManagementMode` enum. The struct is extensible for future
+`managementMode` enum. The struct is extensible for future
 Gateway API configuration fields.
 
 CIO watches this resource and reads
-`spec.gatewayAPI.crdManagementMode` to determine its behavior:
+`spec.gatewayAPI.managementMode` to determine its behavior:
 
 - **Managed** (default): CIO installs, protects (via VAP), and
   upgrades Gateway API CRDs. CIO runs the full Gateway controller
@@ -162,7 +162,7 @@ CIO watches this resource and reads
   product owns the CRDs and Gateway controller. CIO reports
   observational status only.
 
-- **ExternalCRDs**: CIO does not manage CRDs but does run the
+- **ControllersOnly**: CIO does not manage CRDs but does run the
   Gateway controller stack. The customer brings their own CRDs.
   This is an **unsupported** configuration for development and
   testing. CIO reports status including a persistent unsupported
@@ -180,7 +180,7 @@ IngressController resources and manages Gateway API components.
 
 1. The cluster administrator installs or upgrades OpenShift.
 2. CIO reads the Ingress (`operator.openshift.io/v1`) `cluster`
-   resource and observes that `spec.gatewayAPI.crdManagementMode`
+   resource and observes that `spec.gatewayAPI.managementMode`
    is unset (defaults to `Managed`).
 3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
    instance, GatewayClass, and Gateway resources as per the existing
@@ -204,7 +204,7 @@ IngressController resources and manages Gateway API components.
      name: cluster
    spec:
      gatewayAPI:
-       crdManagementMode: Unmanaged
+       managementMode: Unmanaged
    ```
 3. CIO detects the mode change and begins transition:
    a. Shuts down the CIO-managed Istio instance.
@@ -220,7 +220,7 @@ IngressController resources and manages Gateway API components.
 5. The cluster administrator installs their third-party Gateway
    controller and optionally their own CRD version.
 
-#### Workflow 3: Switching to ExternalCRDs Mode
+#### Workflow 3: Switching to ControllersOnly Mode
 
 1. The cluster administrator or developer wants to test with newer
    Gateway API CRDs while using the OpenShift Gateway controller.
@@ -233,7 +233,7 @@ IngressController resources and manages Gateway API components.
      name: cluster
    spec:
      gatewayAPI:
-       crdManagementMode: ExternalCRDs
+       managementMode: ControllersOnly
    ```
 3. CIO detects the mode change:
    a. Removes the VAP protecting Gateway API CRDs.
@@ -241,7 +241,7 @@ IngressController resources and manages Gateway API components.
    c. Keeps the CIO-managed Istio instance, GatewayClass, and
       Gateway resources running.
 4. CIO sets `status.gatewayAPI.conditions`:
-   - `CRDsManaged=False` (reason: `ExternalCRDs`,
+   - `CRDsManaged=False` (reason: `ControllersOnly`,
      message includes unsupported warning)
    - `CRDsPresent=True/False` (observational)
    - `CRDsCompliant=True/False` (whether existing CRDs
@@ -265,7 +265,7 @@ IngressController resources and manages Gateway API components.
      name: cluster
    spec:
      gatewayAPI:
-       crdManagementMode: Managed
+       managementMode: Managed
    ```
 4. CIO detects the mode change:
    a. If CRDs are absent, CIO installs them.
@@ -287,7 +287,7 @@ sequenceDiagram
     participant GW as Gateway Stack<br/>(CIO Istio/GatewayClass/Gateway)
 
     Note over Admin,GW: Workflow: Mode Transition
-    Admin->>IC: Set spec.gatewayAPI.crdManagementMode
+    Admin->>IC: Set spec.gatewayAPI.managementMode
 
     alt Managed (default)
         CIO->>CRDs: Install/upgrade CRDs + VAP
@@ -298,10 +298,10 @@ sequenceDiagram
         CIO->>CRDs: Remove VAP, stop managing
         Note over GW: GatewayClass/Gateway left for<br/>admin cleanup to avoid disruption
         CIO->>IC: Set status: Managed=False (Unmanaged),<br/>Present=observed
-    else ExternalCRDs (unsupported)
+    else ControllersOnly (unsupported)
         CIO->>CRDs: Remove VAP, stop managing
         CIO->>GW: Keep running
-        CIO->>IC: Set status: Managed=False (ExternalCRDs),<br/>Present=observed, Compliant=observed,<br/>UNSUPPORTED
+        CIO->>IC: Set status: Managed=False (ControllersOnly),<br/>Present=observed, Compliant=observed,<br/>UNSUPPORTED
     end
 ```
 
@@ -370,7 +370,7 @@ type IngressSpec struct {
 	// API configuration fields in future releases.
 	//
 	// +required
-	// +openshift:enable:FeatureGate=GatewayAPICRDManagementMode
+	// +openshift:enable:FeatureGate=GatewayAPIManagementMode
 	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI"`
 }
 
@@ -391,11 +391,11 @@ type IngressStatus struct {
 The `GatewayAPIIngressConfig` and `GatewayAPIIngressStatus` types:
 
 ```go
-// GatewayAPICRDManagementMode describes how the Cluster Ingress
+// GatewayAPIManagementMode describes how the Cluster Ingress
 // Operator manages Gateway API Custom Resource Definitions.
 //
-// +kubebuilder:validation:Enum=Managed;Unmanaged;ExternalCRDs
-type GatewayAPICRDManagementMode string
+// +kubebuilder:validation:Enum=Managed;Unmanaged;ControllersOnly
+type GatewayAPIManagementMode string
 
 const (
 	// ManagedGatewayAPICRDs means CIO installs, owns, protects
@@ -403,28 +403,28 @@ const (
 	// deploys the full Gateway controller stack (the Istio
 	// instance deployed by CIO, GatewayClass, Gateway). This is
 	// the default mode and the only fully supported configuration.
-	ManagedGatewayAPICRDs GatewayAPICRDManagementMode = "Managed"
+	ManagedGatewayAPICRDs GatewayAPIManagementMode = "Managed"
 
 	// UnmanagedGatewayAPICRDs means CIO does NOT install or
 	// manage Gateway API CRDs and does NOT deploy the Gateway
 	// controller stack. The customer or a third-party product is
 	// responsible for bringing their own CRDs and Gateway
 	// controller. CIO reports observational status only.
-	UnmanagedGatewayAPICRDs GatewayAPICRDManagementMode = "Unmanaged"
+	UnmanagedGatewayAPICRDs GatewayAPIManagementMode = "Unmanaged"
 
-	// ExternalCRDsGatewayAPICRDs means CIO does NOT manage
+	// ControllersOnlyGatewayAPICRDs means CIO does NOT manage
 	// Gateway API CRDs but DOES deploy the OpenShift Gateway
 	// controller stack (the Istio instance deployed by CIO,
 	// GatewayClass, Gateway). The customer brings their own
 	// CRDs. This is an UNSUPPORTED configuration useful for
 	// development, testing, or advanced users.
-	ExternalCRDsGatewayAPICRDs GatewayAPICRDManagementMode = "ExternalCRDs"
+	ControllersOnlyGatewayAPICRDs GatewayAPIManagementMode = "ControllersOnly"
 )
 
 // GatewayAPIIngressConfig holds configuration for Gateway API
 // integration in the Cluster Ingress Operator.
 type GatewayAPIIngressConfig struct {
-	// crdManagementMode specifies how the Cluster Ingress
+	// managementMode specifies how the Cluster Ingress
 	// Operator manages Gateway API Custom Resource Definitions
 	// (CRDs) and the associated Gateway controller stack.
 	//
@@ -441,7 +441,7 @@ type GatewayAPIIngressConfig struct {
 	// is responsible for providing their own CRDs and Gateway
 	// controller. CIO reports observational status only.
 	//
-	// When set to "ExternalCRDs", CIO does not manage Gateway
+	// When set to "ControllersOnly", CIO does not manage Gateway
 	// API CRDs but does deploy the OpenShift Gateway controller
 	// stack. The cluster administrator brings their own CRDs.
 	// This is an unsupported configuration intended for
@@ -450,7 +450,7 @@ type GatewayAPIIngressConfig struct {
 	// +kubebuilder:default:="Managed"
 	// +default="Managed"
 	// +required
-	CRDManagementMode GatewayAPICRDManagementMode `json:"crdManagementMode"`
+	ManagementMode GatewayAPIManagementMode `json:"managementMode"`
 }
 
 // GatewayAPIIngressStatus holds status information for Gateway
@@ -474,7 +474,7 @@ type GatewayAPIIngressStatus struct {
 The field paths are:
 
 ```
-spec.gatewayAPI.crdManagementMode
+spec.gatewayAPI.managementMode
 status.gatewayAPI.conditions
 ```
 
@@ -485,7 +485,7 @@ The following conditions are set within
 |---|---|---|---|
 | `CRDsManaged` | `True` | `ManagedByCIO` | CIO is actively managing CRDs |
 | `CRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
-| `CRDsManaged` | `False` | `ExternalCRDs` | Administrator chose ExternalCRDs mode (unsupported) |
+| `CRDsManaged` | `False` | `ControllersOnly` | Administrator chose ControllersOnly mode (unsupported) |
 | `CRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
 | `CRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
 | `CRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
@@ -529,17 +529,17 @@ enables Gateway API on OKE by eliminating OSSM licensing concerns.
 
 #### Feature Gate
 
-New feature gate: `GatewayAPICRDManagementMode`, added to
+New feature gate: `GatewayAPIManagementMode`, added to
 `TechPreviewNoUpgrade` in
 [features.go](https://github.com/openshift/api/blob/master/features/features.go).
 
 The `gatewayAPI` field uses the
-`+openshift:enable:FeatureGate=GatewayAPICRDManagementMode` marker
+`+openshift:enable:FeatureGate=GatewayAPIManagementMode` marker
 so it only appears in CRDs when the gate is enabled.
 
 #### Interaction with the GatewayAPI Feature Gate
 
-The `crdManagementMode` field only takes effect when the existing
+The `managementMode` field only takes effect when the existing
 `GatewayAPI` feature gate is also enabled. When `GatewayAPI` is
 disabled, CIO does not manage any Gateway API resources regardless
 of the mode setting.
@@ -548,7 +548,7 @@ of the mode setting.
 
 Affected controllers:
 
-| Controller | Managed | Unmanaged | ExternalCRDs |
+| Controller | Managed | Unmanaged | ControllersOnly |
 |---|---|---|---|
 | CRD management | Install, upgrade, protect (VAP) | Observe only | Observe only |
 | GatewayClass | Active | Disabled | Active |
@@ -592,18 +592,18 @@ to avoid leaving the cluster in an inconsistent state:
   shutdown CIO-managed Istio instance. GatewayClass and Gateway
   resources are left in place; administrator is responsible for
   cleanup.
-- **Managed to ExternalCRDs**: Remove VAP, stop CRD management,
+- **Managed to ControllersOnly**: Remove VAP, stop CRD management,
   keep CIO-managed Istio instance, GatewayClass, and Gateway
   running.
 - **Unmanaged to Managed**: Verify CRDs match expected version (or
   are absent), install CRDs if absent, deploy VAP, start
   CIO-managed Istio instance, GatewayClass, and Gateway.
-- **Unmanaged to ExternalCRDs**: Start CIO-managed Istio instance,
+- **Unmanaged to ControllersOnly**: Start CIO-managed Istio instance,
   GatewayClass, and Gateway (CRDs must already be present or
   controller will wait).
-- **ExternalCRDs to Managed**: Verify CRDs match expected version,
+- **ControllersOnly to Managed**: Verify CRDs match expected version,
   take ownership, deploy VAP.
-- **ExternalCRDs to Unmanaged**: Shutdown CIO-managed Istio
+- **ControllersOnly to Unmanaged**: Shutdown CIO-managed Istio
   instance. GatewayClass and Gateway resources are left in place.
 
 #### Long-Term: Unknown Field Management
@@ -611,7 +611,7 @@ to avoid leaving the cluster in an inconsistent state:
 The "unknown fields" problem (CRDs containing fields the controller
 does not recognize) is tracked upstream in
 [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
-The `ExternalCRDs` mode is particularly susceptible. This
+The `ControllersOnly` mode is particularly susceptible. This
 enhancement provides the management mode infrastructure that future
 work (version ranges, unknown field detection, compatibility
 checks) can build on. See Non-Goals for scope.
@@ -619,7 +619,7 @@ checks) can build on. See Non-Goals for scope.
 #### Future Work on the Ingress Resource
 
 The new Ingress (`operator.openshift.io/v1`) resource is designed
-to accommodate future configuration beyond `crdManagementMode`:
+to accommodate future configuration beyond `managementMode`:
 
 1. **GatewayClass customization**: The `gatewayAPI` struct can be
    extended to allow administrators to define additional OpenShift
@@ -641,9 +641,9 @@ These are out of scope for this enhancement.
 
 ### Risks and Mitigations
 
-#### Risk: Unsupported ExternalCRDs Mode Misuse
+#### Risk: Unsupported ControllersOnly Mode Misuse
 
-Customers may use `ExternalCRDs` in production and file support
+Customers may use `ControllersOnly` in production and file support
 tickets when CRD incompatibility causes issues.
 
 **Mitigation**: CIO sets a persistent unsupported warning condition
@@ -683,7 +683,7 @@ controller enable/disable states and mode transition logic. This is
 justified by customer demand -- the alternative is customers
 fighting the VAP and CRD reconciler.
 
-The `ExternalCRDs` mode introduces an explicitly unsupported
+The `ControllersOnly` mode introduces an explicitly unsupported
 configuration, but without it, advanced users would resort to worse
 workarounds (disabling the VAP manually, using
 `unsupportedConfigOverrides`).
@@ -693,7 +693,7 @@ workarounds (disabling the VAP manually, using
 1. ~~**Field placement**: Resolved. New Ingress singleton in
    `operator.openshift.io/v1`, following the DNS/Console pattern.~~
 
-2. **ExternalCRDs mode scope**: Should `ExternalCRDs` mode perform
+2. **ControllersOnly mode scope**: Should `ControllersOnly` mode perform
    compatibility pre-checks before starting the Gateway controller,
    or always start and report incompatibility via status conditions?
 
@@ -705,7 +705,7 @@ workarounds (disabling the VAP manually, using
 4. **Interaction with `unsupportedConfigOverrides`**: The CRD
    lifecycle management enhancement uses an "unsupported config
    override" mechanism to bypass CRD succession checks. Should
-   `crdManagementMode` replace this mechanism or coexist with it?
+   `managementMode` replace this mechanism or coexist with it?
 
 5. **Telemetry**: What telemetry should be collected? At minimum
    the configured mode. Should CIO also report metrics for CRD
@@ -727,7 +727,7 @@ workarounds (disabling the VAP manually, using
 
 <!-- TODO: Tests must include the following labels per
 dev-guide/feature-zero-to-hero.md:
-- [OCPFeatureGate:GatewayAPICRDManagementMode] for the feature gate
+- [OCPFeatureGate:GatewayAPIManagementMode] for the feature gate
 - [Jira:"Networking / ingress"] for the component
 - Appropriate test type labels: [Serial], [Slow], [Disruptive]
   as needed
@@ -738,7 +738,7 @@ for each management mode and mode transitions.
 
 ### Unit Tests
 
-- Validation of the `crdManagementMode` field (valid enum values,
+- Validation of the `managementMode` field (valid enum values,
   defaulting behavior).
 - Status condition computation logic for each mode.
 - Controller enable/disable logic based on mode.
@@ -763,12 +763,12 @@ The following e2e test scenarios are required:
    preserved. Verify status conditions report `Unmanaged`. Verify
    a third-party GatewayClass can be created.
 
-3. **Transition to ExternalCRDs**: Set mode to `ExternalCRDs`. Verify that the
+3. **Transition to ControllersOnly**: Set mode to `ControllersOnly`. Verify that the
    VAP is removed, CRDs are no longer managed, but the Gateway
    controller stack remains running. Verify the unsupported warning
    condition.
 
-4. **Return to Managed**: From `Unmanaged` or `ExternalCRDs`, return to
+4. **Return to Managed**: From `Unmanaged` or `ControllersOnly`, return to
    `Managed`. Verify CIO takes ownership of compatible CRDs, or
    reports incompatibility for mismatched CRDs.
 
@@ -776,13 +776,13 @@ The following e2e test scenarios are required:
    a cluster with no Gateway API CRDs. Verify CIO does not install
    CRDs and reports `CRDsNotFound`.
 
-6. **ExternalCRDs mode with incompatible CRDs**: Set mode to `ExternalCRDs` and
+6. **ControllersOnly mode with incompatible CRDs**: Set mode to `ControllersOnly` and
    install CRDs that do not match the expected version. Verify CIO
    reports compliance failure but continues running the Gateway
    controller stack.
 
 7. **Upgrade with non-default mode**: Upgrade a cluster that has
-   `Unmanaged` or `ExternalCRDs` mode set. Verify the mode is preserved
+   `Unmanaged` or `ControllersOnly` mode set. Verify the mode is preserved
    and CIO does not attempt to take over CRDs during upgrade.
 
 ## Graduation Criteria
@@ -798,10 +798,10 @@ dev-guide/feature-zero-to-hero.md:
 
 ### Dev Preview -> Tech Preview
 
-- Feature gate `GatewayAPICRDManagementMode` added to
+- Feature gate `GatewayAPIManagementMode` added to
   `TechPreviewNoUpgrade` feature set.
 - `Managed` and `Unmanaged` modes fully functional.
-- `ExternalCRDs` mode functional with unsupported warning.
+- `ControllersOnly` mode functional with unsupported warning.
 - Status conditions implemented and observable.
 - Unit and integration tests passing.
 - Initial e2e tests for basic mode transitions.
@@ -844,7 +844,7 @@ Backport scope:
 - Ingress CRD manifest for `operator.openshift.io/v1` (CVO).
 - `gatewayAPI` spec/status structs with all three enum values.
 - `status.gatewayAPI.conditions` reporting.
-- Feature gate `GatewayAPICRDManagementMode` (behind
+- Feature gate `GatewayAPIManagementMode` (behind
   `TechPreviewNoUpgrade`).
 - CIO controller changes.
 
@@ -868,7 +868,7 @@ When upgrading from a version that does not have the Ingress
 upgrading from 4.18 to 4.19 with the backport applied):
 
 - CVO installs the new Ingress CRD. The `cluster` singleton is
-  created with `spec.gatewayAPI.crdManagementMode` defaulting to
+  created with `spec.gatewayAPI.managementMode` defaulting to
   `Managed`, preserving existing behavior. No action is required
   from the cluster administrator.
 - Existing clusters with CIO-managed CRDs continue to work
@@ -880,7 +880,7 @@ upgrading from 4.19 to 4.20+ with mode already configured):
 - **Unmanaged mode**: CIO does not attempt to install or manage
   CRDs during the upgrade. The administrator's third-party CRDs
   are preserved.
-- **ExternalCRDs mode**: CIO does not upgrade CRDs but does upgrade
+- **ControllersOnly mode**: CIO does not upgrade CRDs but does upgrade
   the CIO-managed Istio instance. If the new Istio version is
   incompatible with the existing CRDs, CIO reports degraded status.
   The administrator is responsible for updating the CRDs.
@@ -901,7 +901,7 @@ When downgrading from a version that has the Ingress
   management succession logic (from
   [gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md))
   applies.
-- **If the cluster was in `ExternalCRDs` mode**: The downgraded CIO
+- **If the cluster was in `ControllersOnly` mode**: The downgraded CIO
   will attempt to take ownership of the CRDs. If they do not match
   the expected version, the operator reports `Degraded`.
 
@@ -926,7 +926,7 @@ resource read during CIO reconciliation.
 - **Failure modes**:
   - VAP removal failure during mode transition: CRDs remain locked.
     CIO retries and reports in status.
-  - `ExternalCRDs` mode with absent CRDs: Gateway controller cannot
+  - `ControllersOnly` mode with absent CRDs: Gateway controller cannot
     start. CIO reports and retries when CRDs appear.
 
 - **Escalation**: Networking / Ingress team. For Istio CRD
@@ -938,7 +938,7 @@ resource read during CIO reconciliation.
 
 ```bash
 oc get ingress.operator.openshift.io cluster \
-  -o jsonpath='{.spec.gatewayAPI.crdManagementMode}'
+  -o jsonpath='{.spec.gatewayAPI.managementMode}'
 ```
 
 ### Checking CRD Management Status
@@ -981,14 +981,14 @@ oc delete crd \
   grpcroutes.gateway.networking.k8s.io
 ```
 
-**Symptom**: Gateway controller not starting in `ExternalCRDs` mode.
+**Symptom**: Gateway controller not starting in `ControllersOnly` mode.
 
 **Resolution**: Install Gateway API CRDs. CIO starts the
 controller when CRDs appear.
 
-**Symptom**: `CRDsManaged=False` with reason `ExternalCRDs`.
+**Symptom**: `CRDsManaged=False` with reason `ControllersOnly`.
 
-**Resolution**: Expected behavior for `ExternalCRDs` mode. Verify
+**Resolution**: Expected behavior for `ControllersOnly` mode. Verify
 the customer intentionally chose this mode. For production
 clusters, recommend switching to `Managed`.
 
@@ -996,7 +996,7 @@ clusters, recommend switching to `Managed`.
 
 ### Alternative 1: Boolean Gateway API Disable Switch
 
-Does not address the `ExternalCRDs` use case (CRDs external, controller
+Does not address the `ControllersOnly` use case (CRDs external, controller
 active). Also prohibited by OpenShift API conventions (no boolean
 fields in CRDs).
 

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -29,15 +29,13 @@ see-also:
 
 This enhancement introduces a new cluster-scoped singleton API
 resource, `Ingress` (resource `ingresses`, singleton named
-`cluster`), in the `operator.openshift.io/v1` group. The
+`cluster`), in the `operator.openshift.io/v1alpha1` group. The
 resource exposes a `spec.gatewayAPI.managementMode` enum
 field that controls how the Cluster Ingress Operator (CIO)
 manages Gateway API CRDs and the associated Gateway controller
-stack (CIO-managed Istio, GatewayClass, Gateway). Three modes
-are provided: `Managed` (default -- CIO owns everything),
-`Unmanaged` (CIO does nothing, external entity takes over), and
-`ControllersOnly` (CIO runs the Gateway controller against
-externally-provided CRDs, unsupported configuration).
+stack (CIO-managed Istio, GatewayClass, Gateway). Two modes
+are provided: `Managed` (default -- CIO owns everything) and
+`Unmanaged` (CIO does nothing, external entity takes over).
 
 The field lives on a new resource rather than on
 `IngressController` (where multiple instances could conflict) or
@@ -55,8 +53,8 @@ and
 [gateway-api-without-olm](gateway-api-without-olm.md)
 enhancements, CIO owns the Gateway API CRDs, pins them to a
 specific version, protects them with Validating Admission Policies
-(VAPs), and upgrades them during cluster upgrades. This is the
-right default for most customers, but creates friction for:
+(VAPs), and upgrades them during cluster upgrades. This default
+suits most customers but creates friction for:
 
 1. **Third-party Gateway API implementations**: Customers using
    Envoy Gateway, Traefik, Kong, or other non-OpenShift controllers
@@ -66,8 +64,8 @@ right default for most customers, but creates friction for:
 2. **Development and testing**: Platform engineers who need newer CRD
    versions must fight the VAP and CIO reconciler.
 
-3. **Supportability**: There is no API-level signal indicating who
-   owns the CRDs or whether the current state is intentional.
+3. **Supportability**: No API-level signal indicates who owns the
+   CRDs or whether the current state is intentional.
 
 ### User Stories
 
@@ -78,15 +76,7 @@ CRD management and Gateway controller so that I can install and use a
 third-party Gateway API implementation (such as Envoy Gateway or Kong)
 without conflicts with CIO's CRD ownership or VAP protections.
 
-#### Story 2: Development and Testing with External CRDs
-
-As a platform engineer, I want to use externally-provided Gateway API
-CRDs while keeping the OpenShift Gateway controller running so that I
-can test with newer CRD versions or experimental fields in a
-development environment, understanding that this configuration is
-unsupported.
-
-#### Story 3: Determining CRD Ownership State
+#### Story 2: Determining CRD Ownership State
 
 As a support engineer responding to a customer escalation, I want to
 quickly determine who owns the Gateway API CRDs on a cluster and
@@ -94,7 +84,7 @@ whether the current CRD state matches the configured ownership mode
 so that I can diagnose issues without needing to inspect labels,
 annotations, and controller logs manually.
 
-#### Story 4: Operational Monitoring
+#### Story 3: Operational Monitoring
 
 As a fleet administrator, I want to monitor Gateway API CRD ownership
 state via standard OpenShift status conditions so that I can detect
@@ -104,8 +94,8 @@ drifted from the expected state.
 ### Goals
 
 1. Provide a `managementMode` enum field on a new Ingress
-   (`operator.openshift.io/v1`) singleton with three modes:
-   `Managed`, `Unmanaged`, and `ControllersOnly`.
+   (`operator.openshift.io/v1alpha1`) singleton with two modes:
+   `Managed` and `Unmanaged`.
 2. Allow customers and third-party products to take full control of
    Gateway API CRDs without fighting CIO's reconciler or VAP.
 3. Expose status conditions reporting CRD ownership mode, presence,
@@ -135,7 +125,7 @@ drifted from the expected state.
 ## Proposal
 
 Introduce a new cluster-scoped singleton API resource in the
-`operator.openshift.io/v1` group:
+`operator.openshift.io/v1alpha1` group:
 
 - **Kind**: `Ingress`
 - **Resource**: `ingresses`
@@ -160,13 +150,10 @@ CIO watches this resource and reads
 - **Unmanaged**: CIO does not install CRDs and does not deploy
   the Gateway controller stack. The customer or a third-party
   product owns the CRDs and Gateway controller. CIO reports
-  observational status only.
-
-- **ControllersOnly**: CIO does not manage CRDs but does run the
-  Gateway controller stack. The customer brings their own CRDs.
-  This is an **unsupported** configuration for development and
-  testing. CIO reports status including a persistent unsupported
-  warning.
+  observational status only. This mode also serves as a signal
+  to layered products that the installed CRDs may not be the
+  ones supported by the OpenShift Gateway API implementation,
+  and those products should adjust their behavior accordingly.
 
 ### Workflow Description
 
@@ -179,7 +166,7 @@ IngressController resources and manages Gateway API components.
 #### Workflow 1: Default Managed Mode (No Action Required)
 
 1. The cluster administrator installs or upgrades OpenShift.
-2. CIO reads the Ingress (`operator.openshift.io/v1`) `cluster`
+2. CIO reads the Ingress (`operator.openshift.io/v1alpha1`) `cluster`
    resource and observes that `spec.gatewayAPI.managementMode`
    is unset (defaults to `Managed`).
 3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
@@ -196,9 +183,9 @@ IngressController resources and manages Gateway API components.
 1. The cluster administrator decides to use a third-party Gateway
    API implementation.
 2. The cluster administrator edits the Ingress
-   (`operator.openshift.io/v1`) `cluster` resource:
+   (`operator.openshift.io/v1alpha1`) `cluster` resource:
    ```yaml
-   apiVersion: operator.openshift.io/v1
+   apiVersion: operator.openshift.io/v1alpha1
    kind: Ingress
    metadata:
      name: cluster
@@ -207,7 +194,7 @@ IngressController resources and manages Gateway API components.
        managementMode: Unmanaged
    ```
 3. CIO detects the mode change and begins transition:
-   a. Shuts down the CIO-managed Istio instance.
+   a. Stops the CIO-managed Istio instance.
    b. Removes the VAP protecting Gateway API CRDs.
    c. Does **not** remove the GatewayClass, Gateway resources, or
       Gateway API CRDs. Removing these resources could cause
@@ -219,47 +206,22 @@ IngressController resources and manages Gateway API components.
    - `CRDsCompliant=Unknown` (not applicable in this mode)
 5. The cluster administrator installs their third-party Gateway
    controller and optionally their own CRD version.
+6. Layered products observe the `CRDsManaged=False` condition with
+   reason `Unmanaged` and treat this as a signal that the installed
+   CRDs may not be the ones supported by the OpenShift Gateway API
+   implementation. They should adjust their behavior accordingly
+   (e.g., not relying on specific CRD versions or fields).
 
-#### Workflow 3: Switching to ControllersOnly Mode
-
-1. The cluster administrator or developer wants to test with newer
-   Gateway API CRDs while using the OpenShift Gateway controller.
-2. The cluster administrator edits the Ingress
-   (`operator.openshift.io/v1`) `cluster` resource:
-   ```yaml
-   apiVersion: operator.openshift.io/v1
-   kind: Ingress
-   metadata:
-     name: cluster
-   spec:
-     gatewayAPI:
-       managementMode: ControllersOnly
-   ```
-3. CIO detects the mode change:
-   a. Removes the VAP protecting Gateway API CRDs.
-   b. Stops managing (installing/upgrading) Gateway API CRDs.
-   c. Keeps the CIO-managed Istio instance, GatewayClass, and
-      Gateway resources running.
-4. CIO sets `status.gatewayAPI.conditions`:
-   - `CRDsManaged=False` (reason: `ControllersOnly`,
-     message includes unsupported warning)
-   - `CRDsPresent=True/False` (observational)
-   - `CRDsCompliant=True/False` (whether existing CRDs
-     match the expected version)
-5. The cluster administrator installs their own CRD version.
-6. If the CRDs are incompatible with the CIO-managed Istio
-   instance, CIO reports degraded status but continues running.
-
-#### Workflow 4: Returning to Managed Mode
+#### Workflow 3: Returning to Managed Mode
 
 1. The cluster administrator wants to return to the fully managed
    configuration.
 2. The cluster administrator ensures the existing Gateway API CRDs
    match the version CIO expects, or removes them entirely.
 3. The cluster administrator edits the Ingress
-   (`operator.openshift.io/v1`) `cluster` resource:
+   (`operator.openshift.io/v1alpha1`) `cluster` resource:
    ```yaml
-   apiVersion: operator.openshift.io/v1
+   apiVersion: operator.openshift.io/v1alpha1
    kind: Ingress
    metadata:
      name: cluster
@@ -273,15 +235,15 @@ IngressController resources and manages Gateway API components.
       ownership (adds labels, deploys VAP).
    c. If CRDs are present but do not match the expected version, CIO
       sets `CRDsCompliant=False` (in `status.gatewayAPI.conditions`)
-      and does NOT overwrite
-      them. The administrator must resolve the mismatch.
+      and does NOT overwrite them. The administrator must resolve
+      the mismatch.
 5. CIO deploys the full Gateway controller stack if not already
    running.
 
 ```mermaid
 sequenceDiagram
     participant Admin as Cluster Admin
-    participant IC as Ingress (operator.openshift.io/v1)
+    participant IC as Ingress (operator.openshift.io/v1alpha1)
     participant CIO as Cluster Ingress Operator
     participant CRDs as Gateway API CRDs
     participant GW as Gateway Stack<br/>(CIO Istio/GatewayClass/Gateway)
@@ -294,23 +256,19 @@ sequenceDiagram
         CIO->>GW: Deploy CIO Istio, GatewayClass, Gateway
         CIO->>IC: Set status: Managed=True,<br/>Present=True, Compliant=True
     else Unmanaged
-        CIO->>GW: Shutdown CIO Istio instance
+        CIO->>GW: Stop CIO Istio instance
         CIO->>CRDs: Remove VAP, stop managing
         Note over GW: GatewayClass/Gateway left for<br/>admin cleanup to avoid disruption
         CIO->>IC: Set status: Managed=False (Unmanaged),<br/>Present=observed
-    else ControllersOnly (unsupported)
-        CIO->>CRDs: Remove VAP, stop managing
-        CIO->>GW: Keep running
-        CIO->>IC: Set status: Managed=False (ControllersOnly),<br/>Present=observed, Compliant=observed,<br/>UNSUPPORTED
     end
 ```
 
 ### API Extensions
 
 This enhancement introduces a **new CRD** in the
-`operator.openshift.io/v1` group. The new resource follows the
+`operator.openshift.io/v1alpha1` group. The new resource follows the
 same pattern as the existing `DNS` and `Console` cluster-scoped
-singletons in this group.
+singletons in `operator.openshift.io/v1`.
 
 **Why a new resource** (see also Alternatives section):
 `IngressController` is namespaced and multi-instance, so it
@@ -320,10 +278,9 @@ install-time configuration. A dedicated singleton in
 `operator.openshift.io` follows the DNS/Console pattern and
 provides a clean extension point.
 
-The proposed Go types are in a new file in `operator/v1/` in the
-`openshift/api` repository (note: `types_ingress.go` already
-exists for `IngressController`, so this type needs a separate
-file, e.g. `types_ingress_gateway.go`):
+The proposed Go types are in a new file in `operator/v1alpha1/` in
+the `openshift/api` repository (e.g.,
+`types_ingress_gateway.go`):
 
 ```go
 // +genclient
@@ -334,9 +291,10 @@ file, e.g. `types_ingress_gateway.go`):
 // integration managed by the Cluster Ingress Operator. The
 // canonical name is `cluster`.
 //
-// Compatibility level 1: Stable within a major release for a
-// minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 4: No compatibility is provided, the API
+// can change at any point for any reason. These capabilities
+// should not be used by applications needing long-term support.
+// +openshift:compatibility-gen:level=4
 // +openshift:api-approved.openshift.io=<TBD>
 // +openshift:file-pattern=cvoRunLevel=0000_50,operatorName=ingress,operatorOrdering=02
 // +kubebuilder:object:root=true
@@ -366,8 +324,6 @@ type IngressSpec struct {
 	// gatewayAPI holds configuration for Gateway API
 	// integration, including how the Cluster Ingress Operator
 	// manages Gateway API CRDs and the Gateway controller stack.
-	// This struct is designed to accommodate additional Gateway
-	// API configuration fields in future releases.
 	//
 	// +required
 	// +openshift:enable:FeatureGate=GatewayAPIManagementMode
@@ -394,31 +350,27 @@ The `GatewayAPIIngressConfig` and `GatewayAPIIngressStatus` types:
 // GatewayAPIManagementMode describes how the Cluster Ingress
 // Operator manages Gateway API Custom Resource Definitions.
 //
-// +kubebuilder:validation:Enum=Managed;Unmanaged;ControllersOnly
+// +kubebuilder:validation:Enum=Managed;Unmanaged
 type GatewayAPIManagementMode string
 
 const (
-	// ManagedGatewayAPICRDs means CIO installs, owns, protects
-	// (via VAP), and upgrades the Gateway API CRDs. CIO also
-	// deploys the full Gateway controller stack (the Istio
-	// instance deployed by CIO, GatewayClass, Gateway). This is
-	// the default mode and the only fully supported configuration.
-	ManagedGatewayAPICRDs GatewayAPIManagementMode = "Managed"
+	// GatewayAPIManagementModeManaged means CIO installs, owns,
+	// protects (via VAP), and upgrades the Gateway API CRDs.
+	// CIO also deploys the full Gateway controller stack (the
+	// Istio instance deployed by CIO, GatewayClass, Gateway).
+	// This is the default mode and the only fully supported
+	// configuration.
+	GatewayAPIManagementModeManaged GatewayAPIManagementMode = "Managed"
 
-	// UnmanagedGatewayAPICRDs means CIO does NOT install or
-	// manage Gateway API CRDs and does NOT deploy the Gateway
-	// controller stack. The customer or a third-party product is
-	// responsible for bringing their own CRDs and Gateway
-	// controller. CIO reports observational status only.
-	UnmanagedGatewayAPICRDs GatewayAPIManagementMode = "Unmanaged"
-
-	// ControllersOnlyGatewayAPICRDs means CIO does NOT manage
-	// Gateway API CRDs but DOES deploy the OpenShift Gateway
-	// controller stack (the Istio instance deployed by CIO,
-	// GatewayClass, Gateway). The customer brings their own
-	// CRDs. This is an UNSUPPORTED configuration useful for
-	// development, testing, or advanced users.
-	ControllersOnlyGatewayAPICRDs GatewayAPIManagementMode = "ControllersOnly"
+	// GatewayAPIManagementModeUnmanaged means CIO does NOT
+	// install or manage Gateway API CRDs and does NOT deploy
+	// the Gateway controller stack. The customer or a
+	// third-party product is responsible for bringing their own
+	// CRDs and Gateway controller. CIO reports observational
+	// status only. This mode signals to layered products that
+	// the installed CRDs may not be the ones supported by the
+	// OpenShift Gateway API implementation.
+	GatewayAPIManagementModeUnmanaged GatewayAPIManagementMode = "Unmanaged"
 )
 
 // GatewayAPIIngressConfig holds configuration for Gateway API
@@ -439,13 +391,10 @@ type GatewayAPIIngressConfig struct {
 	// Gateway API CRDs and does not deploy the Gateway controller
 	// stack. The cluster administrator or a third-party product
 	// is responsible for providing their own CRDs and Gateway
-	// controller. CIO reports observational status only.
-	//
-	// When set to "ControllersOnly", CIO does not manage Gateway
-	// API CRDs but does deploy the OpenShift Gateway controller
-	// stack. The cluster administrator brings their own CRDs.
-	// This is an unsupported configuration intended for
-	// development and testing.
+	// controller. CIO reports observational status only. This
+	// mode also serves as a signal to layered products that the
+	// installed CRDs may not be the ones supported by the
+	// OpenShift Gateway API implementation.
 	//
 	// +kubebuilder:default:="Managed"
 	// +default="Managed"
@@ -457,12 +406,38 @@ type GatewayAPIIngressConfig struct {
 // API integration managed by the Cluster Ingress Operator.
 type GatewayAPIIngressStatus struct {
 	// conditions is a list of conditions related to Gateway API
-	// CRD management and the Gateway controller stack.
+	// CRD management and the Gateway controller stack. These
+	// conditions are scoped to Gateway API concerns and are
+	// separate from the Ingress resource's top-level conditions.
 	//
 	// Supported condition types are:
-	// * CRDsManaged - whether CIO is actively managing CRDs
-	// * CRDsPresent - whether Gateway API CRDs exist on cluster
-	// * CRDsCompliant - whether installed CRDs match expected version
+	//
+	// "CRDsManaged" indicates whether CIO is actively managing
+	// Gateway API CRDs:
+	//   - status: True, reason: "ManagedByCIO" — CIO is
+	//     installing, protecting (via VAP), and upgrading CRDs.
+	//   - status: False, reason: "Unmanaged" — the administrator
+	//     chose Unmanaged mode; CIO does not manage CRDs or the
+	//     Gateway controller stack.
+	//
+	// "CRDsPresent" indicates whether Gateway API CRDs exist on
+	// the cluster:
+	//   - status: True, reason: "CRDsFound" — Gateway API CRDs
+	//     are present on the cluster.
+	//   - status: False, reason: "CRDsNotFound" — Gateway API
+	//     CRDs are not present on the cluster.
+	//
+	// "CRDsCompliant" indicates whether the installed CRDs match
+	// the version expected by this CIO release:
+	//   - status: True, reason: "VersionMatch" — installed CRDs
+	//     match the expected version.
+	//   - status: False, reason: "VersionMismatch" — installed
+	//     CRDs do not match the expected version. The message
+	//     includes expected and actual versions and a pointer
+	//     to where valid manifests can be obtained.
+	//   - status: Unknown, reason: "NotApplicable" — compliance
+	//     check is not applicable (e.g., Unmanaged mode with no
+	//     CRDs present).
 	//
 	// +listType=map
 	// +listMapKey=type
@@ -485,12 +460,16 @@ The following conditions are set within
 |---|---|---|---|
 | `CRDsManaged` | `True` | `ManagedByCIO` | CIO is actively managing CRDs |
 | `CRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
-| `CRDsManaged` | `False` | `ControllersOnly` | Administrator chose ControllersOnly mode (unsupported) |
 | `CRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
 | `CRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
 | `CRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
 | `CRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
 | `CRDsCompliant` | `Unknown` | `NotApplicable` | Compliance check is not applicable (e.g., Unmanaged mode with no CRDs present) |
+
+**API versioning note:** As a net-new API, this resource is
+introduced at `v1alpha1` (`operator.openshift.io/v1alpha1`). It
+will be promoted to `operator.openshift.io/v1` once the feature
+reaches GA and graduates from the feature gate.
 
 **Note:** This is a new CRD and must go through the full API
 review process via `#forum-api-review`. The API approver must
@@ -508,8 +487,7 @@ affect the management cluster.
 
 #### Standalone Clusters
 
-Primary topology. All three modes apply with no special
-considerations.
+Primary topology. Both modes apply with no special considerations.
 
 #### Single-node Deployments or MicroShift
 
@@ -521,9 +499,15 @@ disabling the Gateway controller stack to reclaim resources.
 
 #### OpenShift Kubernetes Engine
 
-All three modes are available. The
+Both modes are available on OKE. However, Gateway API support on
+OKE depends on the
 [gateway-api-without-olm](gateway-api-without-olm.md) enhancement
-enables Gateway API on OKE by eliminating OSSM licensing concerns.
+which eliminates OSSM licensing concerns. Given the desire to
+backport this management mode feature to OCP 4.19, OKE enablement
+depends on whether `gateway-api-without-olm` is also backported
+to the same version. If that enhancement is not backported, OKE
+support for this feature is limited to the OCP version where
+`gateway-api-without-olm` is first available.
 
 ### Implementation Details/Notes/Constraints
 
@@ -548,12 +532,12 @@ of the mode setting.
 
 Affected controllers:
 
-| Controller | Managed | Unmanaged | ControllersOnly |
-|---|---|---|---|
-| CRD management | Install, upgrade, protect (VAP) | Observe only | Observe only |
-| GatewayClass | Active | Disabled | Active |
-| Gateway | Active | Disabled | Active |
-| Status | Report conditions | Report conditions | Report conditions + unsupported warning |
+| Controller | Managed | Unmanaged |
+|---|---|---|
+| CRD management | Install, upgrade, protect (VAP) | Observe only |
+| GatewayClass | Active | Disabled |
+| Gateway | Active | Disabled |
+| Status | Report conditions | Report conditions |
 
 #### VAP Management
 
@@ -589,36 +573,25 @@ When transitioning between modes, CIO must follow a specific order
 to avoid leaving the cluster in an inconsistent state:
 
 - **Managed to Unmanaged**: Remove VAP, stop CRD management,
-  shutdown CIO-managed Istio instance. GatewayClass and Gateway
+  shut down CIO-managed Istio instance. GatewayClass and Gateway
   resources are left in place; administrator is responsible for
   cleanup.
-- **Managed to ControllersOnly**: Remove VAP, stop CRD management,
-  keep CIO-managed Istio instance, GatewayClass, and Gateway
-  running.
 - **Unmanaged to Managed**: Verify CRDs match expected version (or
   are absent), install CRDs if absent, deploy VAP, start
   CIO-managed Istio instance, GatewayClass, and Gateway.
-- **Unmanaged to ControllersOnly**: Start CIO-managed Istio instance,
-  GatewayClass, and Gateway (CRDs must already be present or
-  controller will wait).
-- **ControllersOnly to Managed**: Verify CRDs match expected version,
-  take ownership, deploy VAP.
-- **ControllersOnly to Unmanaged**: Shutdown CIO-managed Istio
-  instance. GatewayClass and Gateway resources are left in place.
 
 #### Long-Term: Unknown Field Management
 
 The "unknown fields" problem (CRDs containing fields the controller
 does not recognize) is tracked upstream in
 [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
-The `ControllersOnly` mode is particularly susceptible. This
-enhancement provides the management mode infrastructure that future
+This enhancement provides the management mode infrastructure that future
 work (version ranges, unknown field detection, compatibility
 checks) can build on. See Non-Goals for scope.
 
 #### Future Work on the Ingress Resource
 
-The new Ingress (`operator.openshift.io/v1`) resource is designed
+The new Ingress (`operator.openshift.io/v1alpha1`) resource is designed
 to accommodate future configuration beyond `managementMode`:
 
 1. **GatewayClass customization**: The `gatewayAPI` struct can be
@@ -640,15 +613,6 @@ to accommodate future configuration beyond `managementMode`:
 These are out of scope for this enhancement.
 
 ### Risks and Mitigations
-
-#### Risk: Unsupported ControllersOnly Mode Misuse
-
-Customers may use `ControllersOnly` in production and file support
-tickets when CRD incompatibility causes issues.
-
-**Mitigation**: CIO sets a persistent unsupported warning condition
-in status. Telemetry captures the management mode for support
-triage.
 
 #### Risk: Orphaned Resources During Mode Transition
 
@@ -678,46 +642,34 @@ applies. Documentation must state that VAP protection is removed.
 
 ### Drawbacks
 
-Increased CIO complexity: three behavioral modes with different
+Increased CIO complexity: two behavioral modes with different
 controller enable/disable states and mode transition logic. This is
 justified by customer demand -- the alternative is customers
 fighting the VAP and CRD reconciler.
 
-The `ControllersOnly` mode introduces an explicitly unsupported
-configuration, but without it, advanced users would resort to worse
-workarounds (disabling the VAP manually, using
-`unsupportedConfigOverrides`).
-
 ## Open Questions
 
-1. ~~**Field placement**: Resolved. New Ingress singleton in
-   `operator.openshift.io/v1`, following the DNS/Console pattern.~~
-
-2. **ControllersOnly mode scope**: Should `ControllersOnly` mode perform
-   compatibility pre-checks before starting the Gateway controller,
-   or always start and report incompatibility via status conditions?
-
-3. **CRD cleanup on Unmanaged transition**: Should CIO offer an
+1. **CRD cleanup on Unmanaged transition**: Should CIO offer an
    option to remove CRDs when transitioning to `Unmanaged`? This
    would delete all Gateway/HTTPRoute resources. The current
    proposal preserves CRDs during transitions.
 
-4. **Interaction with `unsupportedConfigOverrides`**: The CRD
+2. **Interaction with `unsupportedConfigOverrides`**: The CRD
    lifecycle management enhancement uses an "unsupported config
    override" mechanism to bypass CRD succession checks. Should
    `managementMode` replace this mechanism or coexist with it?
 
-5. **Telemetry**: What telemetry should be collected? At minimum
+3. **Telemetry**: What telemetry should be collected? At minimum
    the configured mode. Should CIO also report metrics for CRD
    compliance and mode transitions?
 
-6. **Singleton creation**: Should the `cluster` singleton instance
+4. **Singleton creation**: Should the `cluster` singleton instance
    be created by CVO (via a manifest in the release payload) or
    by CIO on first startup? This affects upgrade behavior and
    needs alignment with the operator pattern used by DNS/Console.
 
-7. **Kind name collision**: The proposed Kind `Ingress` in
-   `operator.openshift.io/v1` shares a name with the well-known
+5. **Kind name collision**: The proposed Kind `Ingress` in
+   `operator.openshift.io/v1alpha1` shares a name with the well-known
    `networking.k8s.io/v1` Ingress. While API groups disambiguate,
    this may cause user confusion with `oc get ingress`. The short
    name and resource disambiguation strategy should be decided
@@ -758,32 +710,22 @@ The following e2e test scenarios are required:
    running. Verify status conditions report `Managed`.
 
 2. **Transition to Unmanaged**: Set mode to `Unmanaged`. Verify
-   that the CIO-managed Istio instance is shut down, the VAP is
+   that the CIO-managed Istio instance is stopped, the VAP is
    removed, and CRDs, GatewayClass, and Gateway resources are
    preserved. Verify status conditions report `Unmanaged`. Verify
    a third-party GatewayClass can be created.
 
-3. **Transition to ControllersOnly**: Set mode to `ControllersOnly`. Verify that the
-   VAP is removed, CRDs are no longer managed, but the Gateway
-   controller stack remains running. Verify the unsupported warning
-   condition.
+3. **Return to Managed**: From `Unmanaged`, return to `Managed`.
+   Verify CIO takes ownership of compatible CRDs, or reports
+   incompatibility for mismatched CRDs.
 
-4. **Return to Managed**: From `Unmanaged` or `ControllersOnly`, return to
-   `Managed`. Verify CIO takes ownership of compatible CRDs, or
-   reports incompatibility for mismatched CRDs.
-
-5. **Unmanaged mode with absent CRDs**: Set mode to `Unmanaged` on
+4. **Unmanaged mode with absent CRDs**: Set mode to `Unmanaged` on
    a cluster with no Gateway API CRDs. Verify CIO does not install
    CRDs and reports `CRDsNotFound`.
 
-6. **ControllersOnly mode with incompatible CRDs**: Set mode to `ControllersOnly` and
-   install CRDs that do not match the expected version. Verify CIO
-   reports compliance failure but continues running the Gateway
-   controller stack.
-
-7. **Upgrade with non-default mode**: Upgrade a cluster that has
-   `Unmanaged` or `ControllersOnly` mode set. Verify the mode is preserved
-   and CIO does not attempt to take over CRDs during upgrade.
+5. **Upgrade with non-default mode**: Upgrade a cluster that has
+   `Unmanaged` mode set. Verify the mode is preserved and CIO does
+   not attempt to take over CRDs during upgrade.
 
 ## Graduation Criteria
 
@@ -801,7 +743,6 @@ dev-guide/feature-zero-to-hero.md:
 - Feature gate `GatewayAPIManagementMode` added to
   `TechPreviewNoUpgrade` feature set.
 - `Managed` and `Unmanaged` modes fully functional.
-- `ControllersOnly` mode functional with unsupported warning.
 - Status conditions implemented and observable.
 - Unit and integration tests passing.
 - Initial e2e tests for basic mode transitions.
@@ -818,6 +759,8 @@ dev-guide/feature-zero-to-hero.md:
 - User-facing documentation created in
   [openshift-docs](https://github.com/openshift/openshift-docs/).
 - Feature gate promoted to `Default` feature set.
+- API promoted from `operator.openshift.io/v1alpha1` to
+  `operator.openshift.io/v1`.
 - Sufficient time for customer feedback (at least one minor
   release in Tech Preview).
 
@@ -841,8 +784,8 @@ the backport (customer upgrade path continuity) and demonstrate
 bounded risk.
 
 Backport scope:
-- Ingress CRD manifest for `operator.openshift.io/v1` (CVO).
-- `gatewayAPI` spec/status structs with all three enum values.
+- Ingress CRD manifest for `operator.openshift.io/v1alpha1` (CVO).
+- `gatewayAPI` spec/status structs with both enum values.
 - `status.gatewayAPI.conditions` reporting.
 - Feature gate `GatewayAPIManagementMode` (behind
   `TechPreviewNoUpgrade`).
@@ -864,7 +807,7 @@ Not applicable. This enhancement adds new functionality.
 ### Upgrade
 
 When upgrading from a version that does not have the Ingress
-(`operator.openshift.io/v1`) resource to one that does (e.g.,
+(`operator.openshift.io/v1alpha1`) resource to one that does (e.g.,
 upgrading from 4.18 to 4.19 with the backport applied):
 
 - CVO installs the new Ingress CRD. The `cluster` singleton is
@@ -880,15 +823,11 @@ upgrading from 4.19 to 4.20+ with mode already configured):
 - **Unmanaged mode**: CIO does not attempt to install or manage
   CRDs during the upgrade. The administrator's third-party CRDs
   are preserved.
-- **ControllersOnly mode**: CIO does not upgrade CRDs but does upgrade
-  the CIO-managed Istio instance. If the new Istio version is
-  incompatible with the existing CRDs, CIO reports degraded status.
-  The administrator is responsible for updating the CRDs.
 
 ### Downgrade
 
 When downgrading from a version that has the Ingress
-(`operator.openshift.io/v1`) resource to one that does not:
+(`operator.openshift.io/v1alpha1`) resource to one that does not:
 
 - The Ingress CRD and `cluster` singleton persist on the cluster
   (CRDs are not removed during rollbacks), but the older CIO does
@@ -901,9 +840,6 @@ When downgrading from a version that has the Ingress
   management succession logic (from
   [gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md))
   applies.
-- **If the cluster was in `ControllersOnly` mode**: The downgraded CIO
-  will attempt to take ownership of the CRDs. If they do not match
-  the expected version, the operator reports `Degraded`.
 
 **Recommendation**: Set mode to `Managed` and ensure CRD
 compatibility before downgrading.
@@ -926,8 +862,6 @@ resource read during CIO reconciliation.
 - **Failure modes**:
   - VAP removal failure during mode transition: CRDs remain locked.
     CIO retries and reports in status.
-  - `ControllersOnly` mode with absent CRDs: Gateway controller cannot
-    start. CIO reports and retries when CRDs appear.
 
 - **Escalation**: Networking / Ingress team. For Istio CRD
   interactions, consult the OSSM team.
@@ -981,43 +915,49 @@ oc delete crd \
   grpcroutes.gateway.networking.k8s.io
 ```
 
-**Symptom**: Gateway controller not starting in `ControllersOnly` mode.
-
-**Resolution**: Install Gateway API CRDs. CIO starts the
-controller when CRDs appear.
-
-**Symptom**: `CRDsManaged=False` with reason `ControllersOnly`.
-
-**Resolution**: Expected behavior for `ControllersOnly` mode. Verify
-the customer intentionally chose this mode. For production
-clusters, recommend switching to `Managed`.
-
 ## Alternatives (Not Implemented)
 
-### Alternative 1: Boolean Gateway API Disable Switch
+### Alternative 1: ControllersOnly Mode (Controller without CRD Management)
 
-Does not address the `ControllersOnly` use case (CRDs external, controller
-active). Also prohibited by OpenShift API conventions (no boolean
-fields in CRDs).
+A third mode, `ControllersOnly`, was considered where CIO would not
+manage Gateway API CRDs but would still deploy the OpenShift Gateway
+controller stack (CIO-managed Istio, GatewayClass, Gateway). The
+customer would bring their own CRDs. This would have been an
+explicitly unsupported configuration intended for development and
+testing with newer CRD versions.
 
-### Alternative 2: Modify `ingress.config.openshift.io/cluster`
+This mode was removed from the proposal due to a lack of evidence
+that it would be used in practice. The primary customer need is to
+opt out of CIO's CRD management entirely (to use a third-party
+controller), which `Unmanaged` mode addresses. Running the OpenShift
+controller against arbitrary externally-provided CRDs introduces
+significant compatibility risks (unknown fields, schema mismatches)
+with limited benefit. This decision will be revisited if customer
+demand or concrete use cases emerge.
+
+### Alternative 2: Boolean Gateway API Disable Switch
+
+Prohibited by OpenShift API conventions (no boolean fields in CRDs).
+Also does not provide the observability benefits of the enum pattern.
+
+### Alternative 3: Modify `ingress.config.openshift.io/cluster`
 
 That resource is owned by `config-operator` for install-time
 configuration (base domain, HSTS policies, component routes).
 Gateway API operational behavior belongs in `operator.openshift.io`.
 
-### Alternative 3: Annotation-Based Configuration
+### Alternative 4: Annotation-Based Configuration
 
 Lacks validation, defaulting, and discoverability. Not visible in
 `oc describe` as structured fields.
 
-### Alternative 4: Separate `GatewayAPIConfig` CRD
+### Alternative 5: Separate `GatewayAPIConfig` CRD
 
 Adds unnecessary complexity. CRD management is an ingress concern,
-so the Ingress resource in `operator.openshift.io/v1` is a more
+so the Ingress resource in `operator.openshift.io/v1alpha1` is a more
 natural home.
 
-### Alternative 5: Per-CRD Management Granularity
+### Alternative 6: Per-CRD Management Granularity
 
 Per-CRD modes (e.g., manage GatewayClass CRD but not HTTPRoute)
 add significant complexity for minimal benefit. In practice, CRDs

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -12,7 +12,7 @@ approvers:
 api-approvers:
   - "@everettraven"
 creation-date: 2026-05-26
-last-updated: 2026-05-27
+last-updated: 2026-05-28
 status: provisional
 tracking-link:
   - https://redhat.atlassian.net/browse/NE-2733
@@ -27,71 +27,47 @@ see-also:
 
 ## Summary
 
-This enhancement introduces a new `gatewayAPI` configuration struct
-on the cluster-scoped `Ingress` configuration resource
-(`ingress.config.openshift.io/cluster`) that contains a
-`crdManagementMode` enum field controlling how the Cluster Ingress
-Operator (CIO) manages Gateway API Custom Resource Definitions
-(CRDs) and the associated Gateway controller stack (the Istio
-instance deployed by CIO, GatewayClass, Gateway resources). The
-enum exposes three modes -- `Managed`, `Unmanaged`, and
-`ExternalCRDs` -- enabling cluster administrators and third-party
-products to choose whether CIO fully owns the Gateway API CRDs and
-controller, delegates CRD ownership entirely to an external entity,
-or runs the OpenShift Gateway controller against
-externally-provided CRDs. The `gatewayAPI` struct is designed to be
-extended in the future with additional Gateway API-related
-configuration fields.
+This enhancement introduces a new cluster-scoped singleton API
+resource, `Ingress` (resource `ingresses`, singleton named
+`cluster`), in the `operator.openshift.io/v1` group. The
+resource exposes a `spec.gatewayAPI.crdManagementMode` enum
+field that controls how the Cluster Ingress Operator (CIO)
+manages Gateway API CRDs and the associated Gateway controller
+stack (CIO-managed Istio, GatewayClass, Gateway). Three modes
+are provided: `Managed` (default -- CIO owns everything),
+`Unmanaged` (CIO does nothing, external entity takes over), and
+`ExternalCRDs` (CIO runs the Gateway controller against
+externally-provided CRDs, unsupported configuration).
 
-The `ingress.config.openshift.io` API is the correct home for this
-setting because Gateway API CRD management is a cluster-wide,
-platform-level concern. CRDs are cluster-scoped resources, and the
-management mode must apply uniformly across the platform rather
-than being a per-IngressController decision. The
-`ingress.config.openshift.io/cluster` resource already serves as
-the authoritative source of platform-wide ingress configuration
-(base domain, load balancer platform defaults, HSTS policies) that
-the Cluster Ingress Operator watches and consumes to configure
-individual IngressControllers. Adding the Gateway API CRD
-management mode here follows the same established pattern and
-avoids the risk of conflicting configurations from multiple
-IngressController resources.
+The field lives on a new resource rather than on
+`IngressController` (where multiple instances could conflict) or
+`ingress.config.openshift.io/cluster` (which is owned by
+`config-operator` for install-time configuration). The
+`operator.openshift.io` group already has cluster-scoped
+singletons (`DNS`, `Console`) and is the natural home for
+operator-managed behavior.
 
 ## Motivation
 
-The current Gateway API integration in OpenShift, as established by
-the
+As established by the
 [gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md)
 and
 [gateway-api-without-olm](gateway-api-without-olm.md)
-enhancements, treats Gateway API CRDs as a core platform API. CIO
-owns the CRDs, pins them to a specific version, protects them with
-Validating Admission Policies (VAPs), and upgrades them automatically
-during cluster upgrades. This is the right default for most customers.
+enhancements, CIO owns the Gateway API CRDs, pins them to a
+specific version, protects them with Validating Admission Policies
+(VAPs), and upgrades them during cluster upgrades. This is the
+right default for most customers, but creates friction for:
 
-However, this "CIO owns everything" model creates friction for several
-legitimate use cases:
+1. **Third-party Gateway API implementations**: Customers using
+   Envoy Gateway, Traefik, Kong, or other non-OpenShift controllers
+   cannot install their own CRD versions because CIO owns and
+   protects them.
 
-1. **Third-party Gateway API implementations**: Customers who want to
-   use a non-OpenShift Gateway API controller (e.g., Envoy Gateway,
-   Traefik, Kong) cannot do so cleanly because CIO installs and
-   protects its own CRD versions. The third-party controller may
-   require a different CRD version or schema.
+2. **Development and testing**: Platform engineers who need newer CRD
+   versions must fight the VAP and CIO reconciler.
 
-2. **Development and testing**: Platform engineers and advanced users
-   sometimes need to test with newer CRD versions or experimental
-   fields. Today, this requires fighting the VAP and the CIO
-   reconciler.
-
-3. **Supportability and observability**: When CRDs are modified
-   outside the expected flow (e.g., by bypassing the VAP), there is
-   no explicit API-level signal that tells support or monitoring
-   who is supposed to own the CRDs and whether the current state is
-   intentional.
-
-This enhancement addresses these gaps by providing an explicit,
-API-level knob that makes CRD ownership a first-class configuration
-choice rather than an implicit assumption.
+3. **Supportability**: There is no API-level signal indicating who
+   owns the CRDs or whether the current state is intentional.
 
 ### User Stories
 
@@ -118,110 +94,79 @@ whether the current CRD state matches the configured ownership mode
 so that I can diagnose issues without needing to inspect labels,
 annotations, and controller logs manually.
 
-#### Story 4: Operational Monitoring at Scale
+#### Story 4: Operational Monitoring
 
-As a fleet administrator managing hundreds of OpenShift clusters, I
-want to monitor the Gateway API CRD ownership state via standard
-OpenShift status conditions and metrics so that I can detect clusters
-where CRD ownership is misconfigured or where CRDs have drifted from
-the expected state, enabling proactive remediation before users are
-affected.
-
-#### Story 5: Automatic CRD Upgrades
-
-As a cluster administrator using the default configuration, I want
-OpenShift to continue automatically upgrading Gateway API CRDs during
-cluster upgrades so that I do not need to manage CRD versions myself,
-and I want the ownership state to be clearly reported in the
-`ingress.config.openshift.io/cluster` status.
+As a fleet administrator, I want to monitor Gateway API CRD ownership
+state via standard OpenShift status conditions so that I can detect
+clusters where CRD ownership is misconfigured or where CRDs have
+drifted from the expected state.
 
 ### Goals
 
-1. Provide an explicit API field on
-   `ingress.config.openshift.io/cluster` that controls Gateway API
-   CRD ownership with three modes: `Managed`, `Unmanaged`, and
-   `ExternalCRDs`.
-2. Enable customers and third-party products to take full control of
-   Gateway API CRDs when needed, without fighting CIO's reconciler
-   or VAP protections.
-3. Expose clear, observable status conditions that report the current
-   CRD ownership mode, CRD presence, and CRD compliance with the
-   expected version.
-4. Signal via status conditions the CRD management state so that
-   external consumers can determine the platform's Gateway API
-   posture.
-5. Preserve the current fully-managed behavior as the default,
+1. Provide a `crdManagementMode` enum field on a new Ingress
+   (`operator.openshift.io/v1`) singleton with three modes:
+   `Managed`, `Unmanaged`, and `ExternalCRDs`.
+2. Allow customers and third-party products to take full control of
+   Gateway API CRDs without fighting CIO's reconciler or VAP.
+3. Expose status conditions reporting CRD ownership mode, presence,
+   and version compliance.
+4. Preserve the current fully-managed behavior as the default,
    requiring no action from existing customers.
-6. Define clear upgrade and downgrade semantics for transitioning
-   between modes.
+5. Define clear upgrade and downgrade semantics for mode transitions.
 
 ### Non-Goals
 
-1. **Unknown field management**: Handling fields in CRDs that are not
-   recognized by the current controller version is a long-term goal
-   that will build on top of this work. This enhancement mentions it
-   for context but does not define the solution. See
-   [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624)
-   for upstream tracking.
-2. **CRD version ranges**: Allowing a configurable range of acceptable
-   CRD versions rather than pinning to one specific version. This is
-   future work that depends on resolving the unknown fields problem.
+1. **Unknown field management**: Future work tracked upstream in
+   [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
+   This enhancement mentions it for context but does not define the
+   solution.
+2. **CRD version ranges**: Future work that depends on resolving
+   the unknown fields problem.
 3. **Automatic migration of third-party CRDs**: When switching from
-   `Unmanaged` to `Managed`, CIO will not attempt to reconcile or
-   migrate third-party CRDs automatically. The administrator must
-   ensure the cluster state is compatible before changing modes.
-4. **MicroShift support**: MicroShift does not use CIO and has its own
-   Gateway API design. This enhancement does not affect MicroShift.
-5. **Istio CRD management mode**: This enhancement controls only
-   Gateway API CRDs (`gateway.networking.k8s.io` group). Istio CRD
-   management (the `networking.istio.io`, `security.istio.io`, etc.
-   groups) is handled separately by the sail-operator library as
-   described in
+   `Unmanaged` to `Managed`, CIO will not migrate third-party CRDs.
+   The administrator must ensure compatibility before changing modes.
+4. **MicroShift support**: MicroShift does not use CIO and is
+   unaffected by this enhancement.
+5. **Istio CRD management**: This enhancement controls only Gateway
+   API CRDs (`gateway.networking.k8s.io`). Istio CRDs are handled
+   by the sail-operator library as described in
    [gateway-api-without-olm](gateway-api-without-olm.md).
 
 ## Proposal
 
-Add a new `gatewayAPI` struct field to the `IngressSpec` of the
-cluster-scoped `Ingress` configuration resource
-(`ingress.config.openshift.io/cluster`). This struct serves as a
-namespace for all Gateway API-related platform configuration.
-Initially, it contains a single `crdManagementMode` enum field
-with three values: `Managed` (default), `Unmanaged`, and
-`ExternalCRDs`. The struct is intentionally designed to be
-extensible so that future Gateway API configuration fields can be
-added without further API restructuring.
+Introduce a new cluster-scoped singleton API resource in the
+`operator.openshift.io/v1` group:
 
-The Cluster Ingress Operator already watches the
-`ingress.config.openshift.io/cluster` resource and reconciles all
-IngressControllers when it changes. CIO will read the
-`spec.gatewayAPI.crdManagementMode` field from this resource to
-determine its behavior regarding Gateway API CRD lifecycle
-management and the Gateway controller stack (the Istio instance
-deployed by CIO, GatewayClass, Gateway resources).
+- **Kind**: `Ingress`
+- **Resource**: `ingresses`
+- **Scope**: Cluster (non-namespaced)
+- **Singleton name**: `cluster`
+- **Pattern**: Same as `DNS` and `Console` in
+  `operator.openshift.io/v1` -- embeds
+  `OperatorSpec`/`OperatorStatus` inline.
 
-The three modes are:
+The spec contains a `gatewayAPI` struct with a
+`crdManagementMode` enum. The struct is extensible for future
+Gateway API configuration fields.
 
-- **Managed** (default): CIO maintains the Gateway API CRDs, protects
-  them via VAPs, upgrades them during cluster upgrades, and runs the
-  full Gateway controller stack (the Istio instance deployed by CIO,
-  GatewayClass, Gateway). This is the current behavior and the only
-  fully supported configuration.
+CIO watches this resource and reads
+`spec.gatewayAPI.crdManagementMode` to determine its behavior:
 
-- **Unmanaged**: CIO does NOT install Gateway API CRDs and does NOT
-  deploy the Gateway controller stack. The customer or a third-party
-  product brings their own CRDs and Gateway controller. CIO's
-  Gateway-related controllers are disabled entirely. CIO reports
-  observational status (CRD presence, version) but takes no
-  management action.
+- **Managed** (default): CIO installs, protects (via VAP), and
+  upgrades Gateway API CRDs. CIO runs the full Gateway controller
+  stack (CIO-managed Istio, GatewayClass, Gateway). This is the
+  current behavior and the only fully supported configuration.
 
-- **ExternalCRDs**: CIO does NOT manage Gateway API CRDs (no install,
-  no upgrade, no VAP protection) but DOES run the OpenShift Gateway
-  controller stack (the Istio instance deployed by CIO, GatewayClass,
-  Gateway). The customer
-  brings their own CRDs. This is explicitly marked as an
-  **unsupported** configuration, useful for development, testing, or
-  advanced users who need newer CRD versions. CIO reports status
-  including a persistent unsupported warning.
+- **Unmanaged**: CIO does not install CRDs and does not deploy
+  the Gateway controller stack. The customer or a third-party
+  product owns the CRDs and Gateway controller. CIO reports
+  observational status only.
+
+- **ExternalCRDs**: CIO does not manage CRDs but does run the
+  Gateway controller stack. The customer brings their own CRDs.
+  This is an **unsupported** configuration for development and
+  testing. CIO reports status including a persistent unsupported
+  warning.
 
 ### Workflow Description
 
@@ -234,9 +179,9 @@ IngressController resources and manages Gateway API components.
 #### Workflow 1: Default Managed Mode (No Action Required)
 
 1. The cluster administrator installs or upgrades OpenShift.
-2. CIO reads the `ingress.config.openshift.io/cluster` resource and observes that
-   `spec.gatewayAPI.crdManagementMode` is unset (defaults to
-   `Managed`).
+2. CIO reads the Ingress (`operator.openshift.io/v1`) `cluster`
+   resource and observes that `spec.gatewayAPI.crdManagementMode`
+   is unset (defaults to `Managed`).
 3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
    instance, GatewayClass, and Gateway resources as per the existing
    behavior.
@@ -250,8 +195,13 @@ IngressController resources and manages Gateway API components.
 
 1. The cluster administrator decides to use a third-party Gateway
    API implementation.
-2. The cluster administrator edits the `ingress.config.openshift.io/cluster` resource:
+2. The cluster administrator edits the Ingress
+   (`operator.openshift.io/v1`) `cluster` resource:
    ```yaml
+   apiVersion: operator.openshift.io/v1
+   kind: Ingress
+   metadata:
+     name: cluster
    spec:
      gatewayAPI:
        crdManagementMode: Unmanaged
@@ -274,8 +224,13 @@ IngressController resources and manages Gateway API components.
 
 1. The cluster administrator or developer wants to test with newer
    Gateway API CRDs while using the OpenShift Gateway controller.
-2. The cluster administrator edits the `ingress.config.openshift.io/cluster` resource:
+2. The cluster administrator edits the Ingress
+   (`operator.openshift.io/v1`) `cluster` resource:
    ```yaml
+   apiVersion: operator.openshift.io/v1
+   kind: Ingress
+   metadata:
+     name: cluster
    spec:
      gatewayAPI:
        crdManagementMode: ExternalCRDs
@@ -301,8 +256,13 @@ IngressController resources and manages Gateway API components.
    configuration.
 2. The cluster administrator ensures the existing Gateway API CRDs
    match the version CIO expects, or removes them entirely.
-3. The cluster administrator edits the `ingress.config.openshift.io/cluster` resource:
+3. The cluster administrator edits the Ingress
+   (`operator.openshift.io/v1`) `cluster` resource:
    ```yaml
+   apiVersion: operator.openshift.io/v1
+   kind: Ingress
+   metadata:
+     name: cluster
    spec:
      gatewayAPI:
        crdManagementMode: Managed
@@ -321,7 +281,7 @@ IngressController resources and manages Gateway API components.
 ```mermaid
 sequenceDiagram
     participant Admin as Cluster Admin
-    participant IC as ingress.config.openshift.io/cluster
+    participant IC as Ingress (operator.openshift.io/v1)
     participant CIO as Cluster Ingress Operator
     participant CRDs as Gateway API CRDs
     participant GW as Gateway Stack<br/>(CIO Istio/GatewayClass/Gateway)
@@ -347,34 +307,88 @@ sequenceDiagram
 
 ### API Extensions
 
-This enhancement modifies the existing cluster-scoped `Ingress`
-resource (`ingress.config.openshift.io/cluster`, defined in
-`config/v1/types_ingress.go` in the `openshift/api` repository) by
-adding new fields to `IngressSpec` and `IngressStatus`. No new
-CRDs, admission webhooks, conversion webhooks, aggregated API
-servers, or finalizers are introduced.
+This enhancement introduces a **new CRD** in the
+`operator.openshift.io/v1` group. The new resource follows the
+same pattern as the existing `DNS` and `Console` cluster-scoped
+singletons in this group.
 
-**Why `ingress.config.openshift.io` instead of
-`operator.openshift.io` IngressController:**
+**Why a new resource** (see also Alternatives section):
+`IngressController` is namespaced and multi-instance, so it
+cannot hold a cluster-wide setting without conflicts.
+`ingress.config.openshift.io` is owned by `config-operator` for
+install-time configuration. A dedicated singleton in
+`operator.openshift.io` follows the DNS/Console pattern and
+provides a clean extension point.
 
-The `ingress.config.openshift.io/cluster` resource is the
-cluster-scoped singleton that holds platform-wide ingress
-configuration. It already contains settings that apply uniformly
-across the platform (base domain, load balancer platform defaults,
-HSTS policies) and is watched by CIO to configure individual
-IngressControllers. Gateway API CRD management is a cluster-wide
-concern because:
+The proposed Go types are in a new file in `operator/v1/` in the
+`openshift/api` repository (note: `types_ingress.go` already
+exists for `IngressController`, so this type needs a separate
+file, e.g. `types_ingress_gateway.go`):
 
-1. CRDs are cluster-scoped Kubernetes resources -- there is exactly
-   one set of Gateway API CRDs per cluster.
-2. The management mode must be consistent across the platform. If
-   it lived on IngressController, multiple IngressControllers could
-   specify conflicting modes, creating undefined behavior.
-3. The `ingress.config.openshift.io/cluster` resource is already
-   the authoritative source that CIO watches for platform-level
-   ingress decisions, making it the natural integration point.
+```go
+// +genclient
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+//
+// Ingress holds cluster-wide configuration for Gateway API
+// integration managed by the Cluster Ingress Operator. The
+// canonical name is `cluster`.
+//
+// Compatibility level 1: Stable within a major release for a
+// minimum of 12 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=1
+// +openshift:api-approved.openshift.io=<TBD>
+// +openshift:file-pattern=cvoRunLevel=0000_50,operatorName=ingress,operatorOrdering=02
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=ingresses,scope=Cluster
+// +kubebuilder:subresource:status
+// +openshift:capability=Ingress
+type Ingress struct {
+	metav1.TypeMeta `json:",inline"`
 
-The proposed Go types are (in `config/v1/types_ingress.go`):
+	// metadata is the standard object's metadata.
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// spec holds user settable values for configuration.
+	// +required
+	Spec IngressSpec `json:"spec"`
+
+	// status holds observed values from the cluster.
+	// +optional
+	Status IngressStatus `json:"status"`
+}
+
+type IngressSpec struct {
+	// Inline OperatorSpec for standard operator fields
+	// (managementState, logLevel, etc.)
+	OperatorSpec `json:",inline"`
+
+	// gatewayAPI holds configuration for Gateway API
+	// integration, including how the Cluster Ingress Operator
+	// manages Gateway API CRDs and the Gateway controller stack.
+	// This struct is designed to accommodate additional Gateway
+	// API configuration fields in future releases.
+	//
+	// +required
+	// +openshift:enable:FeatureGate=GatewayAPICRDManagementMode
+	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI"`
+}
+
+type IngressStatus struct {
+	// Inline OperatorStatus for standard operator status fields
+	// (conditions, version, observedGeneration, etc.)
+	OperatorStatus `json:",inline"`
+
+	// gatewayAPI holds status information for Gateway API
+	// integration, including conditions related to CRD
+	// management and the Gateway controller stack.
+	//
+	// +optional
+	GatewayAPI GatewayAPIIngressStatus `json:"gatewayAPI,omitempty"`
+}
+```
+
+The `GatewayAPIIngressConfig` and `GatewayAPIIngressStatus` types:
 
 ```go
 // GatewayAPICRDManagementMode describes how the Cluster Ingress
@@ -398,19 +412,17 @@ const (
 	// controller. CIO reports observational status only.
 	UnmanagedGatewayAPICRDs GatewayAPICRDManagementMode = "Unmanaged"
 
-	// ExternalCRDsGatewayAPICRDs means CIO does NOT manage Gateway
-	// API CRDs but DOES deploy the OpenShift Gateway controller
-	// stack (the Istio instance deployed by CIO, GatewayClass,
-	// Gateway). The customer brings their own CRDs. This is an
-	// UNSUPPORTED configuration useful for development, testing,
-	// or advanced users.
+	// ExternalCRDsGatewayAPICRDs means CIO does NOT manage
+	// Gateway API CRDs but DOES deploy the OpenShift Gateway
+	// controller stack (the Istio instance deployed by CIO,
+	// GatewayClass, Gateway). The customer brings their own
+	// CRDs. This is an UNSUPPORTED configuration useful for
+	// development, testing, or advanced users.
 	ExternalCRDsGatewayAPICRDs GatewayAPICRDManagementMode = "ExternalCRDs"
 )
 
 // GatewayAPIIngressConfig holds configuration for Gateway API
-// integration in the Cluster Ingress Operator. This struct is
-// designed to be extended with additional Gateway API-related
-// configuration fields in the future.
+// integration in the Cluster Ingress Operator.
 type GatewayAPIIngressConfig struct {
 	// crdManagementMode specifies how the Cluster Ingress
 	// Operator manages Gateway API Custom Resource Definitions
@@ -429,70 +441,28 @@ type GatewayAPIIngressConfig struct {
 	// is responsible for providing their own CRDs and Gateway
 	// controller. CIO reports observational status only.
 	//
-	// When set to "ExternalCRDs", CIO does not manage Gateway API
-	// CRDs but does deploy the OpenShift Gateway controller stack.
-	// The cluster administrator brings their own CRDs. This is an
-	// unsupported configuration intended for development and
-	// testing.
+	// When set to "ExternalCRDs", CIO does not manage Gateway
+	// API CRDs but does deploy the OpenShift Gateway controller
+	// stack. The cluster administrator brings their own CRDs.
+	// This is an unsupported configuration intended for
+	// development and testing.
 	//
 	// +kubebuilder:default:="Managed"
 	// +default="Managed"
 	// +required
 	CRDManagementMode GatewayAPICRDManagementMode `json:"crdManagementMode"`
 }
-```
 
-The `GatewayAPIIngressConfig` struct is added to `IngressSpec` as a
-value type (not a pointer). The field is mandatory and defaults to
-`Managed` mode. Once set, the administrator must change the mode
-to a different value rather than removing the field entirely:
-
-```go
-type IngressSpec struct {
-	// ... existing fields (domain, appsDomain, componentRoutes,
-	//     requiredHSTSPolicies, loadBalancer) ...
-
-	// gatewayAPI holds configuration for Gateway API integration,
-	// including how the Cluster Ingress Operator manages Gateway
-	// API CRDs and the Gateway controller stack. This struct is
-	// designed to accommodate additional Gateway API configuration
-	// fields in future releases.
-	//
-	// +required
-	// +openshift:enable:FeatureGate=GatewayAPICRDManagementMode
-	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI"`
-}
-```
-
-The field path for the CRD management mode is:
-
-```
-spec.gatewayAPI.crdManagementMode
-```
-
-This nesting under the `gatewayAPI` struct allows future fields
-such as `spec.gatewayAPI.someOtherSetting` to be added without
-further API restructuring.
-
-A new `gatewayAPI` struct is added to `IngressStatus` to namespace
-all Gateway API-related status, mirroring the spec-side `gatewayAPI`
-struct. This keeps Gateway API conditions separate from the
-Ingress resource's existing status fields and makes it easy for
-consumers to find all Gateway API state in one place.
-
-```go
-// GatewayAPIIngressStatus holds status information for Gateway API
-// integration managed by the Cluster Ingress Operator.
+// GatewayAPIIngressStatus holds status information for Gateway
+// API integration managed by the Cluster Ingress Operator.
 type GatewayAPIIngressStatus struct {
 	// conditions is a list of conditions related to Gateway API
-	// CRD management and the Gateway controller stack. These
-	// conditions are scoped to Gateway API concerns and are
-	// separate from the Ingress resource's top-level status.
+	// CRD management and the Gateway controller stack.
 	//
 	// Supported condition types are:
 	// * CRDsManaged - whether CIO is actively managing CRDs
-	// * CRDsPresent - whether Gateway API CRDs exist on the cluster
-	// * CRDsCompliant - whether installed CRDs match the expected version
+	// * CRDsPresent - whether Gateway API CRDs exist on cluster
+	// * CRDsCompliant - whether installed CRDs match expected version
 	//
 	// +listType=map
 	// +listMapKey=type
@@ -501,32 +471,15 @@ type GatewayAPIIngressStatus struct {
 }
 ```
 
-The `GatewayAPIIngressStatus` struct is added to `IngressStatus`:
-
-```go
-type IngressStatus struct {
-	// ... existing fields (componentRoutes, defaultPlacement) ...
-
-	// gatewayAPI holds status information for Gateway API
-	// integration, including conditions related to CRD management
-	// and the Gateway controller stack.
-	//
-	// +optional
-	GatewayAPI GatewayAPIIngressStatus `json:"gatewayAPI,omitempty"`
-}
-```
-
-The status field path for Gateway API conditions is:
+The field paths are:
 
 ```
+spec.gatewayAPI.crdManagementMode
 status.gatewayAPI.conditions
 ```
 
 The following conditions are set within
-`status.gatewayAPI.conditions`. These conditions follow the
-standard Kubernetes condition semantics with `type`, `status`,
-`reason`, `message`, `lastTransitionTime`, and
-`observedGeneration` fields:
+`status.gatewayAPI.conditions`:
 
 | Condition Type | Status | Reason | Description |
 |---|---|---|---|
@@ -539,160 +492,96 @@ standard Kubernetes condition semantics with `type`, `status`,
 | `CRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
 | `CRDsCompliant` | `Unknown` | `NotApplicable` | Compliance check is not applicable (e.g., Unmanaged mode with no CRDs present) |
 
-Since these conditions live under `status.gatewayAPI.conditions`,
-the `GatewayAPICRDs` prefix is no longer needed on the condition
-type names — the namespace is provided by the struct itself.
-
-Note that CIO already has the machinery to write to the
-`ingress.config.openshift.io/cluster` status subresource -- this is
-the same pattern used for `status.componentRoutes`.
+**Note:** This is a new CRD and must go through the full API
+review process via `#forum-api-review`. The API approver must
+review both this enhancement and the implementation PR in
+`openshift/api`.
 
 ### Topology Considerations
 
 #### Hypershift / Hosted Control Planes
 
-This enhancement applies to Hypershift with the same semantics as
-standalone clusters. The Ingress Operator runs on the management
-cluster but manages resources on the guest cluster via kubeconfig.
-The `spec.gatewayAPI.crdManagementMode` field on the
-`ingress.config.openshift.io/cluster` resource in the guest
-cluster controls CRD management on that guest cluster.
-
-No management-cluster-side changes are required. The mode
-configuration is per-guest-cluster and does not affect the
-management cluster or other guest clusters.
+Same semantics as standalone clusters. The Ingress Operator runs
+on the management cluster but manages resources on the guest
+cluster. The mode is configured per-guest-cluster and does not
+affect the management cluster.
 
 #### Standalone Clusters
 
-This is the primary topology for this enhancement. All three modes
-are fully applicable to standalone clusters with no special
+Primary topology. All three modes apply with no special
 considerations.
 
 #### Single-node Deployments or MicroShift
 
-**Single-node OpenShift (SNO)**: This enhancement applies to SNO
-with no additional resource consumption concerns beyond what the
-existing Gateway API feature already introduces. The `Unmanaged`
-mode may be particularly useful for SNO deployments with constrained
-resources, as it allows disabling the Gateway controller stack
-entirely (the CIO-managed Istio instance, Envoy proxies) to reclaim
-CPU and memory.
+**SNO**: No additional resource concerns. `Unmanaged` mode allows
+disabling the Gateway controller stack to reclaim resources.
 
-**MicroShift**: MicroShift does not use the Cluster Ingress Operator
-and has its own Gateway API design (see the
-[MicroShift Gateway API Support Enhancement](../microshift/gateway-api-support.md)).
-This enhancement does not affect MicroShift.
+**MicroShift**: Not affected. MicroShift does not use CIO (see
+[MicroShift Gateway API Support](../microshift/gateway-api-support.md)).
 
 #### OpenShift Kubernetes Engine
 
-This enhancement is fully applicable to OKE. Since the
+All three modes are available. The
 [gateway-api-without-olm](gateway-api-without-olm.md) enhancement
-enables Gateway API on OKE by eliminating OSSM licensing concerns,
-all three CRD management modes are available on OKE clusters.
-
-The `Unmanaged` mode may be particularly relevant for OKE customers
-who prefer to use their own Gateway API implementation.
+enables Gateway API on OKE by eliminating OSSM licensing concerns.
 
 ### Implementation Details/Notes/Constraints
 
 #### Feature Gate
 
-Per the OpenShift feature development process, this enhancement
-requires a new feature gate. The proposed feature gate name is
-`GatewayAPICRDManagementMode`. The feature gate must be added to
-https://github.com/openshift/api/blob/master/features/features.go
-with the `TechPreviewNoUpgrade` feature set initially.
+New feature gate: `GatewayAPICRDManagementMode`, added to
+`TechPreviewNoUpgrade` in
+[features.go](https://github.com/openshift/api/blob/master/features/features.go).
 
-The `gatewayAPI` field on `IngressSpec` must use the
+The `gatewayAPI` field uses the
 `+openshift:enable:FeatureGate=GatewayAPICRDManagementMode` marker
-to ensure the field is only present in CRDs for feature sets where
-the feature gate is enabled.
-
-The `ExternalCRDs` enum value should use the
-`+openshift:validation:FeatureGateAwareEnum` marker if the intent
-is to gate the unsupported mode separately from the other two modes.
+so it only appears in CRDs when the gate is enabled.
 
 #### Interaction with the GatewayAPI Feature Gate
 
-The existing `GatewayAPI` feature gate controls whether CIO's
-Gateway API controllers are enabled at all. The new
-`GatewayAPICRDManagementMode` feature gate and the
-`crdManagementMode` field only take effect when the `GatewayAPI`
-feature gate is also enabled. When `GatewayAPI` is disabled, the
-`crdManagementMode` field is ignored and CIO does not manage any
-Gateway API resources regardless of the mode.
+The `crdManagementMode` field only takes effect when the existing
+`GatewayAPI` feature gate is also enabled. When `GatewayAPI` is
+disabled, CIO does not manage any Gateway API resources regardless
+of the mode setting.
 
 #### CIO Controller Changes
 
-The following controllers in CIO are affected:
+Affected controllers:
 
-1. **GatewayClass controller**: Must respect the management mode.
-   In `Unmanaged` mode, this controller must be fully disabled. In
-   `Managed` and `ExternalCRDs` modes, it operates as today.
-
-2. **CRD management controller**: Must respect the management mode.
-   In `Managed` mode, it installs, upgrades, and protects CRDs. In
-   `Unmanaged` and `ExternalCRDs` modes, it does not install or manage
-   CRDs but does observe their presence and compliance.
-
-3. **Gateway controller**: Must respect the management mode. In
-   `Unmanaged` mode, this controller is disabled. In `Managed` and
-   `ExternalCRDs` modes, it operates as today.
-
-4. **Status controller**: A new or extended controller that computes
-   the `CRDsManaged`, `CRDsPresent`, and `CRDsCompliant`
-   conditions in `status.gatewayAPI.conditions` based on the
-   configured
-   mode and the observed cluster state.
+| Controller | Managed | Unmanaged | ExternalCRDs |
+|---|---|---|---|
+| CRD management | Install, upgrade, protect (VAP) | Observe only | Observe only |
+| GatewayClass | Active | Disabled | Active |
+| Gateway | Active | Disabled | Active |
+| Status | Report conditions | Report conditions | Report conditions + unsupported warning |
 
 #### VAP Management
 
-In `Managed` mode, the VAP that protects Gateway API CRDs from
-unauthorized modification is deployed as today. In `Unmanaged` and
-`ExternalCRDs` modes, the VAP must be removed to allow the cluster
-administrator or third-party products to modify the CRDs.
-
-The transition from `Managed` to `Unmanaged` or `ExternalCRDs` must
-remove the VAP before CIO stops managing the CRDs, to avoid
-leaving the cluster in a state where CRDs cannot be modified by
-anyone.
+The VAP protecting Gateway API CRDs is deployed only in `Managed`
+mode. When transitioning away from `Managed`, the VAP must be
+removed first to avoid leaving CRDs locked.
 
 #### CRD Validity Definition
 
-A Gateway API CRD is considered **valid** (compliant) when it meets
-the following criteria:
+A Gateway API CRD is considered **compliant** when:
 
-1. **Strict version match**: The CRD must be the exact version that
-   the current CIO release expects. CIO pins to a specific Gateway
-   API release version (e.g., `v1.2.1`). The CRD's
-   `gateway.networking.k8s.io/bundle-version` label must match this
-   pinned version exactly. Version ranges are not supported in this
-   enhancement (see Non-Goals regarding future CRD version range
-   support).
+1. **Strict version match**: The CRD's
+   `gateway.networking.k8s.io/bundle-version` annotation matches
+   the exact Gateway API version that CIO expects (e.g.,
+   `v1.2.1`). Version ranges are not supported (see Non-Goals).
 
-2. **Checksum verification** (future iteration): As a subsequent
-   improvement within this enhancement's scope, CIO will compute a
-   SHA-256 checksum of the CRD's OpenAPI schema and compare it
-   against the expected checksum embedded in the CIO binary. This
-   ensures that even if the version label matches, the actual schema
-   has not been tampered with or partially modified. Until checksum
-   verification is implemented, version label matching is the
-   primary compliance check.
+2. **Checksum verification** (future iteration): SHA-256 checksum
+   of the CRD's OpenAPI schema compared against the expected
+   checksum embedded in the CIO binary.
 
-When CRDs are found to be non-compliant (in any mode), CIO will
-report the mismatch in the `CRDsCompliant` condition (under
-`status.gatewayAPI.conditions`)
-message, including:
-- The expected version and (when available) checksum.
-- The actual version and (when available) checksum found on the
-  cluster.
-- A pointer to where the administrator can obtain the correct CRD
-  manifests. The valid CRD manifests can be obtained from the
-  `gateway-api` container image shipped in the OpenShift release
-  payload at the path `/manifests/gateway-api/`. Alternatively,
-  they can be extracted from the upstream Gateway API release at
-  `https://github.com/kubernetes-sigs/gateway-api/releases` matching
-  the expected version.
+When CRDs are non-compliant, CIO reports the mismatch in the
+`CRDsCompliant` condition message, including expected vs. actual
+versions and where to obtain valid manifests. Valid CRD manifests
+are available from:
+- The `gateway-api` container image in the OpenShift release
+  payload at `/manifests/gateway-api/`.
+- The upstream Gateway API release at
+  `https://github.com/kubernetes-sigs/gateway-api/releases`.
 
 #### Mode Transition Ordering
 
@@ -719,132 +608,97 @@ to avoid leaving the cluster in an inconsistent state:
 
 #### Long-Term: Unknown Field Management
 
-As mentioned in
-[gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md),
-the "unknown fields" (or "dead fields") problem is being tracked
-upstream in
+The "unknown fields" problem (CRDs containing fields the controller
+does not recognize) is tracked upstream in
 [gateway-api#3624](https://github.com/kubernetes-sigs/gateway-api/issues/3624).
-The `ExternalCRDs` mode is particularly susceptible to this problem because
-the CRDs may contain fields that the OpenShift Gateway controller
-does not recognize.
-
-This enhancement establishes the foundation for future work on
-unknown field management by providing the management mode
-infrastructure. Future enhancements can build on this to add:
-
-- CRD version range support (allowing a set of compatible versions
-  rather than a single pinned version).
-- Unknown field detection and warning mechanisms.
-- Automated compatibility checks between CRDs and the controller
-  version.
-
-This future work is out of scope for this enhancement.
+The `ExternalCRDs` mode is particularly susceptible. This
+enhancement provides the management mode infrastructure that future
+work (version ranges, unknown field detection, compatibility
+checks) can build on. See Non-Goals for scope.
 
 ### Risks and Mitigations
 
 #### Risk: Unsupported ExternalCRDs Mode Misuse
 
-**Description**: Customers may use the `ExternalCRDs` mode in production
-and then file support tickets when things break due to CRD
-incompatibility.
+Customers may use `ExternalCRDs` in production and file support
+tickets when CRD incompatibility causes issues.
 
-**Mitigation**: The `ExternalCRDs` mode will be clearly documented as
-unsupported. CIO will set a persistent unsupported warning condition
-on the `ingress.config.openshift.io/cluster` status. The condition
-message will include
-explicit language that this configuration is not supported.
-Additionally, telemetry can capture the management mode to help
-support engineers quickly identify clusters using unsupported
-configurations.
+**Mitigation**: CIO sets a persistent unsupported warning condition
+in status. Telemetry captures the management mode for support
+triage.
 
 #### Risk: Orphaned Resources During Mode Transition
 
-**Description**: Switching from `Managed` to `Unmanaged` leaves
-GatewayClass, Gateway, and HTTPRoute resources on the cluster
-without a managing controller, which may confuse administrators.
+Switching to `Unmanaged` leaves GatewayClass, Gateway, and
+HTTPRoute resources without a managing controller.
 
-**Mitigation**: CIO intentionally does NOT remove Gateway API CRDs,
-GatewayClass, or Gateway resources when transitioning to `Unmanaged`
-mode to avoid disrupting existing workloads. The CIO-managed Istio
-instance is shut down, but all Gateway API resources are preserved.
-The cluster administrator is responsible for cleaning up these
-resources if desired. Documentation must clearly state that
-resources are preserved during mode transitions and that the
-administrator must handle cleanup.
+**Mitigation**: CIO preserves all Gateway API resources during
+transitions to avoid disruption. The administrator is responsible
+for cleanup. Documentation must state this clearly.
 
 #### Risk: Incompatible Mode Transition
 
-**Description**: Switching from `Unmanaged` or `ExternalCRDs` to `Managed`
-may fail if the existing CRDs do not match the expected version.
+Switching to `Managed` may fail if existing CRDs do not match the
+expected version.
 
-**Mitigation**: CIO will verify CRD compliance before taking
-ownership. If CRDs are incompatible, CIO will set
-`CRDsCompliant=False` (in `status.gatewayAPI.conditions`) and will
-NOT overwrite the CRDs.
-The administrator must resolve the mismatch (by upgrading or
-removing the CRDs) before the transition can complete. This
-prevents accidental data loss or breaking existing configurations.
+**Mitigation**: CIO verifies CRD compliance before taking
+ownership. If incompatible, CIO sets `CRDsCompliant=False` and
+does not overwrite. The administrator must resolve the mismatch.
 
 #### Risk: Security Implications of Removing VAP
 
-**Description**: In `Unmanaged` and `ExternalCRDs` modes, the VAP is
-removed, allowing any actor with sufficient RBAC to modify the
-Gateway API CRDs.
+In non-`Managed` modes, the VAP is removed, allowing any actor
+with CRD RBAC to modify Gateway API CRDs.
 
-**Mitigation**: This is an explicit trade-off of these modes.
-Documentation must clearly state that the VAP protection is
-removed in non-Managed modes. Customers who choose these modes
-are accepting responsibility for CRD integrity. Standard
-Kubernetes RBAC still applies to CRD modifications.
+**Mitigation**: Explicit trade-off. Standard Kubernetes RBAC still
+applies. Documentation must state that VAP protection is removed.
 
 ### Drawbacks
 
-The primary drawback is increased complexity in CIO. The operator
-must now handle three distinct behavioral modes, each with its own
-set of controllers to enable/disable and status conditions to
-compute. This increases the testing surface and the potential for
-edge-case bugs during mode transitions.
+Increased CIO complexity: three behavioral modes with different
+controller enable/disable states and mode transition logic. This is
+justified by customer demand -- the alternative is customers
+fighting the VAP and CRD reconciler.
 
-However, this complexity is justified by the clear customer demand
-for CRD ownership flexibility and the fact that the alternative --
-customers fighting the VAP and CRD reconciler -- is worse for both
-customers and support.
-
-Another drawback is the `ExternalCRDs` mode, which introduces an explicitly
-unsupported configuration. While this creates a risk of support
-confusion, the alternative of not providing this mode would push
-advanced users toward even more unsupported workarounds (e.g.,
-disabling the VAP manually and using `unsupportedConfigOverrides`).
+The `ExternalCRDs` mode introduces an explicitly unsupported
+configuration, but without it, advanced users would resort to worse
+workarounds (disabling the VAP manually, using
+`unsupportedConfigOverrides`).
 
 ## Open Questions
 
-1. ~~**Field placement**: Resolved. The field lives on
-   `ingress.config.openshift.io/cluster` (not on IngressController)
-   because Gateway API CRDs are cluster-scoped and the management
-   mode is a platform-wide decision that must not conflict across
-   multiple IngressControllers.~~
+1. ~~**Field placement**: Resolved. New Ingress singleton in
+   `operator.openshift.io/v1`, following the DNS/Console pattern.~~
 
-2. **ExternalCRDs mode scope**: Should the `ExternalCRDs` mode
-   perform any compatibility pre-checks before starting the
-   CIO-managed Istio instance, or should it always attempt to start
-   and report incompatibility via status conditions after the fact?
+2. **ExternalCRDs mode scope**: Should `ExternalCRDs` mode perform
+   compatibility pre-checks before starting the Gateway controller,
+   or always start and report incompatibility via status conditions?
 
 3. **CRD cleanup on Unmanaged transition**: Should CIO offer an
-   option to remove the CRDs when transitioning to `Unmanaged`?
-   This is dangerous (it would delete all Gateway/HTTPRoute
-   resources) but some customers may want a clean slate. The
-   current proposal preserves CRDs during transitions.
+   option to remove CRDs when transitioning to `Unmanaged`? This
+   would delete all Gateway/HTTPRoute resources. The current
+   proposal preserves CRDs during transitions.
 
-4. **Interaction with `unsupportedConfigOverrides`**: The existing
-   CRD lifecycle management enhancement mentions
-   `unsupportedConfigOverrides` as a mechanism for bypassing CRD
-   succession checks. Should the new `crdManagementMode` field
-   replace this mechanism, or should they coexist?
+4. **Interaction with `unsupportedConfigOverrides`**: The CRD
+   lifecycle management enhancement uses an "unsupported config
+   override" mechanism to bypass CRD succession checks. Should
+   `crdManagementMode` replace this mechanism or coexist with it?
 
-5. **Telemetry**: What telemetry should be collected for the
-   management mode? At minimum, the configured mode should be
-   reported. Should CIO also report metrics for CRD compliance
-   state and mode transition events?
+5. **Telemetry**: What telemetry should be collected? At minimum
+   the configured mode. Should CIO also report metrics for CRD
+   compliance and mode transitions?
+
+6. **Singleton creation**: Should the `cluster` singleton instance
+   be created by CVO (via a manifest in the release payload) or
+   by CIO on first startup? This affects upgrade behavior and
+   needs alignment with the operator pattern used by DNS/Console.
+
+7. **Kind name collision**: The proposed Kind `Ingress` in
+   `operator.openshift.io/v1` shares a name with the well-known
+   `networking.k8s.io/v1` Ingress. While API groups disambiguate,
+   this may cause user confusion with `oc get ingress`. The short
+   name and resource disambiguation strategy should be decided
+   during API review.
 
 ## Test Plan
 
@@ -946,35 +800,37 @@ dev-guide/feature-zero-to-hero.md:
 
 ### Backport to OCP 4.19
 
-There is a desire to backport this feature all the way back to
-OpenShift OCP 4.19. The motivation is to allow customers who are
-already running 4.19 with third-party Gateway API controllers (or
-who need to opt out of CIO's CRD management) to do so cleanly,
-and to ensure that customers upgrading from 4.19 through later
-releases have a consistent, supported upgrade path with the CRD
-management mode available at every step.
+The official backport target is OCP 4.19. Without this backport,
+customers on 4.19 with third-party Gateway API CRDs face CRD
+succession conflicts when upgrading, because CIO enforces
+ownership with no opt-out. Backporting lets customers set
+`Unmanaged` before upgrading.
 
-Without the backport, customers on 4.19 who have installed
-third-party Gateway API CRDs would face CRD succession conflicts
-during upgrade to a version that includes this knob, because the
-older 4.19 CIO would still enforce CRD ownership with no opt-out
-mechanism. Backporting gives customers the ability to set
-`Unmanaged` or `ExternalCRDs` mode on 4.19 before upgrading,
-ensuring a smooth transition.
+> **Note**: There is also a desire to backport to OCP 4.18, as the
+> lack of this feature is currently blocking 4.18 upgrades for
+> customers with third-party CRDs. This requires the same SBAR
+> exception process and is subject to architect approval.
 
-The backport scope includes:
-- The `gatewayAPI` spec and status structs on
-  `ingress.config.openshift.io`.
-- The `crdManagementMode` enum with all three values.
-- The `status.gatewayAPI.conditions` reporting.
-- The feature gate `GatewayAPICRDManagementMode` (behind
-  `TechPreviewNoUpgrade` on 4.19).
+**SBAR exception process**: Backporting a new CRD to a released
+version requires SBAR (Situation, Background, Assessment,
+Recommendation) with architect approval. The SBAR must justify
+the backport (customer upgrade path continuity) and demonstrate
+bounded risk.
 
-The backport does NOT require changes to the CRD succession logic
-already present in 4.19 (from
-[gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md)).
-Instead, it adds the opt-out mechanism on top of the existing
-behavior.
+Backport scope:
+- Ingress CRD manifest for `operator.openshift.io/v1` (CVO).
+- `gatewayAPI` spec/status structs with all three enum values.
+- `status.gatewayAPI.conditions` reporting.
+- Feature gate `GatewayAPICRDManagementMode` (behind
+  `TechPreviewNoUpgrade`).
+- CIO controller changes.
+
+**E2E requirements**: 95%+ pass rate, 7 runs/week on supported
+platforms.
+
+The backport does not change CRD succession logic from
+[gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md).
+It adds the opt-out mechanism on top of existing behavior.
 
 ### Removing a deprecated feature
 
@@ -984,17 +840,16 @@ Not applicable. This enhancement adds new functionality.
 
 ### Upgrade
 
-When upgrading from a version that does not have the
-`gatewayAPI.crdManagementMode` field to one that does (e.g.,
+When upgrading from a version that does not have the Ingress
+(`operator.openshift.io/v1`) resource to one that does (e.g.,
 upgrading from 4.18 to 4.19 with the backport applied):
 
-- The field defaults to `Managed`, which preserves the existing
-  behavior. No action is required from the cluster administrator.
+- CVO installs the new Ingress CRD. The `cluster` singleton is
+  created with `spec.gatewayAPI.crdManagementMode` defaulting to
+  `Managed`, preserving existing behavior. No action is required
+  from the cluster administrator.
 - Existing clusters with CIO-managed CRDs continue to work
   identically.
-- The new status conditions are added to the
-  `ingress.config.openshift.io/cluster` status on the first
-  reconciliation after upgrade.
 
 When upgrading a cluster that has a non-default mode set (e.g.,
 upgrading from 4.19 to 4.20+ with mode already configured):
@@ -1009,89 +864,64 @@ upgrading from 4.19 to 4.20+ with mode already configured):
 
 ### Downgrade
 
-When downgrading from a version that has the
-`gatewayAPI.crdManagementMode` field to one that does not:
+When downgrading from a version that has the Ingress
+(`operator.openshift.io/v1`) resource to one that does not:
 
-- The older CIO version does not recognize the `gatewayAPI` field
-  and ignores it (standard Kubernetes API behavior for unknown
-  fields -- the field is simply pruned on the next write).
-- The older CIO version will behave as if the mode is `Managed`
-  (its only behavior), which means it will attempt to install and
-  manage CRDs.
+- The Ingress CRD and `cluster` singleton persist on the cluster
+  (CRDs are not removed during rollbacks), but the older CIO does
+  not watch this resource. It has no effect.
+- The older CIO behaves as `Managed` (its only behavior) and
+  attempts to install and manage Gateway API CRDs.
 - **If the cluster was in `Unmanaged` mode**: The downgraded CIO
   will attempt to install CRDs and deploy the Gateway controller
   stack. If third-party CRDs are present, the existing CRD
   management succession logic (from
   [gateway-api-crd-life-cycle-management](gateway-api-crd-life-cycle-management.md))
   applies.
-- **If the cluster was in `ExternalCRDs` mode**: The downgraded CIO will
-  attempt to take ownership of the CRDs. If they do not match the
-  expected version, the operator reports `Degraded`.
+- **If the cluster was in `ExternalCRDs` mode**: The downgraded CIO
+  will attempt to take ownership of the CRDs. If they do not match
+  the expected version, the operator reports `Degraded`.
 
-**Recommendation**: Before downgrading, the administrator should
-set the mode to `Managed` and ensure CRDs are compatible with the
-target version. Documentation must include this as a required
-pre-downgrade step.
+**Recommendation**: Set mode to `Managed` and ensure CRD
+compatibility before downgrading.
 
 ## Version Skew Strategy
 
-During an upgrade, there may be a brief period where the new CIO
-binary is running but the `ingress.config.openshift.io` CRD has
-not yet been updated to include the `gatewayAPI` field. During this period, CIO
-will treat the absence of the field as `Managed` mode (the default),
-which is the existing behavior. No version skew issues are expected.
-
-The `gatewayAPI` field is consumed only by CIO and does not require
-coordination with any other component on the node or in the control
-plane.
+During upgrade, CIO may start before CVO creates the Ingress CRD.
+CIO treats the absence as `Managed` mode (existing behavior). The
+field is consumed only by CIO and requires no cross-component
+coordination.
 
 ## Operational Aspects of API Extensions
 
-This enhancement adds new fields to the existing
-`ingress.config.openshift.io` CRD and new status conditions. The
-operational impact is minimal:
+Operational impact is minimal -- one additional cluster-scoped
+resource read during CIO reconciliation.
 
-- **API throughput**: No measurable impact. The new field is read
-  by CIO during reconciliation, which already reads the full
-  `Ingress` spec. The additional status conditions add a
-  small amount of data to status updates.
-
-- **SLIs**: The new status conditions themselves serve as SLIs for
-  Gateway API CRD management health. Administrators and monitoring
-  systems can watch for:
-  - `status.gatewayAPI.conditions` `CRDsManaged=False` with
-    unexpected reasons
-  - `status.gatewayAPI.conditions` `CRDsCompliant=False` indicating
-    CRD drift
-  - `status.gatewayAPI.conditions` `CRDsPresent=False` in modes
-    that expect CRDs
+- **SLIs**: `status.gatewayAPI.conditions` (`CRDsManaged`,
+  `CRDsPresent`, `CRDsCompliant`).
 
 - **Failure modes**:
-  - If CIO fails to remove the VAP during a mode transition, CRDs
-    remain protected and the administrator cannot modify them. CIO
-    should retry VAP removal and report the failure in status.
-  - If CIO fails to deploy the Gateway controller stack in
-    `ExternalCRDs` mode because CRDs are absent, CIO should report the
-    failure and retry when CRDs become available.
+  - VAP removal failure during mode transition: CRDs remain locked.
+    CIO retries and reports in status.
+  - `ExternalCRDs` mode with absent CRDs: Gateway controller cannot
+    start. CIO reports and retries when CRDs appear.
 
-- **Escalation**: Issues with CRD management mode should be
-  escalated to the Networking / Ingress team (NID). For issues
-  involving Istio CRD interactions, the OSSM team should be
-  consulted.
+- **Escalation**: Networking / Ingress team. For Istio CRD
+  interactions, consult the OSSM team.
 
 ## Support Procedures
 
 ### Detecting the Current Mode
 
 ```bash
-oc get ingress.config.openshift.io cluster \
+oc get ingress.operator.openshift.io cluster \
   -o jsonpath='{.spec.gatewayAPI.crdManagementMode}'
 ```
 
 ### Checking CRD Management Status
 
 ```bash
-oc get ingress.config.openshift.io cluster \
+oc get ingress.operator.openshift.io cluster \
   -o jsonpath='{.status.gatewayAPI.conditions}' | \
   jq '.[]'
 ```
@@ -1114,7 +944,7 @@ the expected version shown in the condition message.
 
 ```bash
 # Check expected version from condition message
-oc get ingress.config.openshift.io cluster \
+oc get ingress.operator.openshift.io cluster \
   -o jsonpath='{.status.gatewayAPI.conditions}' | \
   jq '.[] | select(.type=="CRDsCompliant")'
 
@@ -1128,56 +958,47 @@ oc delete crd \
   grpcroutes.gateway.networking.k8s.io
 ```
 
-**Symptom**: Gateway controller stack not starting in `ExternalCRDs` mode.
+**Symptom**: Gateway controller not starting in `ExternalCRDs` mode.
 
-**Diagnosis**: Gateway API CRDs are absent. The controller cannot
-create GatewayClass/Gateway resources without the CRDs.
+**Resolution**: Install Gateway API CRDs. CIO starts the
+controller when CRDs appear.
 
-**Resolution**: Install Gateway API CRDs. CIO will detect their
-presence and start the controller stack.
+**Symptom**: `CRDsManaged=False` with reason `ExternalCRDs`.
 
-**Symptom**: `CRDsManaged=False` with reason `ExternalCRDs` and an
-unsupported warning in `status.gatewayAPI.conditions`.
-
-**Diagnosis**: This is expected behavior for `ExternalCRDs` mode. Verify
-with the customer that they intentionally chose this mode. If this
-is a production cluster, recommend switching to `Managed` mode.
+**Resolution**: Expected behavior for `ExternalCRDs` mode. Verify
+the customer intentionally chose this mode. For production
+clusters, recommend switching to `Managed`.
 
 ## Alternatives (Not Implemented)
 
 ### Alternative 1: Boolean Gateway API Disable Switch
 
-A simpler approach would be a boolean field to enable/disable
-Gateway API entirely. However, this does not address the use case
-where customers want to bring their own CRDs while using the
-OpenShift Gateway controller. Additionally, OpenShift API
-conventions prohibit boolean fields in CRDs.
+Does not address the `ExternalCRDs` use case (CRDs external, controller
+active). Also prohibited by OpenShift API conventions (no boolean
+fields in CRDs).
 
-### Alternative 2: Annotation-Based Configuration
+### Alternative 2: Modify `ingress.config.openshift.io/cluster`
 
-Using annotations on the `ingress.config.openshift.io/cluster`
-resource to control CRD management
-mode would avoid an API change but would lack validation,
-defaulting, and discoverability. Annotations are also not visible
-in `oc describe` output as structured fields and cannot have
-kubebuilder validation applied.
+That resource is owned by `config-operator` for install-time
+configuration (base domain, HSTS policies, component routes).
+Gateway API operational behavior belongs in `operator.openshift.io`.
 
-### Alternative 3: Separate CRD for Gateway API Configuration
+### Alternative 3: Annotation-Based Configuration
 
-Creating a new `GatewayAPIConfig` CRD would provide a clean
-separation of concerns but adds operational complexity (a new
-resource to manage, new RBAC rules, a new controller to reconcile).
-Given that CRD management mode is a platform-wide ingress concern,
-placing it on the `ingress.config.openshift.io/cluster` spec is
-more natural and discoverable.
+Lacks validation, defaulting, and discoverability. Not visible in
+`oc describe` as structured fields.
 
-### Alternative 4: Per-CRD Management Granularity
+### Alternative 4: Separate `GatewayAPIConfig` CRD
 
-Instead of a single mode for all Gateway API CRDs, each CRD could
-have its own management mode (e.g., manage GatewayClass CRD but not
-HTTPRoute CRD). This would provide maximum flexibility but adds
-significant complexity for minimal benefit. In practice, CRDs are
-either managed as a cohesive set or not managed at all.
+Adds unnecessary complexity. CRD management is an ingress concern,
+so the Ingress resource in `operator.openshift.io/v1` is a more
+natural home.
+
+### Alternative 5: Per-CRD Management Granularity
+
+Per-CRD modes (e.g., manage GatewayClass CRD but not HTTPRoute)
+add significant complexity for minimal benefit. In practice, CRDs
+are managed as a cohesive set or not at all.
 
 ## Infrastructure Needed
 

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -172,10 +172,10 @@ IngressController resources and manages Gateway API components.
 3. CIO deploys Gateway API CRDs, VAPs, the CIO-managed Istio
    instance, GatewayClass, and Gateway resources as per the existing
    behavior.
-4. CIO sets `status.gatewayAPI.conditions`:
-   - `CRDsManaged=True` (reason: `ManagedByCIO`)
-   - `CRDsPresent=True`
-   - `CRDsCompliant=True`
+4. CIO sets the following conditions in `status.conditions`:
+   - `GatewayAPICRDsManaged=True` (reason: `ManagedByCIO`)
+   - `GatewayAPICRDsPresent=True`
+   - `GatewayAPICRDsCompliant=True`
 5. External consumers observe the conditions and proceed normally.
 
 #### Workflow 2: Switching to Unmanaged Mode
@@ -200,17 +200,18 @@ IngressController resources and manages Gateway API components.
       Gateway API CRDs. Removing these resources could cause
       disruptions to existing workloads. The cluster administrator
       is responsible for cleaning up these resources if desired.
-4. CIO sets `status.gatewayAPI.conditions`:
-   - `CRDsManaged=False` (reason: `Unmanaged`)
-   - `CRDsPresent=True/False` (observational)
-   - `CRDsCompliant=Unknown` (not applicable in this mode)
+4. CIO sets the following conditions in `status.conditions`:
+   - `GatewayAPICRDsManaged=False` (reason: `Unmanaged`)
+   - `GatewayAPICRDsPresent=True/False` (observational)
+   - `GatewayAPICRDsCompliant=Unknown` (not applicable in this mode)
 5. The cluster administrator installs their third-party Gateway
    controller and optionally their own CRD version.
-6. Layered products observe the `CRDsManaged=False` condition with
-   reason `Unmanaged` and treat this as a signal that the installed
-   CRDs may not be the ones supported by the OpenShift Gateway API
-   implementation. They should adjust their behavior accordingly
-   (e.g., not relying on specific CRD versions or fields).
+6. Layered products observe the `GatewayAPICRDsManaged=False`
+   condition with reason `Unmanaged` and treat this as a signal
+   that the installed CRDs may not be the ones supported by the
+   OpenShift Gateway API implementation. They should adjust their
+   behavior accordingly (e.g., not relying on specific CRD
+   versions or fields).
 
 #### Workflow 3: Returning to Managed Mode
 
@@ -234,7 +235,7 @@ IngressController resources and manages Gateway API components.
    b. If CRDs are present and match the expected version, CIO takes
       ownership (adds labels, deploys VAP).
    c. If CRDs are present but do not match the expected version, CIO
-      sets `CRDsCompliant=False` (in `status.gatewayAPI.conditions`)
+      sets `GatewayAPICRDsCompliant=False` (in `status.conditions`)
       and does NOT overwrite them. The administrator must resolve
       the mismatch.
 5. CIO deploys the full Gateway controller stack if not already
@@ -254,12 +255,12 @@ sequenceDiagram
     alt Managed (default)
         CIO->>CRDs: Install/upgrade CRDs + VAP
         CIO->>GW: Deploy CIO Istio, GatewayClass, Gateway
-        CIO->>IC: Set status: Managed=True,<br/>Present=True, Compliant=True
+        CIO->>IC: Set status.conditions: GatewayAPICRDsManaged=True,<br/>GatewayAPICRDsPresent=True, GatewayAPICRDsCompliant=True
     else Unmanaged
         CIO->>GW: Stop CIO Istio instance
         CIO->>CRDs: Remove VAP, stop managing
         Note over GW: GatewayClass/Gateway left for<br/>admin cleanup to avoid disruption
-        CIO->>IC: Set status: Managed=False (Unmanaged),<br/>Present=observed
+        CIO->>IC: Set status.conditions: GatewayAPICRDsManaged=False (Unmanaged),<br/>GatewayAPICRDsPresent=observed
     end
 ```
 
@@ -332,19 +333,42 @@ type IngressSpec struct {
 
 type IngressStatus struct {
 	// Inline OperatorStatus for standard operator status fields
-	// (conditions, version, observedGeneration, etc.)
-	OperatorStatus `json:",inline"`
-
-	// gatewayAPI holds status information for Gateway API
-	// integration, including conditions related to CRD
-	// management and the Gateway controller stack.
+	// (conditions, version, observedGeneration, etc.).
+	// conditions holds a list of conditions representing the
+	// operator's current state. Gateway API CRD management
+	// conditions are reported here with the "GatewayAPI" prefix:
 	//
-	// +optional
-	GatewayAPI GatewayAPIIngressStatus `json:"gatewayAPI,omitempty"`
+	// "GatewayAPICRDsManaged" indicates whether CIO is actively
+	// managing Gateway API CRDs:
+	//   - status: True, reason: "ManagedByCIO" — CIO is
+	//     installing, protecting (via VAP), and upgrading CRDs.
+	//   - status: False, reason: "Unmanaged" — the administrator
+	//     chose Unmanaged mode; CIO does not manage CRDs or the
+	//     Gateway controller stack.
+	//
+	// "GatewayAPICRDsPresent" indicates whether Gateway API CRDs
+	// exist on the cluster:
+	//   - status: True, reason: "CRDsFound" — Gateway API CRDs
+	//     are present on the cluster.
+	//   - status: False, reason: "CRDsNotFound" — Gateway API
+	//     CRDs are not present on the cluster.
+	//
+	// "GatewayAPICRDsCompliant" indicates whether the installed
+	// CRDs match the version expected by this CIO release:
+	//   - status: True, reason: "VersionMatch" — installed CRDs
+	//     match the expected version.
+	//   - status: False, reason: "VersionMismatch" — installed
+	//     CRDs do not match the expected version. The message
+	//     includes expected and actual versions and a pointer
+	//     to where valid manifests can be obtained.
+	//   - status: Unknown, reason: "NotApplicable" — compliance
+	//     check is not applicable (e.g., Unmanaged mode with no
+	//     CRDs present).
+	OperatorStatus `json:",inline"`
 }
 ```
 
-The `GatewayAPIIngressConfig` and `GatewayAPIIngressStatus` types:
+The `GatewayAPIIngressConfig` type:
 
 ```go
 // GatewayAPIManagementMode describes how the Cluster Ingress
@@ -402,69 +426,27 @@ type GatewayAPIIngressConfig struct {
 	ManagementMode GatewayAPIManagementMode `json:"managementMode"`
 }
 
-// GatewayAPIIngressStatus holds status information for Gateway
-// API integration managed by the Cluster Ingress Operator.
-type GatewayAPIIngressStatus struct {
-	// conditions is a list of conditions related to Gateway API
-	// CRD management and the Gateway controller stack. These
-	// conditions are scoped to Gateway API concerns and are
-	// separate from the Ingress resource's top-level conditions.
-	//
-	// Supported condition types are:
-	//
-	// "CRDsManaged" indicates whether CIO is actively managing
-	// Gateway API CRDs:
-	//   - status: True, reason: "ManagedByCIO" — CIO is
-	//     installing, protecting (via VAP), and upgrading CRDs.
-	//   - status: False, reason: "Unmanaged" — the administrator
-	//     chose Unmanaged mode; CIO does not manage CRDs or the
-	//     Gateway controller stack.
-	//
-	// "CRDsPresent" indicates whether Gateway API CRDs exist on
-	// the cluster:
-	//   - status: True, reason: "CRDsFound" — Gateway API CRDs
-	//     are present on the cluster.
-	//   - status: False, reason: "CRDsNotFound" — Gateway API
-	//     CRDs are not present on the cluster.
-	//
-	// "CRDsCompliant" indicates whether the installed CRDs match
-	// the version expected by this CIO release:
-	//   - status: True, reason: "VersionMatch" — installed CRDs
-	//     match the expected version.
-	//   - status: False, reason: "VersionMismatch" — installed
-	//     CRDs do not match the expected version. The message
-	//     includes expected and actual versions and a pointer
-	//     to where valid manifests can be obtained.
-	//   - status: Unknown, reason: "NotApplicable" — compliance
-	//     check is not applicable (e.g., Unmanaged mode with no
-	//     CRDs present).
-	//
-	// +listType=map
-	// +listMapKey=type
-	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
-}
 ```
 
 The field paths are:
 
 ```
 spec.gatewayAPI.managementMode
-status.gatewayAPI.conditions
+status.conditions
 ```
 
-The following conditions are set within
-`status.gatewayAPI.conditions`:
+The following Gateway API conditions are set within
+`status.conditions` (inherited from `OperatorStatus`):
 
 | Condition Type | Status | Reason | Description |
 |---|---|---|---|
-| `CRDsManaged` | `True` | `ManagedByCIO` | CIO is actively managing CRDs |
-| `CRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
-| `CRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
-| `CRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
-| `CRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
-| `CRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
-| `CRDsCompliant` | `Unknown` | `NotApplicable` | Compliance check is not applicable (e.g., Unmanaged mode with no CRDs present) |
+| `GatewayAPICRDsManaged` | `True` | `ManagedByCIO` | CIO is actively managing CRDs |
+| `GatewayAPICRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
+| `GatewayAPICRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
+| `GatewayAPICRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
+| `GatewayAPICRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
+| `GatewayAPICRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
+| `GatewayAPICRDsCompliant` | `Unknown` | `NotApplicable` | Compliance check is not applicable (e.g., Unmanaged mode with no CRDs present) |
 
 **API versioning note:** As a net-new API, this resource is
 introduced at `v1alpha1` (`operator.openshift.io/v1alpha1`). It
@@ -559,7 +541,7 @@ A Gateway API CRD is considered **compliant** when:
    checksum embedded in the CIO binary.
 
 When CRDs are non-compliant, CIO reports the mismatch in the
-`CRDsCompliant` condition message, including expected vs. actual
+`GatewayAPICRDsCompliant` condition message, including expected vs. actual
 versions and where to obtain valid manifests. Valid CRD manifests
 are available from:
 - The `gateway-api` container image in the OpenShift release
@@ -629,7 +611,7 @@ Switching to `Managed` may fail if existing CRDs do not match the
 expected version.
 
 **Mitigation**: CIO verifies CRD compliance before taking
-ownership. If incompatible, CIO sets `CRDsCompliant=False` and
+ownership. If incompatible, CIO sets `GatewayAPICRDsCompliant=False` and
 does not overwrite. The administrator must resolve the mismatch.
 
 #### Risk: Security Implications of Removing VAP
@@ -786,7 +768,7 @@ bounded risk.
 Backport scope:
 - Ingress CRD manifest for `operator.openshift.io/v1alpha1` (CVO).
 - `gatewayAPI` spec/status structs with both enum values.
-- `status.gatewayAPI.conditions` reporting.
+- `status.conditions` Gateway API condition reporting.
 - Feature gate `GatewayAPIManagementMode` (behind
   `TechPreviewNoUpgrade`).
 - CIO controller changes.
@@ -856,8 +838,8 @@ coordination.
 Operational impact is minimal -- one additional cluster-scoped
 resource read during CIO reconciliation.
 
-- **SLIs**: `status.gatewayAPI.conditions` (`CRDsManaged`,
-  `CRDsPresent`, `CRDsCompliant`).
+- **SLIs**: `status.conditions` (`GatewayAPICRDsManaged`,
+  `GatewayAPICRDsPresent`, `GatewayAPICRDsCompliant`).
 
 - **Failure modes**:
   - VAP removal failure during mode transition: CRDs remain locked.
@@ -879,13 +861,13 @@ oc get ingress.operator.openshift.io cluster \
 
 ```bash
 oc get ingress.operator.openshift.io cluster \
-  -o jsonpath='{.status.gatewayAPI.conditions}' | \
-  jq '.[]'
+  -o jsonpath='{.status.conditions}' | \
+  jq '.[] | select(.type | startswith("GatewayAPI"))'
 ```
 
 ### Common Issues
 
-**Symptom**: `CRDsCompliant=False` in `status.gatewayAPI.conditions`
+**Symptom**: `GatewayAPICRDsCompliant=False` in `status.conditions`
 after switching to `Managed` mode.
 
 **Diagnosis**: The existing CRDs do not match the expected version.
@@ -902,8 +884,8 @@ the expected version shown in the condition message.
 ```bash
 # Check expected version from condition message
 oc get ingress.operator.openshift.io cluster \
-  -o jsonpath='{.status.gatewayAPI.conditions}' | \
-  jq '.[] | select(.type=="CRDsCompliant")'
+  -o jsonpath='{.status.conditions}' | \
+  jq '.[] | select(.type=="GatewayAPICRDsCompliant")'
 
 # Remove CRDs to let CIO reinstall (WARNING: this deletes
 # all Gateway, HTTPRoute, and other Gateway API resources)

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -3,18 +3,19 @@ title: gateway-api-crd-management-mode
 authors:
   - "@rikatz"
 reviewers:
-  - "@Miciah" 
-  - "@gcs278" 
-  - "@knobunc" 
+  - "@Miciah"
+  - "@gcs278"
+  - "@knobunc"
+  - "@everettraven"
 approvers:
-  - TBD
+  - "@knobunc"
 api-approvers:
-  - TBD
+  - "@everettraven"
 creation-date: 2026-05-26
-last-updated: 2026-05-26
+last-updated: 2026-05-27
 status: provisional
 tracking-link:
-  - TBD
+  - https://redhat.atlassian.net/browse/NE-2733
 see-also:
   - "/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md"
   - "/enhancements/ingress/gateway-api-crd-life-cycle-management.md"

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -616,6 +616,29 @@ enhancement provides the management mode infrastructure that future
 work (version ranges, unknown field detection, compatibility
 checks) can build on. See Non-Goals for scope.
 
+#### Future Work on the Ingress Resource
+
+The new Ingress (`operator.openshift.io/v1`) resource is designed
+to accommodate future configuration beyond `crdManagementMode`:
+
+1. **GatewayClass customization**: The `gatewayAPI` struct can be
+   extended to allow administrators to define additional OpenShift
+   GatewayClasses in a structured way -- specifying service type,
+   resource allocation for Envoy proxies, and other per-class
+   parameters. This would replace the current model where only a
+   single default GatewayClass is created by CIO.
+
+2. **Operator and operand logging levels**: The Ingress resource
+   embeds `OperatorSpec`, which includes `logLevel` (for operands)
+   and `operatorLogLevel` (for the operator) fields. These can be
+   used to implement the logging level controls originally proposed
+   in
+   [ingress-operator-operand-logging-level](ingress-operator-operand-logging-level.md),
+   providing a supported API for adjusting CIO and Gateway
+   controller verbosity.
+
+These are out of scope for this enhancement.
+
 ### Risks and Mitigations
 
 #### Risk: Unsupported ExternalCRDs Mode Misuse

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -11,7 +11,7 @@ approvers:
 api-approvers:
   - "@everettraven"
 creation-date: 2026-05-26
-last-updated: 2026-06-12
+last-updated: 2026-06-18
 status: implementable
 tracking-link:
   - https://redhat.atlassian.net/browse/NE-2733
@@ -34,7 +34,7 @@ field that controls how the Cluster Ingress Operator (CIO)
 manages Gateway API CRDs and the associated Gateway controller
 stack (CIO-managed Istio, GatewayClass, Gateway). Two modes
 are provided: `Managed` (default -- CIO owns everything) and
-`Unmanaged` (CIO does nothing, external entity takes over).
+`Unmanaged` (CIO stops managing, reports observational status only).
 
 The field lives on a new resource rather than on
 `IngressController` (where multiple instances could conflict) or
@@ -135,8 +135,7 @@ Introduce a new cluster-scoped singleton API resource in the
   `OperatorSpec`/`OperatorStatus` inline.
 
 The spec contains a `gatewayAPI` struct with a
-`managementMode` enum. The struct is extensible for future
-Gateway API configuration fields.
+`managementMode` enum.
 
 CIO watches this resource and reads
 `spec.gatewayAPI.managementMode` to determine its behavior:
@@ -172,7 +171,7 @@ IngressController resources and manages Gateway API components.
    instance, GatewayClass, and Gateway resources as per the existing
    behavior.
 4. CIO sets the following conditions in `status.conditions`:
-   - `GatewayAPICRDsManaged=True` (reason: `ManagedByCIO`)
+   - `GatewayAPICRDsManaged=True` (reason: `ManagedByIngressOperator`)
    - `GatewayAPICRDsPresent=True`
    - `GatewayAPICRDsCompliant=True`
 5. External consumers observe the conditions and proceed normally.
@@ -202,7 +201,9 @@ IngressController resources and manages Gateway API components.
 4. CIO sets the following conditions in `status.conditions`:
    - `GatewayAPICRDsManaged=False` (reason: `Unmanaged`)
    - `GatewayAPICRDsPresent=True/False` (observational)
-   - `GatewayAPICRDsCompliant=Unknown` (not applicable in this mode)
+   - `GatewayAPICRDsCompliant=True/False/Unknown` (whether the
+     installed CRDs match the version expected by the ingress
+     operator; `Unknown` if no Gateway API CRDs are present)
 5. The cluster administrator installs their third-party Gateway
    controller and optionally their own CRD version.
 6. Layered products observe the `GatewayAPICRDsManaged=False`
@@ -216,8 +217,8 @@ IngressController resources and manages Gateway API components.
 
 1. The cluster administrator wants to return to the fully managed
    configuration.
-2. The cluster administrator ensures the existing Gateway API CRDs
-   match the version CIO expects, or removes them entirely.
+2. The cluster administrator should ensure the existing Gateway API
+   CRDs match the version CIO expects, or remove them entirely.
 3. The cluster administrator edits the Ingress
    (`operator.openshift.io/v1alpha1`) `cluster` resource:
    ```yaml
@@ -267,7 +268,7 @@ sequenceDiagram
         CIO->>GW: Stop CIO Istio instance
         CIO->>CRDs: Remove VAP, stop managing
         Note over GW: GatewayClass/Gateway left for<br/>admin cleanup to avoid disruption
-        CIO->>IC: Set status.conditions: GatewayAPICRDsManaged=False (Unmanaged),<br/>GatewayAPICRDsPresent=observed
+        CIO->>IC: Set status.conditions: GatewayAPICRDsManaged=False (Unmanaged),<br/>GatewayAPICRDsPresent=observed, GatewayAPICRDsCompliant=observed
     end
 ```
 
@@ -343,13 +344,14 @@ type IngressStatus struct {
 	// operator's current state. Gateway API CRD management
 	// conditions are reported here with the "GatewayAPI" prefix:
 	//
-	// "GatewayAPICRDsManaged" indicates whether CIO is actively
-	// managing Gateway API CRDs:
-	//   - status: True, reason: "ManagedByCIO" — CIO is
-	//     installing, protecting (via VAP), and upgrading CRDs.
+	// "GatewayAPICRDsManaged" indicates whether the ingress operator is
+	// actively managing Gateway API CRDs:
+	//   - status: True, reason: "ManagedByIngressOperator" — the
+	//     ingress operator is installing, protecting (via VAP), and
+	//     upgrading CRDs.
 	//   - status: False, reason: "Unmanaged" — the administrator
-	//     chose Unmanaged mode; CIO does not manage CRDs or the
-	//     Gateway controller stack.
+	//     chose Unmanaged mode; the ingress operator does not manage
+	//     CRDs or the Gateway controller stack.
 	//
 	// "GatewayAPICRDsPresent" indicates whether Gateway API CRDs
 	// exist on the cluster:
@@ -359,16 +361,16 @@ type IngressStatus struct {
 	//     CRDs are not present on the cluster.
 	//
 	// "GatewayAPICRDsCompliant" indicates whether the installed
-	// CRDs match the version expected by this CIO release:
+	// CRDs match the version expected by this ingress operator release:
 	//   - status: True, reason: "VersionMatch" — installed CRDs
 	//     match the expected version.
 	//   - status: False, reason: "VersionMismatch" — installed
 	//     CRDs do not match the expected version. The message
 	//     includes expected and actual versions and a pointer
 	//     to where valid manifests can be obtained.
-	//   - status: Unknown, reason: "NotApplicable" — compliance
-	//     check is not applicable (e.g., Unmanaged mode with no
-	//     CRDs present).
+	//   - status: Unknown, reason: "Unknown" — compliance
+	//     check is not applicable (e.g., no Gateway API CRDs
+	//     are present on the cluster).
 	OperatorStatus `json:",inline"`
 }
 ```
@@ -383,22 +385,22 @@ The `GatewayAPIIngressConfig` type:
 type GatewayAPIManagementMode string
 
 const (
-	// GatewayAPIManagementModeManaged means CIO installs, owns,
-	// protects (via VAP), and upgrades the Gateway API CRDs.
-	// CIO also deploys the full Gateway controller stack (the
-	// Istio instance deployed by CIO, GatewayClass, Gateway).
-	// This is the default mode and the only fully supported
-	// configuration.
+	// GatewayAPIManagementModeManaged means the ingress operator
+	// installs, owns, protects (via VAP), and upgrades the Gateway
+	// API CRDs. The ingress operator also deploys the full Gateway
+	// controller stack (the Istio instance deployed by the ingress
+	// operator, GatewayClass, Gateway). This is the default mode
+	// and the only fully supported configuration.
 	GatewayAPIManagementModeManaged GatewayAPIManagementMode = "Managed"
 
-	// GatewayAPIManagementModeUnmanaged means CIO does NOT
-	// install or manage Gateway API CRDs and does NOT deploy
-	// the Gateway controller stack. The customer or a
+	// GatewayAPIManagementModeUnmanaged means the ingress operator
+	// does NOT install or manage Gateway API CRDs and does NOT
+	// deploy the Gateway controller stack. The customer or a
 	// third-party product is responsible for bringing their own
-	// CRDs and Gateway controller. CIO reports observational
-	// status only. This mode signals to layered products that
-	// the installed CRDs may not be the ones supported by the
-	// OpenShift Gateway API implementation.
+	// CRDs and Gateway controller. The ingress operator reports
+	// observational status only. This mode signals to layered
+	// products that the installed CRDs may not be the ones
+	// supported by the OpenShift Gateway API implementation.
 	GatewayAPIManagementModeUnmanaged GatewayAPIManagementMode = "Unmanaged"
 )
 
@@ -409,28 +411,27 @@ type GatewayAPIIngressConfig struct {
 	// Operator manages Gateway API Custom Resource Definitions
 	// (CRDs) and the associated Gateway controller stack.
 	//
-	// When set to "Managed" (the default), CIO installs, owns,
-	// and upgrades the Gateway API CRDs, protects them with a
-	// Validating Admission Policy, and deploys the full Gateway
-	// controller stack (the Istio instance deployed by CIO,
-	// GatewayClass, Gateway resources). This is the only fully
-	// supported configuration.
+	// When set to "Managed" (the default), the ingress operator
+	// installs, owns, and upgrades the Gateway API CRDs, protects
+	// them with a Validating Admission Policy, and deploys the
+	// full Gateway controller stack (the Istio instance deployed
+	// by the ingress operator, GatewayClass, Gateway resources).
+	// This is the only fully supported configuration.
 	//
-	// When set to "Unmanaged", CIO does not install or manage
-	// Gateway API CRDs and does not deploy the Gateway controller
-	// stack. The cluster administrator or a third-party product
-	// is responsible for providing their own CRDs and Gateway
-	// controller. CIO reports observational status only. This
-	// mode also serves as a signal to layered products that the
-	// installed CRDs may not be the ones supported by the
-	// OpenShift Gateway API implementation.
+	// When set to "Unmanaged", the ingress operator does not
+	// install or manage Gateway API CRDs and does not deploy the
+	// Gateway controller stack. The cluster administrator or a
+	// third-party product is responsible for providing their own
+	// CRDs and Gateway controller. The ingress operator reports
+	// observational status only. This mode also serves as a signal
+	// to layered products that the installed CRDs may not be the
+	// ones supported by the OpenShift Gateway API implementation.
 	//
 	// +kubebuilder:default:="Managed"
 	// +default="Managed"
 	// +required
 	ManagementMode GatewayAPIManagementMode `json:"managementMode"`
 }
-
 ```
 
 The field paths are:
@@ -445,13 +446,13 @@ The following Gateway API conditions are set within
 
 | Condition Type | Status | Reason | Description |
 |---|---|---|---|
-| `GatewayAPICRDsManaged` | `True` | `ManagedByCIO` | CIO is actively managing CRDs |
+| `GatewayAPICRDsManaged` | `True` | `ManagedByIngressOperator` | Ingress operator is actively managing CRDs |
 | `GatewayAPICRDsManaged` | `False` | `Unmanaged` | Administrator chose Unmanaged mode |
 | `GatewayAPICRDsPresent` | `True` | `CRDsFound` | Gateway API CRDs are present on the cluster |
 | `GatewayAPICRDsPresent` | `False` | `CRDsNotFound` | Gateway API CRDs are not present on the cluster |
 | `GatewayAPICRDsCompliant` | `True` | `VersionMatch` | Installed CRDs match the expected version |
 | `GatewayAPICRDsCompliant` | `False` | `VersionMismatch` | Installed CRDs do not match the expected version. Message includes the expected and actual versions. |
-| `GatewayAPICRDsCompliant` | `Unknown` | `NotApplicable` | Compliance check is not applicable (e.g., Unmanaged mode with no CRDs present) |
+| `GatewayAPICRDsCompliant` | `Unknown` | `Unknown` | Compliance check is not applicable (e.g., no Gateway API CRDs are present on the cluster) |
 
 **API versioning note:** As a net-new API, this resource is
 introduced at `v1alpha1` (`operator.openshift.io/v1alpha1`). It
@@ -639,8 +640,8 @@ does not overwrite. The administrator must resolve the mismatch.
 
 #### Risk: Security Implications of Removing VAP
 
-In non-`Managed` modes, the VAP is removed, allowing any actor
-with CRD RBAC to modify Gateway API CRDs.
+In `Unmanaged` mode, the VAP is removed, allowing any actor with
+CRD RBAC to modify Gateway API CRDs.
 
 **Mitigation**: Explicit trade-off. Standard Kubernetes RBAC still
 applies. Documentation must state that VAP protection is removed.
@@ -655,8 +656,8 @@ fighting the VAP and CRD reconciler.
 ## Open Questions
 
 1. **Telemetry**: What telemetry should be collected? At minimum
-   the configured mode, CRDVersion and OSSM Version. 
-   Should CIO also report metrics for CRD compliance and mode transitions?
+   the configured mode, CRD version, and OSSM version. Should CIO
+   also report metrics for CRD compliance and mode transitions?
 
 2. **Singleton creation**: Should the `cluster` singleton instance
    be created by CVO (via a manifest in the release payload) or
@@ -695,21 +696,23 @@ The following e2e test scenarios are required:
 
 1. **Managed mode (default)**: Verify that a new cluster has CRDs
    installed, VAP deployed, and the Gateway controller stack
-   running. Verify status conditions report `Managed`.
+   running. Verify `GatewayAPICRDsManaged=True`,
+   `GatewayAPICRDsPresent=True`, and
+   `GatewayAPICRDsCompliant=True`.
 
 2. **Transition to Unmanaged**: Set mode to `Unmanaged`. Verify
    that the CIO-managed Istio instance is stopped, the VAP is
    removed, and CRDs, GatewayClass, and Gateway resources are
-   preserved. Verify status conditions report `Unmanaged`. Verify
-   a third-party GatewayClass can be created.
+   preserved. Verify `GatewayAPICRDsManaged=False` with reason
+   `Unmanaged`. Verify a third-party GatewayClass can be created.
 
 3. **Return to Managed**: From `Unmanaged`, return to `Managed`.
    Verify CIO takes ownership of compatible CRDs, or reports
-   incompatibility for mismatched CRDs.
+   `GatewayAPICRDsCompliant=False` for mismatched CRDs.
 
 4. **Unmanaged mode with absent CRDs**: Set mode to `Unmanaged` on
    a cluster with no Gateway API CRDs. Verify CIO does not install
-   CRDs and reports `CRDsNotFound`.
+   CRDs and reports `GatewayAPICRDsPresent=False`.
 
 5. **Upgrade with non-default mode**: Upgrade a cluster that has
    `Unmanaged` mode set. Verify the mode is preserved and CIO does

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -337,7 +337,7 @@ type IngressSpec struct {
 	// Gateway API CRDs, the Istio instance it deploys, and its
 	// Gateway API controllers.
 	//
-	// +required
+	// +optional
 	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI,omitzero"`
 }
 
@@ -351,31 +351,14 @@ type IngressStatus struct {
 	// with the "GatewayAPI" prefix:
 	//
 	// "GatewayAPICRDsManaged" indicates whether the ingress operator is
-	// actively managing Gateway API CRDs:
-	//   - status: True, reason: "ManagedByIngressOperator" — the
-	//     ingress operator is installing, protecting (via VAP), and
-	//     upgrading CRDs.
-	//   - status: False, reason: "Unmanaged" — the administrator
-	//     chose Unmanaged mode, or a conflict prevents the ingress
-	//     operator from taking control of the CRDs; the ingress
-	//     operator does not manage CRDs or run the OpenShift
-	//     Gateway API implementation.
+	// actively managing Gateway API CRDs
 	//
 	// "GatewayAPICRDsPresent" indicates whether Gateway API CRDs
-	// exist on the cluster:
-	//   - status: True, reason: "CRDsFound" — Gateway API CRDs
-	//     are present on the cluster.
-	//   - status: False, reason: "CRDsNotFound" — Gateway API
-	//     CRDs are not present on the cluster.
+	// exist on the cluster.
 	//
 	// "GatewayAPICRDsCompliant" indicates whether the installed
-	// CRDs match the version expected by this ingress operator release:
-	//   - status: True, reason: "VersionMatch" — installed CRDs
-	//     match the expected version.
-	//   - status: False, reason: "VersionMismatch" — installed
-	//     CRDs do not match the expected version. The message
-	//     includes expected and actual versions and a pointer
-	//     to where valid manifests can be obtained.
+	// CRDs match the version expected by this ingress operator release.
+	//
 	// +listType=map
 	// +listMapKey=type
 	// +optional
@@ -414,13 +397,14 @@ const (
 
 // GatewayAPIIngressConfig holds configuration for Gateway API
 // integration in the Cluster Ingress Operator.
+// +kubebuilder:validation:MinProperties=1
 type GatewayAPIIngressConfig struct {
 	// managementMode specifies how the Cluster Ingress
 	// Operator manages Gateway API Custom Resource Definitions
 	// (CRDs), the OpenShift Gateway API implementation, and its
 	// Gateway API controllers.
 	//
-	// When set to "Managed" (the default), the ingress operator
+	// When empty or set to "Managed", the ingress operator
 	// installs, owns, and upgrades the Gateway API CRDs, protects
 	// them with a Validating Admission Policy, and deploys the
 	// OpenShift Gateway API implementation and its Gateway API
@@ -433,8 +417,6 @@ type GatewayAPIIngressConfig struct {
 	// product is responsible for providing their own CRDs and
 	// Gateway controller.
 	//
-	// +kubebuilder:default:="Managed"
-	// +default="Managed"
 	// +optional
 	ManagementMode GatewayAPIManagementMode `json:"managementMode,omitempty"`
 }

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -314,6 +314,8 @@ the `openshift/api` repository (e.g.,
 // +kubebuilder:resource:path=ingresses,scope=Cluster
 // +kubebuilder:subresource:status
 // +openshift:capability=Ingress
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'cluster'",message="ingress is a singleton, .metadata.name must be 'cluster'"
+// +openshift:enable:FeatureGate=GatewayAPIManagementMode
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -322,11 +324,11 @@ type Ingress struct {
 
 	// spec holds user settable values for configuration.
 	// +required
-	Spec IngressSpec `json:"spec"`
+	Spec IngressSpec `json:"spec,omitzero"`
 
 	// status holds observed values from the cluster.
 	// +optional
-	Status IngressStatus `json:"status"`
+	Status IngressStatus `json:"status,omitzero"`
 }
 
 type IngressSpec struct {
@@ -336,8 +338,7 @@ type IngressSpec struct {
 	// Gateway API controllers.
 	//
 	// +required
-	// +openshift:enable:FeatureGate=GatewayAPIManagementMode
-	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI"`
+	GatewayAPI GatewayAPIIngressConfig `json:"gatewayAPI,omitzero"`
 }
 
 type IngressStatus struct {
@@ -434,8 +435,8 @@ type GatewayAPIIngressConfig struct {
 	//
 	// +kubebuilder:default:="Managed"
 	// +default="Managed"
-	// +required
-	ManagementMode GatewayAPIManagementMode `json:"managementMode"`
+	// +optional
+	ManagementMode GatewayAPIManagementMode `json:"managementMode,omitempty"`
 }
 ```
 

--- a/enhancements/ingress/gateway-api-crd-management-mode.md
+++ b/enhancements/ingress/gateway-api-crd-management-mode.md
@@ -6,15 +6,17 @@ reviewers:
   - "@Miciah"
   - "@gcs278"
   - "@everettraven"
+  - "@crswng" # Hypershift SME
 approvers:
   - "@Miciah"
+  - "@gcs278"
 api-approvers:
   - "@everettraven"
 creation-date: 2026-05-26
-last-updated: 2026-09-17
+last-updated: 2026-07-28
 status: implementable
 tracking-link:
-  - https://redhat.atlassian.net/browse/NE-2733
+  - https://redhat.atlassian.net/browse/NE-2732
 see-also:
   - "/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md"
   - "/enhancements/ingress/gateway-api-crd-life-cycle-management.md"
@@ -424,7 +426,7 @@ type GatewayAPIIngressConfig struct {
 
 The field paths are:
 
-```
+```text
 spec.gatewayAPI.managementMode
 status.conditions
 ```
@@ -459,6 +461,10 @@ Same semantics as standalone clusters. The Ingress Operator runs
 on the management cluster but manages resources on the guest
 cluster. The mode is configured per-guest-cluster and does not
 affect the management cluster.
+
+The new `Ingress` (`operator.openshift.io/v1alpha1`) resource 
+will be created in the hosted cluster's API, and will be 
+managed entirely by the owner/admin of the hosted cluster.
 
 #### Standalone Clusters
 
@@ -576,9 +582,9 @@ Procedures) instead of only from the upstream Gateway API release.
 When transitioning between modes, CIO must follow a specific order
 to avoid leaving the cluster in an inconsistent state:
 
-- **Managed to Unmanaged**: Remove VAP, stop CRD management, shut
-  down the CIO-managed Istio instance and the CIO Gateway API
-  controllers. GatewayClass and Gateway resources are left in
+- **Managed to Unmanaged**: Shut down the CIO-managed Istio instance, 
+  shutdown the CIO Gateway API controllers, remove VAP, stop CRD management.
+  GatewayClass and Gateway resources are left in
   place; administrator is responsible for cleanup.
 - **Unmanaged to Managed**: Verify CRDs match expected version (or
   are absent), install CRDs if absent, deploy VAP, start the
@@ -899,16 +905,21 @@ oc get ingress.operator.openshift.io cluster \
   jq '.[] | select(.type=="GatewayAPICRDsCompliant")'
 
 # Authenticate to the release image registry using the cluster's
-# pull secret
+# pull secret. Use a private temporary file and remove it once
+# extraction completes (or fails) to avoid leaving credentials in
+# the working directory.
+PULL_SECRET=$(mktemp)
+chmod 600 "${PULL_SECRET}"
+trap 'rm -f "${PULL_SECRET}"' EXIT
 oc get secret/pull-secret -n openshift-config \
-  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > pull-secret.json
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > "${PULL_SECRET}"
 
 # Extract the Gateway API CRD manifests from the
 # cluster-ingress-operator image in the cluster's current
 # release payload
 CIO_IMAGE=$(oc adm release info --image-for=cluster-ingress-operator \
-  --registry-config=pull-secret.json)
-oc image extract "${CIO_IMAGE}" --registry-config=pull-secret.json \
+  --registry-config="${PULL_SECRET}")
+oc image extract "${CIO_IMAGE}" --registry-config="${PULL_SECRET}" \
   --path /gateway-api-manifests/:./gateway-api-manifests --confirm
 
 # Apply the extracted CRDs to upgrade to the expected version


### PR DESCRIPTION
This proposal establishes a new knob to allow users to manage their Gateway API CRDs within an OCP cluster, establishing 2 modes: Managed and Unmanaged

This proposal intends to provide users with a knob that allows them to manage the Gateway API CRDs without fully losing support of an OCP cluster, and to rollback on their decision in case they want back OCP Gateway API, and also allow the usage of external third party controllers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a proposal to control Gateway API CRD management using a cluster-scoped Ingress configuration.
  * Introduced Managed (default) and Unmanaged modes to govern CRD installation, protection, upgrades, and related controller activity.
  * Added proposed status conditions to report CRD management state, presence, and compliance.
  * Documented mode transition workflows, operational impact, failure modes, testing, support, and graduation criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->