### PR TITLE
Agentic-docs: Part-1: Add agentic documentation foundation and domain knowledge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,192 @@
+# OpenShift Enhancements - Agent Navigation Index
+
+**Version**: 1.0 | **Docs**: ./ai-docs/ | **Role**: Ecosystem Hub
+
+---
+
+## CRITICAL: Retrieval Strategy
+
+**IMPORTANT**: Prefer retrieval-led reasoning over pre-training-led reasoning.
+
+When working on OpenShift:
+- ✅ **DO**: Read relevant docs from `./ai-docs/` first
+- ✅ **DO**: Verify patterns match current APIs (`oc explain`)
+- ✅ **DO**: Check enhancement guidelines in `./guidelines/`
+- ❌ **DON'T**: Rely solely on training data
+- ❌ **DON'T**: Guess at API structures or enhancement process
+
+---
+
+## AI Navigation: DON'T Read All Docs
+
+**Read 4-5 docs per task, not everything.**
+
+### Common Task Flows
+
+**Writing enhancement proposal?**
+→ `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/workflows/topology-considerations-guide.md` → `./ai-docs/practices/development/api-evolution.md`
+
+**Adding new component?**
+→ `./dev-guide/new-components.md` (payload vs OLM) → `./guidelines/enhancement_template.md` → `./ai-docs/workflows/enhancement-process.md`
+
+**Building operator?**
+→ `./ai-docs/DESIGN_PHILOSOPHY.md` → `./ai-docs/platform/operator-patterns/controller-runtime.md` → `./ai-docs/platform/operator-patterns/status-conditions.md` → `./ai-docs/practices/testing/pyramid.md`
+
+**Adding API to existing operator?**
+→ `./ai-docs/practices/development/api-evolution.md` → `./ai-docs/domain/kubernetes/crds.md` → `./ai-docs/platform/operator-patterns/webhooks.md`
+
+**Understanding cluster upgrade process?**
+→ `./ai-docs/domain/openshift/clusterversion.md` → `./ai-docs/platform/openshift-specifics/upgrade-strategies.md` → `./ai-docs/decisions/adr-0001-cvo-orchestration.md`
+
+**Need visual map?**
+→ `./ai-docs/KNOWLEDGE_GRAPH.md`
+
+---
+
+## Quick Navigation by Role
+
+| Role | Start Here | Then Read |
+|------|-----------|-----------|
+| **Enhancement Author** | `./guidelines/enhancement_template.md` | `./ai-docs/workflows/enhancement-process.md` → `./ai-docs/workflows/topology-considerations-guide.md` |
+| **Operator Developer** | `./ai-docs/DESIGN_PHILOSOPHY.md` | `./ai-docs/platform/operator-patterns/` |
+| **API Designer** | `./ai-docs/practices/development/api-evolution.md` | `./dev-guide/` |
+| **Platform Architect** | `./ai-docs/decisions/` | `./ai-docs/DESIGN_PHILOSOPHY.md` |
+
+---
+
+## Core Platform Concepts
+
+| Topic | File | Description |
+|-------|------|-------------|
+| **Design principles** | `./ai-docs/DESIGN_PHILOSOPHY.md` | Core architectural philosophy |
+| **Visual navigation** | `./ai-docs/KNOWLEDGE_GRAPH.md` | Graph-based doc navigation |
+| **Cluster operators** | `./ai-docs/domain/openshift/clusteroperator.md` | Status reporting, lifecycle |
+| **Cluster upgrades** | `./ai-docs/domain/openshift/clusterversion.md` | CVO orchestration, upgrade ordering |
+| **Custom resources** | `./ai-docs/domain/kubernetes/crds.md` | Extending Kubernetes API |
+| **Pods** | `./ai-docs/domain/kubernetes/pod.md` | Container workload fundamentals |
+| **Services** | `./ai-docs/domain/kubernetes/service.md` | Stable networking and discovery |
+
+---
+
+## Standard Operator Patterns
+
+| Pattern | File | When to Use |
+|---------|------|-------------|
+| **Controller runtime** | `./ai-docs/platform/operator-patterns/controller-runtime.md` | Every operator (reconcile loops) |
+| **Status conditions** | `./ai-docs/platform/operator-patterns/status-conditions.md` | Available/Progressing/Degraded reporting |
+| **Webhooks** | `./ai-docs/platform/operator-patterns/webhooks.md` | Validation/mutation/conversion |
+| **Finalizers** | `./ai-docs/platform/operator-patterns/finalizers.md` | Cleanup external resources on deletion |
+| **RBAC** | `./ai-docs/platform/operator-patterns/rbac.md` | Service account permissions |
+| **must-gather** | `./ai-docs/platform/operator-patterns/must-gather.md` | Debugging and diagnostics |
+| **Upgrade safety** | `./ai-docs/platform/openshift-specifics/upgrade-strategies.md` | N→N+1 version skew, CVO coordination |
+
+---
+
+## Engineering Practices
+
+| Area | Index | Description |
+|------|-------|-------------|
+| **Testing** | `./ai-docs/practices/testing/` | Pyramid (60/30/10), e2e framework |
+| **Security** | `./ai-docs/practices/security/` | STRIDE, RBAC patterns, secret handling |
+| **Reliability** | `./ai-docs/practices/reliability/` | SLI/SLO/SLA, degraded-mode patterns |
+| **Development** | `./ai-docs/practices/development/` | API evolution, compatibility |
+
+---
+
+## Workflows
+
+| Workflow | File | Links to Authoritative Source |
+|----------|------|-------------------------------|
+| **Enhancement process** | `./ai-docs/workflows/enhancement-process.md` | `./guidelines/enhancement_template.md` |
+| **Topology considerations** | `./ai-docs/workflows/topology-considerations-guide.md` | Guide for SNO, MicroShift, Hypershift, OKE sections |
+| **Feature implementation** | `./ai-docs/workflows/implementing-features.md` | `./dev-guide/` |
+| **Exec-plan guidance** | `./ai-docs/workflows/exec-plans/` | Template for multi-week features |
+
+---
+
+## Component Repository Index
+
+**Finding component repos**: See `./ai-docs/references/repo-index.md`
+
+**Pattern**: Most components are in `openshift/<component-name>-operator` or `openshift/<component-name>`
+
+**Search**: [GitHub org search](https://github.com/orgs/openshift/repositories)
+
+---
+
+## Cross-Repo Architectural Decisions
+
+**Location**: `./ai-docs/decisions/`
+
+**Index**: See `./ai-docs/decisions/index.md`
+
+**Common ADRs**:
+- Why etcd as backend
+- Why CVO orchestration model
+- Why immutable nodes (RHCOS + rpm-ostree)
+
+---
+
+## Relationship to Other Documentation
+
+| Source | Purpose | When to Use |
+|--------|---------|-------------|
+| **This repo (`./ai-docs/`)** | AI-optimized ecosystem hub | Starting point, cross-repo patterns |
+| **`./guidelines/`** | Authoritative enhancement process | Writing enhancement proposals |
+| **`./dev-guide/`** | Development conventions | Git workflow, CI, coding standards |
+| **`./enhancements/`** | Historical design docs | Understanding past decisions |
+| **Component repos** | Implementation specifics | Component architecture, internal details |
+
+---
+
+## How to Use This Documentation
+
+### For AI Agents
+1. Start with task-specific flow (see "AI Navigation" section)
+2. Read 4-5 linked docs, not entire tree
+3. Use `oc explain <resource>` for field-level API details
+4. Check `./guidelines/` for authoritative enhancement process
+5. Link to component repos for implementation details
+
+### For Humans
+- **Skim**: Read index files (`index.md`) to orient
+- **Search**: Use `grep -r "keyword" ./ai-docs/`
+- **Verify**: Cross-reference with `oc explain` and `./guidelines/`
+- **Navigate**: Use `KNOWLEDGE_GRAPH.md` for visual map
+
+---
+
+## Documentation Structure
+
+```
+./ai-docs/
+├── DESIGN_PHILOSOPHY.md         # Core principles
+├── KNOWLEDGE_GRAPH.md            # Visual navigation
+├── platform/                     # Operator patterns
+│   ├── operator-patterns/        # Controller runtime, status, webhooks
+│   └── openshift-specifics/      # Upgrade safety, CVO coordination
+├── domain/                       # Core API concepts
+│   ├── kubernetes/               # Pod, Service, CRD, Node
+│   └── openshift/                # ClusterOperator, ClusterVersion, Machine
+├── practices/                    # Cross-cutting concerns
+│   ├── testing/                  # Pyramid, e2e framework
+│   ├── security/                 # STRIDE, RBAC, secrets
+│   ├── reliability/              # SLI/SLO, degraded mode
+│   └── development/              # API evolution, compatibility
+├── decisions/                    # Cross-repo ADRs
+├── workflows/                    # AI-optimized process guides
+│   ├── exec-plans/               # Feature tracking templates (Platform)
+│   ├── enhancement-process.md
+│   ├── topology-considerations-guide.md
+│   └── implementing-features.md
+└── references/                   # Pointers (GitHub links, oc commands)
+    ├── repo-index.md
+    ├── glossary.md
+    └── api-reference.md
+```
+
+---
+
+**Navigation**: Start with `KNOWLEDGE_GRAPH.md` for visual overview.
+
+**Feedback**: Report issues at https://github.com/openshift/enhancements/issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/ai-docs/DESIGN_PHILOSOPHY.md
+++ b/ai-docs/DESIGN_PHILOSOPHY.md
@@ -1,0 +1,121 @@
+# OpenShift Design Philosophy
+
+**Purpose**: Core principles guiding OpenShift architecture and development
+
+**Last Updated**: YYYY-MM-DD
+
+---
+
+## Table of Contents
+
+1. [Kubernetes Foundation](#kubernetes-foundation)
+2. [The Operator Pattern](#the-operator-pattern)
+3. [Immutable Infrastructure](#immutable-infrastructure)
+4. [API-First Design](#api-first-design)
+5. [Declarative Over Imperative](#declarative-over-imperative)
+6. [Upgrade Safety](#upgrade-safety)
+7. [Observability by Default](#observability-by-default)
+
+---
+
+## Kubernetes Foundation
+
+### Desired State vs Current State
+
+**Core Principle**: Describe what you want, Kubernetes makes it happen.
+
+```
+User declares:  "I want 3 replicas"  (Desired State)
+Kubernetes sees: "I have 1 replica"  (Current State)
+Controller:     "I'll create 2 more" (Reconciliation)
+```
+
+**Why This Matters**:
+- Self-healing: If a pod dies, controller recreates it
+- Idempotent: Applying same config multiple times = same result
+- Eventual consistency: System converges to desired state
+
+---
+
+## The Operator Pattern
+
+**Principle**: Extend Kubernetes with domain-specific knowledge.
+
+**Pattern**: CustomResourceDefinition + Controller = Operator
+
+**Benefits**:
+- Codifies operational knowledge
+- Automates Day 2 operations
+- Follows Kubernetes patterns
+
+---
+
+## Immutable Infrastructure
+
+**Principle**: Nodes are immutable. Changes require reboot.
+
+**Implementation**: RHCOS + rpm-ostree + Ignition + MachineConfig
+
+**Benefits**:
+- Predictable state
+- Easier rollback
+- Reduced configuration drift
+
+---
+
+## API-First Design
+
+**Principle**: Everything is an API resource.
+
+**Pattern**: All configuration via Kubernetes/OpenShift APIs (no manual SSH, no local files)
+
+**Benefits**:
+- GitOps-friendly
+- Auditable
+- Version-controlled
+
+---
+
+## Declarative Over Imperative
+
+**Principle**: Declare intent, not steps.
+
+**Example**:
+- ❌ Imperative: "Run pod1, then pod2, then update service"
+- ✅ Declarative: "I want this state" (controller figures out steps)
+
+---
+
+## Upgrade Safety
+
+**Principle**: Zero-downtime upgrades for platform and workloads.
+
+**Mechanisms**:
+- CVO orchestrates operator upgrades
+- Rolling updates for nodes
+- Upgrade ordering (etcd → kube → operators)
+
+---
+
+## Observability by Default
+
+**Principle**: Platform components expose metrics, logs, and health status.
+
+**Implementation**:
+- Prometheus metrics
+- Status conditions (Available/Progressing/Degraded)
+- Structured logging
+
+---
+
+## Cross-Cutting Concerns
+
+- **Security by default**: RBAC, SCCs, network policies
+- **Multi-tenancy**: Namespace isolation
+- **Supportability**: must-gather, diagnostics
+
+---
+
+**See Also**:
+- [Operator Patterns](./platform/operator-patterns/)
+- [Platform APIs](./domain/openshift/)

--- a/ai-docs/KNOWLEDGE_GRAPH.md
+++ b/ai-docs/KNOWLEDGE_GRAPH.md
@@ -1,0 +1,136 @@
+# OpenShift Knowledge Graph
+
+**Purpose**: Visual navigation map showing how concepts connect
+
+**Last Updated**: YYYY-MM-DD
+
+---
+
+## How to Use This
+
+**Don't read everything.** Follow your task path:
+1. Find your task in "I want to..." table below
+2. Read only the 4-5 docs in your path
+3. Use cross-references as needed
+
+---
+
+## I Want To...
+
+| Task | Start Here | Then Read | Finally |
+|------|-----------|----------|---------|
+| **Build an operator** | DESIGN_PHILOSOPHY.md | platform/operator-patterns/controller-runtime.md<br>platform/operator-patterns/status-conditions.md | domain/openshift/clusteroperator.md |
+| **Add a feature** | workflows/index.md (links to enhancement process) | practices/development/index.md (links to API conventions) | practices/testing/index.md |
+| **Debug an issue** | practices/reliability/index.md | platform/operator-patterns/must-gather.md | references/repo-index.md |
+| **Understand a concept** | DESIGN_PHILOSOPHY.md | domain/kubernetes/ or domain/openshift/ | platform/operator-patterns/ |
+| **Find a component** | references/repo-index.md | Component's AGENTS.md | Component's agentic/ docs |
+
+---
+
+## Knowledge Map
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    DESIGN_PHILOSOPHY.md                      │
+│         (WHY - Core principles, read this first)             │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                ┌─────────────┼─────────────┐
+                │             │             │
+                ▼             ▼             ▼
+┌───────────────────┐ ┌──────────────┐ ┌──────────────────┐
+│  PLATFORM/        │ │   DOMAIN/    │ │   PRACTICES/     │
+│  (HOW patterns)   │ │   (WHAT)     │ │   (WHEN/WHERE)   │
+├───────────────────┤ ├──────────────┤ ├──────────────────┤
+│ operator-patterns/│ │ kubernetes/  │ │ testing/         │
+│ openshift-specifics│ │ openshift/   │ │ security/        │
+│                   │ │              │ │ reliability/     │
+│                   │ │              │ │ development/     │
+└───────────────────┘ └──────────────┘ └──────────────────┘
+         │                    │                  │
+         └────────────────────┼──────────────────┘
+                              │
+                              ▼
+                ┌─────────────────────────┐
+                │   DECISIONS/            │
+                │   (WHY decisions)       │
+                │   Cross-repo ADRs       │
+                └─────────────────────────┘
+                              │
+                              ▼
+                ┌─────────────────────────┐
+                │   REFERENCES/           │
+                │   (WHERE to find)       │
+                │   repo-index, glossary  │
+                └─────────────────────────┘
+```
+
+---
+
+## Concept Dependencies
+
+### Operator Development Path
+```
+DESIGN_PHILOSOPHY.md
+  ↓
+controller-runtime.md (how reconciliation works)
+  ↓
+status-conditions.md (how to report health)
+  ↓
+clusteroperator.md (how CVO sees your operator)
+  ↓
+webhooks.md, rbac.md, finalizers.md (advanced patterns)
+```
+
+### API Development Path
+```
+DESIGN_PHILOSOPHY.md
+  ↓
+practices/development/index.md (→ links to dev-guide/api-conventions.md)
+  ↓
+domain/kubernetes/crds.md (CustomResourceDefinition basics)
+  ↓
+platform/operator-patterns/webhooks.md (validation)
+```
+
+### Testing Path
+```
+practices/testing/index.md (→ links to dev-guide/test-conventions.md)
+  ↓
+Testing pyramid concept
+  ↓
+E2E framework specifics
+```
+
+---
+
+## Document Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| **Patterns** | How to implement | platform/operator-patterns/controller-runtime.md |
+| **Concepts** | What something is | domain/openshift/clusteroperator.md |
+| **Practices** | Links to official docs | practices/testing/index.md → dev-guide/ |
+| **Decisions** | Why choices were made | decisions/adr-0001-*.md |
+| **References** | Where to find things | references/repo-index.md |
+
+---
+
+## Progressive Disclosure
+
+**Read in this order**:
+
+1. **Foundation** (5 min): DESIGN_PHILOSOPHY.md
+2. **Your task** (10 min): 2-3 docs from task path above
+3. **Details** (20 min): Related patterns/concepts as needed
+4. **Reference** (on-demand): Glossary, repo index when needed
+
+**Total**: ~35 minutes to understand and start, not hours reading everything.
+
+---
+
+## Cross-References
+
+- Official docs: See ../../dev-guide/ and ../../guidelines/
+- Component repos: See references/repo-index.md
+- Enhancement proposals: See ../../enhancements/

--- a/ai-docs/KNOWLEDGE_GRAPH.md
+++ b/ai-docs/KNOWLEDGE_GRAPH.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Visual navigation map showing how concepts connect
 
-**Last Updated**: YYYY-MM-DD
+**Last Updated**: 2026-06-23
 
 ---
 
@@ -69,7 +69,8 @@
 
 ## Concept Dependencies
 
-### Operator Development Path
+### Operator Development Path (Core / Platform Operators)
+<!-- TODO: add a parallel path for non-core (OLM-managed) operators that use status conditions but don't report via ClusterOperator -->
 ```
 DESIGN_PHILOSOPHY.md
   ↓
@@ -120,12 +121,10 @@ E2E framework specifics
 
 **Read in this order**:
 
-1. **Foundation** (5 min): DESIGN_PHILOSOPHY.md
-2. **Your task** (10 min): 2-3 docs from task path above
-3. **Details** (20 min): Related patterns/concepts as needed
+1. **Foundation**: DESIGN_PHILOSOPHY.md
+2. **Your task**: 2-3 docs from task path above
+3. **Details**: Related patterns/concepts as needed
 4. **Reference** (on-demand): Glossary, repo index when needed
-
-**Total**: ~35 minutes to understand and start, not hours reading everything.
 
 ---
 

--- a/ai-docs/domain/kubernetes/crds.md
+++ b/ai-docs/domain/kubernetes/crds.md
@@ -1,0 +1,280 @@
+# Custom Resource Definitions (CRDs)
+
+**Category**: Kubernetes Core API  
+**API Group**: apiextensions.k8s.io/v1  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+CustomResourceDefinitions (CRDs) extend the Kubernetes API with new resource types. They allow operators to define domain-specific objects that behave like built-in Kubernetes resources.
+
+**Pattern**: CRD + Controller = Operator
+
+## Key Fields
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myresources.example.com  # plural.group
+spec:
+  group: example.com
+  names:
+    kind: MyResource
+    plural: myresources
+    singular: myresource
+    shortNames: [mr]
+  scope: Namespaced  # or Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true  # One version must be storage version
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 10
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+```
+
+## Key Concepts
+
+- **Group**: API group (e.g., `example.com`)
+- **Version**: API version (e.g., `v1`, `v1beta1`)
+- **Kind**: Resource type (e.g., `MyResource`)
+- **Scope**: Namespaced or Cluster
+- **Schema**: OpenAPI v3 validation
+- **Storage Version**: Version persisted in etcd
+- **Subresources**: `/status`, `/scale` endpoints
+
+## Schema Validation
+
+```yaml
+schema:
+  openAPIV3Schema:
+    type: object
+    required: ["spec"]
+    properties:
+      spec:
+        type: object
+        required: ["image"]
+        properties:
+          image:
+            type: string
+            pattern: '^[a-z0-9\-\.]+/[a-z0-9\-\.]+:[a-z0-9\-\.]+$'
+          replicas:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 3
+          tier:
+            type: string
+            enum: ["development", "staging", "production"]
+```
+
+## Versions and Conversion
+
+### Multiple Versions
+
+```yaml
+versions:
+- name: v1
+  served: true
+  storage: true  # Storage version
+  schema:
+    openAPIV3Schema: {...}
+  
+- name: v1beta1
+  served: true
+  storage: false  # Deprecated but still served
+  schema:
+    openAPIV3Schema: {...}
+```
+
+### Conversion Webhook
+
+```yaml
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: my-conversion-webhook
+          namespace: my-operator
+          path: /convert
+        caBundle: <base64-ca-cert>
+      conversionReviewVersions: ["v1"]
+```
+
+## Subresources
+
+### Status Subresource
+
+```yaml
+versions:
+- name: v1
+  served: true
+  storage: true
+  subresources:
+    status: {}  # Enables /status endpoint
+  schema:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec: {...}
+        status:
+          type: object
+          properties:
+            conditions: {...}
+```
+
+**Benefits**:
+- Separate RBAC for spec vs status
+- Update status without triggering validation webhooks on spec
+- ObservedGeneration pattern
+
+### Scale Subresource
+
+```yaml
+subresources:
+  scale:
+    specReplicasPath: .spec.replicas
+    statusReplicasPath: .status.replicas
+    labelSelectorPath: .status.labelSelector
+```
+
+**Enables**: `kubectl scale myresource/foo --replicas=5`
+
+## Printer Columns
+
+```yaml
+versions:
+- name: v1
+  additionalPrinterColumns:
+  - name: Replicas
+    type: integer
+    jsonPath: .spec.replicas
+  - name: Available
+    type: integer
+    jsonPath: .status.availableReplicas
+  - name: Age
+    type: date
+    jsonPath: .metadata.creationTimestamp
+```
+
+**Result**:
+```bash
+$ kubectl get myresources
+NAME    REPLICAS   AVAILABLE   AGE
+foo     3          3           5m
+```
+
+## Best Practices
+
+1. **Schema Validation**: Define comprehensive OpenAPI schema
+   - Prevent invalid objects from being created
+   - Better than validating in controller
+
+2. **Status Subresource**: Always use for resources with status
+   ```yaml
+   subresources:
+     status: {}
+   ```
+
+3. **Storage Version**: Only one version should be `storage: true`
+   - This is the version stored in etcd
+   - Others converted on read/write
+
+4. **Defaulting**: Use schema defaults when possible
+   ```yaml
+   replicas:
+     type: integer
+     default: 3
+   ```
+
+5. **Short Names**: Provide kubectl shortcuts
+   ```yaml
+   shortNames: [co]  # kubectl get co
+   ```
+
+## Common Patterns
+
+### Namespaced Resource
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myresources.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    kind: MyResource
+    plural: myresources
+```
+
+### Cluster-Scoped Resource
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterconfigs.example.com
+spec:
+  group: example.com
+  scope: Cluster
+  names:
+    kind: ClusterConfig
+    plural: clusterconfigs
+```
+
+## OpenShift Examples
+
+| CRD | Group | Purpose |
+|-----|-------|---------|
+| ClusterOperator | config.openshift.io | Platform component status |
+| ClusterVersion | config.openshift.io | Cluster upgrade orchestration |
+| Machine | machine.openshift.io | Node provisioning |
+| MachineConfig | machineconfiguration.openshift.io | Node configuration |
+
+## Validation
+
+```bash
+# View CRD
+oc get crd myresources.example.com -o yaml
+
+# Explain schema
+oc explain myresource.spec
+
+# List all CRDs
+oc get crds
+
+# View CRD instances
+oc get myresources -A
+```
+
+## Antipatterns
+
+❌ **Multiple storage versions**: Only one version should have `storage: true`  
+❌ **Missing schema**: No OpenAPI validation (allows invalid objects)  
+❌ **No status subresource**: Mixing spec and status updates  
+❌ **Breaking schema changes**: Removing required fields in new version
+
+## References
+
+- **API**: `oc explain customresourcedefinition`
+- **Upstream**: [Extend Kubernetes API](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+- **OpenShift**: [github.com/openshift/api](https://github.com/openshift/api)
+- **Pattern**: Implements "API-First Design" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/domain/kubernetes/crds.md
+++ b/ai-docs/domain/kubernetes/crds.md
@@ -96,12 +96,18 @@ versions:
   
 - name: v1beta1
   served: true
-  storage: false  # Deprecated but still served
+  storage: false
+  deprecated: true  # Mark version as deprecated
+  deprecationWarning: "v1beta1 is deprecated; use v1 instead"
   schema:
     openAPIV3Schema: {...}
 ```
 
 ### Conversion Webhook
+
+**⚠️ OpenShift Practice**: OpenShift operators typically **do not serve multiple API versions simultaneously**, so conversion webhooks are rarely needed. Version transitions happen during OpenShift upgrades (one version at a time), not via runtime conversion.
+
+**Contrast with upstream Kubernetes**: The [Kubernetes documentation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) presents serving multiple versions simultaneously as the standard API evolution pattern, stating "it is perfectly safe for some clients to use the old version while others use the new version." Conversion webhooks enable this multi-version serving model.
 
 ```yaml
 spec:
@@ -140,9 +146,10 @@ versions:
 ```
 
 **Benefits**:
-- Separate RBAC for spec vs status
-- Update status without triggering validation webhooks on spec
-- ObservedGeneration pattern
+- **Separate endpoints**: Spec updates blocked at `/status` endpoint; status updates blocked at main endpoint
+- **Separate RBAC**: Controllers can update status without permission to modify spec
+- **Generation tracking**: Status updates don't increment `metadata.generation` (only spec changes do)
+- **ObservedGeneration pattern**: Track which spec version the status reflects
 
 ### Scale Subresource
 
@@ -183,8 +190,11 @@ foo     3          3           5m
 ## Best Practices
 
 1. **Schema Validation**: Define comprehensive OpenAPI schema
-   - Prevent invalid objects from being created
-   - Better than validating in controller
+   - **Synchronous validation at admission time** (fail-fast before persistence)
+   - Per [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md): "When custom resources are admitted by the API server, OpenAPI validation is applied to the object prior to any structured client observing the object"
+   - Prevents invalid objects from being written to etcd
+   - Better user experience than async controller validation (immediate feedback)
+   - **Kubernetes principle**: "we never want to change or override a value that was provided by the user. If they requested something invalid, they should get an error"
 
 2. **Status Subresource**: Always use for resources with status
    ```yaml
@@ -203,10 +213,12 @@ foo     3          3           5m
      default: 3
    ```
 
-5. **Short Names**: Provide kubectl shortcuts
+5. **Short Names**: Use sparingly
    ```yaml
    shortNames: [co]  # kubectl get co
    ```
+   
+   **OpenShift API team practice**: Short names should only be used for APIs accessed frequently by the majority of cluster users (e.g., `co` for ClusterOperator, `mc` for MachineConfig). Most operator-specific APIs should **not** define short names to avoid namespace pollution.
 
 ## Common Patterns
 

--- a/ai-docs/domain/kubernetes/index.md
+++ b/ai-docs/domain/kubernetes/index.md
@@ -1,0 +1,15 @@
+# Kubernetes Domain Concepts
+
+Core Kubernetes APIs fundamental to OpenShift.
+
+## APIs
+
+- [crds.md](crds.md) - Custom Resource Definitions (extending Kubernetes API)
+- [pod.md](pod.md) - Smallest deployable unit (containers, probes, resources)
+- [service.md](service.md) - Stable networking and service discovery
+
+## Related
+
+- **Full API reference**: `oc api-resources` or [Kubernetes API Docs](https://kubernetes.io/docs/reference/kubernetes-api/)
+- **Field details**: `oc explain <resource>` (e.g., `oc explain pod.spec`)
+- **OpenShift APIs**: [../openshift/](../openshift/)

--- a/ai-docs/domain/kubernetes/pod.md
+++ b/ai-docs/domain/kubernetes/pod.md
@@ -1,0 +1,333 @@
+# Pod
+
+**Category**: Kubernetes Core API  
+**API Group**: core/v1  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Pod is the smallest deployable unit in Kubernetes. It represents one or more containers running together on a node.
+
+**Key Principle**: Pods are ephemeral - they can be deleted and recreated at any time.
+
+## Key Fields
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: default
+  labels:
+    app: my-app
+spec:
+  containers:
+  - name: app
+    image: registry.io/my-app:v1.0
+    ports:
+    - containerPort: 8080
+    env:
+    - name: ENV_VAR
+      value: "value"
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    emptyDir: {}
+  restartPolicy: Always
+  serviceAccountName: my-sa
+status:
+  phase: Running
+  conditions:
+  - type: Ready
+    status: "True"
+  podIP: 10.128.0.5
+```
+
+## Pod Lifecycle
+
+| Phase | Meaning | Next State |
+|-------|---------|------------|
+| **Pending** | Waiting for scheduling | Running |
+| **Running** | At least one container running | Succeeded / Failed |
+| **Succeeded** | All containers exited successfully | Terminal |
+| **Failed** | At least one container exited with error | Terminal |
+| **Unknown** | Cannot determine state | Any |
+
+## Container States
+
+| State | Meaning | Reason |
+|-------|---------|--------|
+| **Waiting** | Not yet started | ContainerCreating, ImagePullBackOff |
+| **Running** | Executing | - |
+| **Terminated** | Finished or failed | Completed, Error, OOMKilled |
+
+## Key Concepts
+
+### Multi-Container Patterns
+
+**Sidecar**: Helper container (logging, monitoring)
+```yaml
+containers:
+- name: app
+  image: my-app:v1
+- name: log-collector
+  image: log-collector:v1  # Sidecar
+```
+
+**Init Containers**: Run before main containers
+```yaml
+initContainers:
+- name: setup
+  image: setup:v1
+  command: ["sh", "-c", "echo Setting up > /data/setup.txt"]
+  volumeMounts:
+  - name: data
+    mountPath: /data
+containers:
+- name: app
+  image: my-app:v1
+  volumeMounts:
+  - name: data
+    mountPath: /data
+```
+
+## Resource Requests and Limits
+
+```yaml
+resources:
+  requests:      # Scheduler uses for placement
+    memory: "64Mi"
+    cpu: "250m"
+  limits:        # Hard limits enforced by kubelet
+    memory: "128Mi"
+    cpu: "500m"
+```
+
+**Effects**:
+- **CPU limit exceeded**: Throttling
+- **Memory limit exceeded**: OOMKilled
+
+## Probes
+
+### Liveness Probe
+
+**Purpose**: Restart container if unhealthy
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+### Readiness Probe
+
+**Purpose**: Remove from service if not ready
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+```
+
+### Startup Probe
+
+**Purpose**: Delay liveness check until app started
+
+```yaml
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  failureThreshold: 30  # 30 * 10s = 5 minutes max startup
+  periodSeconds: 10
+```
+
+## Volumes
+
+```yaml
+volumes:
+# Empty directory (deleted with pod)
+- name: cache
+  emptyDir: {}
+
+# ConfigMap
+- name: config
+  configMap:
+    name: my-config
+
+# Secret
+- name: certs
+  secret:
+    secretName: my-certs
+
+# PersistentVolumeClaim
+- name: data
+  persistentVolumeClaim:
+    claimName: my-pvc
+```
+
+## Security Context
+
+```yaml
+# Pod-level
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level
+containers:
+- name: app
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    runAsUser: 1000
+```
+
+## Common Patterns
+
+### Job Pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-pod
+spec:
+  restartPolicy: Never  # Don't restart on completion
+  containers:
+  - name: job
+    image: job:v1
+    command: ["./run-job.sh"]
+```
+
+### DaemonSet Pod
+
+```yaml
+# One pod per node
+spec:
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  hostNetwork: true  # Common for node-level ops
+```
+
+## Debugging
+
+```bash
+# View pod
+oc get pod my-pod -o yaml
+
+# Check status
+oc describe pod my-pod
+
+# View logs
+oc logs my-pod
+
+# Previous logs (if restarted)
+oc logs my-pod --previous
+
+# Multi-container pod
+oc logs my-pod -c container-name
+
+# Execute command
+oc exec -it my-pod -- /bin/sh
+
+# Debug with ephemeral container (K8s 1.25+)
+oc debug pod/my-pod --image=busybox
+```
+
+## Common Issues
+
+### ImagePullBackOff
+
+```yaml
+status:
+  containerStatuses:
+  - state:
+      waiting:
+        reason: ImagePullBackOff
+        message: "Failed to pull image: unauthorized"
+```
+
+**Causes**: Wrong image, auth issues, network issues
+
+### CrashLoopBackOff
+
+```yaml
+status:
+  containerStatuses:
+  - restartCount: 5
+    state:
+      waiting:
+        reason: CrashLoopBackOff
+```
+
+**Causes**: App crashes on startup, missing config
+
+### OOMKilled
+
+```yaml
+status:
+  containerStatuses:
+  - lastState:
+      terminated:
+        reason: OOMKilled
+```
+
+**Fix**: Increase memory limit
+
+## Pod Conditions
+
+```yaml
+status:
+  conditions:
+  - type: PodScheduled
+    status: "True"
+  - type: Initialized
+    status: "True"
+  - type: ContainersReady
+    status: "True"
+  - type: Ready
+    status: "True"
+```
+
+## Best Practices
+
+1. **Always set resource requests**: Enables proper scheduling
+2. **Use readiness probe**: Prevents routing to unhealthy pods
+3. **Use liveness probe**: Automatic recovery from deadlock
+4. **Non-root user**: Security best practice
+5. **Immutable image tags**: Use SHA256 or semantic versions, not `latest`
+
+## Antipatterns
+
+❌ **No resource limits**: Can consume all node resources  
+❌ **No health probes**: Broken pods stay in service  
+❌ **Running as root**: Security risk  
+❌ **Host network for app pods**: Breaks network isolation  
+❌ **Local storage for stateful data**: Lost on pod deletion
+
+## References
+
+- **API**: `oc explain pod`
+- **Docs**: [Kubernetes Pods](https://kubernetes.io/docs/concepts/workloads/pods/)
+- **Related**: [service.md](./service.md)

--- a/ai-docs/domain/kubernetes/pod.md
+++ b/ai-docs/domain/kubernetes/pod.md
@@ -318,13 +318,27 @@ status:
 4. **Non-root user**: Security best practice
 5. **Immutable image tags**: Use SHA256 or semantic versions, not `latest`
 
+### OpenShift Platform Component Guidance
+
+**For operators and platform operands**:
+- ✅ **Always set resource requests**: Required for scheduling
+- ❌ **Avoid resource limits**: Cannot set reasonable limits that work across all cluster sizes
+  - 10-node cluster vs 1000-node cluster have vastly different requirements
+  - Limits appropriate for small clusters cause OOMKills in large clusters
+  - Requests ensure fair scheduling; limits risk availability
+
+**For user workloads**:
+- ✅ Set both requests and limits based on known application requirements
+
 ## Antipatterns
 
-❌ **No resource limits**: Can consume all node resources  
+❌ **No resource requests**: Prevents proper scheduling (always set requests)  
 ❌ **No health probes**: Broken pods stay in service  
 ❌ **Running as root**: Security risk  
 ❌ **Host network for app pods**: Breaks network isolation  
 ❌ **Local storage for stateful data**: Lost on pod deletion
+
+**Note**: For user workloads, also avoid missing resource limits. For OpenShift platform components, limits are intentionally omitted (see best practices above).
 
 ## References
 

--- a/ai-docs/domain/kubernetes/service.md
+++ b/ai-docs/domain/kubernetes/service.md
@@ -1,0 +1,383 @@
+# Service
+
+**Category**: Kubernetes Core API  
+**API Group**: core/v1  
+**Last Updated**: 2026-04-29  
+
+## Overview
+
+Service provides stable networking for pods. It acts as a load balancer and service discovery mechanism.
+
+**Key Principle**: Pods are ephemeral, Services are stable.
+
+## Key Fields
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
+  selector:
+    app: my-app
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80        # Service port
+    targetPort: 8080 # Pod port
+  sessionAffinity: None
+status:
+  loadBalancer: {}
+```
+
+## Service Types
+
+| Type | Accessibility | Use Case |
+|------|--------------|----------|
+| **ClusterIP** | Internal only | Inter-service communication |
+| **NodePort** | External (node IP:port) | Development, testing |
+| **LoadBalancer** | External (cloud LB) | Production external access |
+| **ExternalName** | DNS CNAME | External service alias |
+
+## ClusterIP (Default)
+
+**Purpose**: Internal service discovery
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**Access**: `http://backend.default.svc.cluster.local:80`
+
+## NodePort
+
+**Purpose**: Expose service on each node's IP
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+    nodePort: 30080  # Optional (auto-assigned if omitted)
+```
+
+**Access**: `http://<node-ip>:30080`
+
+## LoadBalancer
+
+**Purpose**: Cloud provider load balancer
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-lb
+spec:
+  type: LoadBalancer
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**Status**:
+```yaml
+status:
+  loadBalancer:
+    ingress:
+    - ip: 203.0.113.5  # External IP
+```
+
+## Selectors and Endpoints
+
+**Service selects pods by labels**:
+
+```yaml
+# Service
+spec:
+  selector:
+    app: my-app
+    version: v1
+
+# Matching Pod
+metadata:
+  labels:
+    app: my-app
+    version: v1
+```
+
+**Endpoints (auto-created)**:
+```bash
+$ oc get endpoints my-service
+NAME         ENDPOINTS                     AGE
+my-service   10.128.0.5:8080,10.128.0.6:8080   5m
+```
+
+## Headless Service
+
+**Purpose**: Direct pod-to-pod DNS (no load balancing)
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-headless
+spec:
+  clusterIP: None  # Headless
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**DNS**: Returns pod IPs, not service IP
+```bash
+nslookup my-headless.default.svc.cluster.local
+# Returns: 10.128.0.5, 10.128.0.6 (pod IPs)
+```
+
+## Session Affinity
+
+```yaml
+spec:
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600
+```
+
+**Effect**: Same client IP always routed to same pod
+
+## Multiple Ports
+
+```yaml
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+```
+
+## Named Ports
+
+```yaml
+# Pod
+spec:
+  containers:
+  - name: app
+    ports:
+    - name: http
+      containerPort: 8080
+
+# Service (references named port)
+spec:
+  ports:
+  - port: 80
+    targetPort: http  # Port name, not number
+```
+
+## ExternalName
+
+**Purpose**: Alias for external service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-db
+spec:
+  type: ExternalName
+  externalName: db.example.com
+```
+
+**Access**: `external-db.default.svc.cluster.local` → `db.example.com`
+
+## Service Discovery
+
+### DNS
+
+```bash
+# Same namespace
+curl http://my-service
+
+# Different namespace
+curl http://my-service.other-namespace
+
+# Fully qualified
+curl http://my-service.other-namespace.svc.cluster.local
+```
+
+### Environment Variables
+
+```bash
+# Kubernetes injects for services in same namespace
+MY_SERVICE_SERVICE_HOST=10.96.0.5
+MY_SERVICE_SERVICE_PORT=80
+```
+
+## Common Patterns
+
+### Internal API Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: my-app
+spec:
+  type: ClusterIP
+  selector:
+    component: api
+  ports:
+  - port: 8080
+```
+
+### External Load Balancer
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+  type: LoadBalancer
+  selector:
+    component: frontend
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+### StatefulSet Headless Service
+
+```yaml
+# Headless service for StatefulSet
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  clusterIP: None
+  selector:
+    app: mysql
+  ports:
+  - port: 3306
+```
+
+**DNS**: Each pod gets stable DNS: `mysql-0.mysql.default.svc.cluster.local`
+
+## Debugging
+
+```bash
+# View service
+oc get svc my-service
+
+# Check endpoints
+oc get endpoints my-service
+
+# Describe (shows events)
+oc describe svc my-service
+
+# Test connectivity
+oc run test --rm -it --image=busybox -- wget -O- http://my-service
+
+# Check DNS
+oc run test --rm -it --image=busybox -- nslookup my-service
+```
+
+## Common Issues
+
+### No Endpoints
+
+```bash
+$ oc get endpoints my-service
+NAME         ENDPOINTS   AGE
+my-service   <none>      5m
+```
+
+**Causes**:
+- Selector doesn't match any pods
+- Pods not ready (readiness probe failing)
+- Pods in different namespace
+
+**Fix**: Check selector and pod labels match
+
+### Service Not Accessible
+
+**Checks**:
+1. Endpoints exist? `oc get endpoints`
+2. Pods ready? `oc get pods`
+3. Network policy blocking? `oc get networkpolicy`
+4. Firewall rules? (cloud provider)
+
+## OpenShift-Specific
+
+### Routes (External Access)
+
+```yaml
+# OpenShift Route (Layer 7 load balancing)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: my-route
+spec:
+  to:
+    kind: Service
+    name: my-service
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+```
+
+**Access**: `https://my-route-default.apps.cluster.example.com`
+
+## Best Practices
+
+1. **Use ClusterIP for internal**: Don't expose unnecessarily
+2. **Name ports**: Enables changing port numbers without updating service
+3. **Use Routes for external**: OpenShift Routes > NodePort for production
+4. **Set readiness probe**: Unhealthy pods excluded from endpoints
+5. **Use headless for StatefulSets**: Stable DNS per pod
+
+## Antipatterns
+
+❌ **NodePort for production**: Use LoadBalancer or Route instead  
+❌ **Selector matching all pods**: Too broad, wrong pods selected  
+❌ **No port names**: Hard to understand multi-port services  
+❌ **Hardcoded IPs**: Use DNS names instead  
+❌ **LoadBalancer for internal**: Expensive, use ClusterIP
+
+## References
+
+- **API**: `oc explain service`
+- **Docs**: [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- **OpenShift**: [Routes](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html)
+- **Related**: [pod.md](./pod.md)

--- a/ai-docs/domain/openshift/clusteroperator.md
+++ b/ai-docs/domain/openshift/clusteroperator.md
@@ -33,15 +33,16 @@ status:
     reason: AsExpected
     message: "All 3 pods are ready"
     lastTransitionTime: "2026-04-28T10:00:00Z"
-    lastHeartbeatTime: "2026-04-28T10:05:00Z"
   - type: Progressing
     status: "False"
     reason: AsExpected
     message: "Desired state reached"
+    lastTransitionTime: "2026-04-28T10:00:00Z"
   - type: Degraded
     status: "False"
     reason: AsExpected
     message: "Component is healthy"
+    lastTransitionTime: "2026-04-28T10:00:00Z"
   - type: Upgradeable
     status: "True"
     reason: AsExpected
@@ -85,17 +86,19 @@ See [status-conditions.md](../../platform/operator-patterns/status-conditions.md
 Component start:
   1. Create ClusterOperator (if not exists)
   2. Set all conditions (Available, Progressing, Degraded)
-  3. Update heartbeat every ~60s
 
 Normal operation:
   1. Update conditions when state changes
-  2. Update heartbeat regularly
+  2. Update lastTransitionTime only when condition status changes
 
 Upgrade:
   1. CVO updates operator image
-  2. Operator sets Progressing=True
-  3. Operator rolls out new workload
-  4. Operator sets Progressing=False, updates versions
+  2. Operator reconciles and detects version change
+  3. Operator sets Progressing=True (if rollout needed)
+  4. Operator rolls out new workload (if applicable)
+  5. Operator sets Progressing=False, updates versions
+
+Note: Some upgrades only require image updates without rollout (Progressing may stay False).
 ```
 
 ## Monitoring
@@ -192,20 +195,13 @@ status:
 
 ```promql
 # Alert on unavailable component
-ALERT ClusterOperatorUnavailable
-  IF cluster_operator_conditions{type="Available", status="False"} == 1
-  FOR 15m
-  
-# Alert on degraded component
-ALERT ClusterOperatorDegraded
-  IF cluster_operator_conditions{type="Degraded", status="True"} == 1
-  FOR 15m
+cluster_operator_conditions{condition="Available"} == 0
 
-# Alert on stale heartbeat
-ALERT ClusterOperatorStale
-  IF (time() - cluster_operator_conditions_last_heartbeat) > 300
-  FOR 5m
+# Alert on degraded component
+cluster_operator_conditions{condition="Degraded"} == 1
 ```
+
+**Note**: The metric uses numeric values (0 = False, 1 = True) and `condition` label (not `type`). See [CVO metrics documentation](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/metrics.md) for full metric definition.
 
 ## Common ClusterOperators
 
@@ -222,13 +218,7 @@ ALERT ClusterOperatorStale
 
 1. **Always set all conditions**: Available, Progressing, Degraded must always be present
 
-2. **Update heartbeat regularly**: Every 60s even if nothing changed
-   ```go
-   setCondition(&co.Status.Conditions, type, status, reason, message)
-   // Updates LastHeartbeatTime automatically
-   ```
-
-3. **Use Upgradeable to block**: Set to False when upgrade would break
+2. **Use Upgradeable to block**: Set to False when upgrade would break
    ```yaml
    - type: Upgradeable
      status: "False"
@@ -236,7 +226,7 @@ ALERT ClusterOperatorStale
      message: "Manual intervention required"
    ```
 
-4. **Set RelatedObjects**: Help debugging
+3. **Set RelatedObjects**: Help debugging
    ```yaml
    relatedObjects:
    - resource: namespaces
@@ -246,9 +236,9 @@ ALERT ClusterOperatorStale
 ## Antipatterns
 
 ❌ **Missing conditions**: Not setting Available/Progressing/Degraded  
-❌ **Stale heartbeat**: Not updating LastHeartbeatTime  
 ❌ **Vague messages**: "Error" instead of "Pod xyz crash looping: OOMKilled"  
-❌ **Wrong Available semantics**: Setting False during normal upgrade
+❌ **Wrong Available semantics**: Setting False during normal upgrade  
+❌ **Unnecessary updates**: Updating conditions when nothing has changed (wasteful reconciliation)
 
 ## References
 

--- a/ai-docs/domain/openshift/clusteroperator.md
+++ b/ai-docs/domain/openshift/clusteroperator.md
@@ -1,0 +1,258 @@
+# ClusterOperator
+
+**Category**: OpenShift Platform API  
+**API Group**: config.openshift.io/v1  
+**Last Updated**: 2026-05-26
+**Scope**: All form factors (see HCP note below)
+
+## Overview
+
+ClusterOperator represents the status of a platform component. Every core OpenShift component reports its health via a ClusterOperator resource.
+
+**Purpose**: Centralized health monitoring and upgrade orchestration.
+
+**⚠️ Form Factor Note**: In **Hypershift/HCP**, ClusterOperators exist in **both** clusters:
+- **Guest cluster**: Platform components serving the hosted cluster (same as standalone)
+- **Management cluster**: HyperShift platform components managing hosted control planes
+- The CVO in the **guest** cluster watches ClusterOperators in the guest cluster
+
+See [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) for authoritative details on CVO placement in HCP.
+
+## Key Fields
+
+```yaml
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: kube-apiserver
+spec: {}  # ClusterOperator has no spec
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+    message: "All 3 pods are ready"
+    lastTransitionTime: "2026-04-28T10:00:00Z"
+    lastHeartbeatTime: "2026-04-28T10:05:00Z"
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+    message: "Desired state reached"
+  - type: Degraded
+    status: "False"
+    reason: AsExpected
+    message: "Component is healthy"
+  - type: Upgradeable
+    status: "True"
+    reason: AsExpected
+    message: "Ready for upgrade"
+  versions:
+  - name: operator
+    version: 4.16.0
+  - name: kube-apiserver
+    version: 1.29.5
+  relatedObjects:
+  - group: ""
+    resource: namespaces
+    name: openshift-kube-apiserver
+  - group: apps
+    resource: deployments
+    namespace: openshift-kube-apiserver
+    name: kube-apiserver
+```
+
+## Key Concepts
+
+- **Conditions**: Available, Progressing, Degraded, Upgradeable
+- **Versions**: Operator version and operand versions
+- **RelatedObjects**: Resources managed by this operator
+- **Read-Only**: ClusterOperator has no spec (status only)
+
+## Required Conditions
+
+| Condition | Meaning | True When | False When |
+|-----------|---------|-----------|------------|
+| **Available** | Component functional | Pods ready, API serving | Pods not ready, API down |
+| **Progressing** | Reconciliation in progress | Upgrade/rollout active | Desired state reached |
+| **Degraded** | Impaired functionality | Partial failure | Fully healthy |
+| **Upgradeable** | Safe to upgrade | No blockers | Manual intervention needed |
+
+See [status-conditions.md](../../platform/operator-patterns/status-conditions.md) for detailed semantics.
+
+## Lifecycle
+
+```
+Component start:
+  1. Create ClusterOperator (if not exists)
+  2. Set all conditions (Available, Progressing, Degraded)
+  3. Update heartbeat every ~60s
+
+Normal operation:
+  1. Update conditions when state changes
+  2. Update heartbeat regularly
+
+Upgrade:
+  1. CVO updates operator image
+  2. Operator sets Progressing=True
+  3. Operator rolls out new workload
+  4. Operator sets Progressing=False, updates versions
+```
+
+## Monitoring
+
+```bash
+# View all ClusterOperators
+oc get clusteroperators
+
+# View specific operator
+oc get clusteroperator kube-apiserver -o yaml
+
+# Check degraded operators
+oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Degraded" and .status=="True")) | .metadata.name'
+
+# Check upgrade progress
+oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
+```
+
+## Creating ClusterOperator
+
+```go
+import (
+    configv1 "github.com/openshift/api/config/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ensureClusterOperator(ctx context.Context, client client.Client, name string) error {
+    co := &configv1.ClusterOperator{
+        ObjectMeta: metav1.ObjectMeta{
+            Name: name,
+        },
+    }
+    
+    _, err := controllerutil.CreateOrUpdate(ctx, client, co, func() error {
+        // Set conditions
+        setCondition(&co.Status.Conditions,
+            configv1.OperatorAvailable,
+            configv1.ConditionTrue,
+            "AsExpected",
+            "Component is available")
+        
+        // Set versions
+        co.Status.Versions = []configv1.OperandVersion{
+            {Name: "operator", Version: os.Getenv("RELEASE_VERSION")},
+        }
+        
+        // Set related objects
+        co.Status.RelatedObjects = []configv1.ObjectReference{
+            {
+                Group:    "",
+                Resource: "namespaces",
+                Name:     "my-operator-namespace",
+            },
+        }
+        
+        return nil
+    })
+    
+    return err
+}
+```
+
+## Versions
+
+```yaml
+status:
+  versions:
+  - name: operator
+    version: 4.16.0
+  - name: etcd
+    version: 3.5.12
+```
+
+**Operator version**: Version of the operator itself  
+**Operand versions**: Versions of managed components
+
+## RelatedObjects
+
+```yaml
+status:
+  relatedObjects:
+  - group: ""
+    resource: namespaces
+    name: openshift-kube-apiserver
+  - group: apps
+    resource: deployments
+    namespace: openshift-kube-apiserver
+    name: kube-apiserver
+```
+
+**Purpose**: Help must-gather and debugging tools find related resources.
+
+## Alerts
+
+```promql
+# Alert on unavailable component
+ALERT ClusterOperatorUnavailable
+  IF cluster_operator_conditions{type="Available", status="False"} == 1
+  FOR 15m
+  
+# Alert on degraded component
+ALERT ClusterOperatorDegraded
+  IF cluster_operator_conditions{type="Degraded", status="True"} == 1
+  FOR 15m
+
+# Alert on stale heartbeat
+ALERT ClusterOperatorStale
+  IF (time() - cluster_operator_conditions_last_heartbeat) > 300
+  FOR 5m
+```
+
+## Common ClusterOperators
+
+| Name | Component | Purpose |
+|------|-----------|---------|
+| kube-apiserver | Kubernetes API | API server availability |
+| etcd | etcd cluster | Data store health |
+| kube-controller-manager | KCM | Controller health |
+| machine-api | Machine API | Node provisioning |
+| cluster-network-operator | Networking | SDN/OVN health |
+| cluster-version | CVO | Upgrade orchestration |
+
+## Best Practices
+
+1. **Always set all conditions**: Available, Progressing, Degraded must always be present
+
+2. **Update heartbeat regularly**: Every 60s even if nothing changed
+   ```go
+   setCondition(&co.Status.Conditions, type, status, reason, message)
+   // Updates LastHeartbeatTime automatically
+   ```
+
+3. **Use Upgradeable to block**: Set to False when upgrade would break
+   ```yaml
+   - type: Upgradeable
+     status: "False"
+     reason: UnsupportedConfiguration
+     message: "Manual intervention required"
+   ```
+
+4. **Set RelatedObjects**: Help debugging
+   ```yaml
+   relatedObjects:
+   - resource: namespaces
+     name: my-operator-namespace
+   ```
+
+## Antipatterns
+
+❌ **Missing conditions**: Not setting Available/Progressing/Degraded  
+❌ **Stale heartbeat**: Not updating LastHeartbeatTime  
+❌ **Vague messages**: "Error" instead of "Pod xyz crash looping: OOMKilled"  
+❌ **Wrong Available semantics**: Setting False during normal upgrade
+
+## References
+
+- **API**: `oc explain clusteroperator`
+- **Source**: [github.com/openshift/api/config/v1](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go)
+- **Dev Guide**: [ClusterOperator Guidelines](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md)
+- **Pattern**: [status-conditions.md](../../platform/operator-patterns/status-conditions.md)

--- a/ai-docs/domain/openshift/clusterversion.md
+++ b/ai-docs/domain/openshift/clusterversion.md
@@ -1,0 +1,286 @@
+# ClusterVersion
+
+**Category**: OpenShift Platform API  
+**API Group**: config.openshift.io/v1  
+**Last Updated**: 2026-05-26
+**Scope**: All form factors (see HCP note below)
+
+## Overview
+
+ClusterVersion represents the desired and current version of the OpenShift cluster. The Cluster Version Operator (CVO) watches this resource and orchestrates upgrades.
+
+**Singleton**: Only one ClusterVersion exists, named `version`.
+
+**⚠️ Form Factor Note**: In **Hypershift/HCP**:
+- ClusterVersion exists in the **guest cluster** (not management cluster)
+- The CVO runs in the **guest cluster** and manages guest cluster components
+- The **management cluster** uses HyperShift's `HostedCluster` API instead
+- Control plane and guest cluster have separate version lifecycles
+
+See [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) for authoritative details on HCP version tracking.
+
+## Key Fields
+
+```yaml
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version  # Always "version"
+spec:
+  channel: stable-4.16
+  clusterID: a1b2c3d4-5678-90ab-cdef-1234567890ab
+  desiredUpdate:
+    version: 4.16.1
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
+status:
+  availableUpdates:
+  - version: 4.16.1
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  - version: 4.16.2
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+  desired:
+    version: 4.16.0
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  history:
+  - state: Completed
+    version: 4.16.0
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+    startedTime: "2026-04-01T10:00:00Z"
+    completionTime: "2026-04-01T11:30:00Z"
+  observedGeneration: 5
+  versionHash: abc123def456
+```
+
+## Key Concepts
+
+- **Desired Update**: Target version set by admin
+- **Available Updates**: Valid upgrade paths from upstream
+- **History**: Past upgrade attempts and outcomes
+- **Channel**: Update stream (stable, fast, candidate, eus)
+- **CVO**: Cluster Version Operator orchestrates the upgrade
+
+## Upgrade Flow
+
+```
+1. Admin sets spec.desiredUpdate
+   ↓
+2. CVO validates update (N→N+1, supported path)
+   ↓
+3. CVO sets status.conditions.Progressing=True
+   ↓
+4. CVO updates operators in order:
+   - etcd
+   - kube-apiserver
+   - kube-controller-manager
+   - kube-scheduler
+   - other operators (parallel)
+   ↓
+5. Each operator reports Progressing=True → False
+   ↓
+6. CVO sets status.conditions.Progressing=False
+   ↓
+7. CVO adds entry to status.history
+```
+
+## Channels
+
+| Channel | Purpose | Update Frequency |
+|---------|---------|------------------|
+| **stable-X.Y** | Production | After candidate soak |
+| **fast-X.Y** | Early adopters | Weekly |
+| **candidate-X.Y** | Pre-release testing | Daily |
+| **eus-X.Y** | Extended Update Support | Long-term stable |
+
+**Example**: `stable-4.16`, `fast-4.17`, `eus-4.14`
+
+## Triggering Upgrade
+
+```bash
+# View current version
+oc get clusterversion
+
+# View available updates
+oc adm upgrade
+
+# Start upgrade to specific version
+oc adm upgrade --to=4.16.1
+
+# Start upgrade to latest
+oc adm upgrade --to-latest
+```
+
+## Monitoring Upgrade
+
+```bash
+# Watch upgrade progress
+oc get clusterversion -w
+
+# View operator status
+oc get clusteroperators
+
+# View progressing operators
+oc get co -o json | jq -r '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
+
+# View CVO logs
+oc logs -n openshift-cluster-version deployment/cluster-version-operator
+```
+
+## Upgrade Policies
+
+### Version Skew
+
+- **Supported**: N → N+1 (e.g., 4.15 → 4.16)
+- **Not supported**: N → N+2 (e.g., 4.14 → 4.16)
+- **EUS exception**: EUS releases allow skipping one version
+
+### Upgrade Paths
+
+```yaml
+# Valid upgrade graph
+4.14.0 → 4.14.1 → 4.14.2
+  ↓         ↓         ↓
+4.15.0 ← 4.15.1 ← 4.15.2
+  ↓         ↓         ↓
+4.16.0 ← 4.16.1 ← 4.16.2
+```
+
+**CVO validates**: Upgrade path exists in Cincinnati graph
+
+## Pausing Upgrades
+
+```bash
+# Pause cluster upgrades (for maintenance)
+oc adm upgrade --pause
+
+# Resume upgrades
+oc adm upgrade --resume
+```
+
+## Upgrade Conditions
+
+| Condition | Meaning | True When |
+|-----------|---------|-----------|
+| **Available** | CVO is functional | CVO pod running |
+| **Progressing** | Upgrade in progress | Operators being updated |
+| **Failing** | Upgrade failed | Operator reconciliation failed |
+| **RetrievedUpdates** | Update graph fetched | Cincinnati API reachable |
+
+## History
+
+```yaml
+status:
+  history:
+  - state: Completed
+    version: 4.16.0
+    completionTime: "2026-04-01T11:30:00Z"
+  - state: Completed
+    version: 4.15.5
+    completionTime: "2026-03-01T10:00:00Z"
+  - state: Partial
+    version: 4.15.4
+    startedTime: "2026-02-15T09:00:00Z"
+    # No completionTime = upgrade failed/rolled back
+```
+
+**States**: Completed, Partial
+
+## CVO Operator Ordering
+
+```yaml
+# manifests/0000_*.yaml files in release image
+0000_00_cluster-version-operator_*.yaml
+0000_50_cluster-etcd-operator_*.yaml
+0000_60_cluster-kube-apiserver-operator_*.yaml
+0000_70_cluster-kube-controller-manager-operator_*.yaml
+0000_80_cluster-kube-scheduler-operator_*.yaml
+0000_90_*  # All other operators (parallel)
+```
+
+**Ordering ensures**: etcd → API server → controllers → operators
+
+## Overrides
+
+```yaml
+spec:
+  overrides:
+  - kind: Deployment
+    name: my-operator
+    namespace: openshift-my-operator
+    unmanaged: true  # CVO won't update this
+```
+
+**Use case**: Prevent CVO from managing specific resources (debugging only)
+
+## Examples
+
+### View ClusterVersion
+
+```bash
+$ oc get clusterversion version -o yaml
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.16
+  clusterID: abc-123
+status:
+  desired:
+    version: 4.16.0
+  history:
+  - state: Completed
+    version: 4.16.0
+```
+
+### Upgrade Status
+
+```bash
+$ oc get clusterversion
+NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
+version   4.16.0    True        False         5h      Cluster version is 4.16.0
+```
+
+## Best Practices
+
+1. **Use Recommended Updates**: CVO validates upgrade paths
+   ```bash
+   oc adm upgrade  # Shows recommended updates only
+   ```
+
+2. **Monitor Operator Health Before Upgrade**:
+   ```bash
+   oc get co | grep -v "True.*False.*False"
+   ```
+
+3. **Check Upgrade Graph**: Ensure path exists
+   ```bash
+   oc adm upgrade --to=4.16.1  # Validates before starting
+   ```
+
+4. **Watch Operator Progress**: Don't interrupt during upgrade
+   ```bash
+   watch oc get co
+   ```
+
+## Antipatterns
+
+❌ **Version skipping**: 4.14 → 4.16 (use intermediate version)  
+❌ **Upgrading degraded cluster**: Fix issues first  
+❌ **Manual operator updates**: Always use CVO  
+❌ **Interrupting upgrade**: Can leave cluster in inconsistent state
+
+## References
+
+- **API**: `oc explain clusterversion`
+- **Source**: [github.com/openshift/api/config/v1](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go)
+- **CVO**: [cluster-version-operator](https://github.com/openshift/cluster-version-operator)
+- **Docs**: [Updating Clusters](https://docs.openshift.com/container-platform/latest/updating/index.html)
+- **Pattern**: [upgrade-strategies.md](../../platform/openshift-specifics/upgrade-strategies.md)

--- a/ai-docs/domain/openshift/clusterversion.md
+++ b/ai-docs/domain/openshift/clusterversion.md
@@ -12,10 +12,12 @@ ClusterVersion represents the desired and current version of the OpenShift clust
 **Singleton**: Only one ClusterVersion exists, named `version`.
 
 **⚠️ Form Factor Note**: In **Hypershift/HCP**:
-- ClusterVersion exists in the **guest cluster** (not management cluster)
-- The CVO runs in the **guest cluster** and manages guest cluster components
-- The **management cluster** uses HyperShift's `HostedCluster` API instead
-- Control plane and guest cluster have separate version lifecycles
+- **Guest cluster**: Has ClusterVersion (managed by CVO running in guest cluster)
+- **Management cluster**: Has its own separate ClusterVersion (for management cluster infrastructure)
+- **HostedCluster API** (in management cluster): Drives version upgrades for the guest cluster
+  - `HostedClusterStatus.Version` reflects CVO-reported state from guest cluster
+  - Control plane pods run in management cluster but serve the guest cluster
+- Control plane (management-side) and data plane (guest cluster) have **independent** version lifecycles
 
 See [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) for authoritative details on HCP version tracking.
 
@@ -76,18 +78,20 @@ status:
    ↓
 3. CVO sets status.conditions.Progressing=True
    ↓
-4. CVO updates operators in order:
-   - etcd
-   - kube-apiserver
-   - kube-controller-manager
-   - kube-scheduler
-   - other operators (parallel)
+4. CVO applies manifests in runlevel order:
+   - Runlevel 00-09: Core platform (network, DNS, certs)
+   - Runlevel 10-29: Kubernetes operators (API server, controllers, scheduler)
+   - Runlevel 30+: Other operators (Machine API, OLM, OpenShift core)
+   - Components at same runlevel apply in parallel
    ↓
-5. Each operator reports Progressing=True → False
+5. CVO waits for each operator to reach expected state:
+   - Operator version matches desired version
+   - Operator reports Progressing=False
+   - Operator reports Available=True
    ↓
-6. CVO sets status.conditions.Progressing=False
-   ↓
-7. CVO adds entry to status.history
+6. Once all operators reach expected state:
+   - CVO sets status.conditions.Progressing=False
+   - CVO adds entry to status.history with state=Completed
 ```
 
 ## Channels
@@ -138,31 +142,41 @@ oc logs -n openshift-cluster-version deployment/cluster-version-operator
 ### Version Skew
 
 - **Supported**: N → N+1 (e.g., 4.15 → 4.16)
-- **Not supported**: N → N+2 (e.g., 4.14 → 4.16)
-- **EUS exception**: EUS releases allow skipping one version
+- **Not supported**: N → N+2 version skips (e.g., 4.14 → 4.16)
+
+### EUS (Extended Update Support) Releases
+
+**What EUS provides:**
+- **Extended support lifecycle**: Designated releases receive ~14 months additional support
+  - **OCP 4.x**: Even-numbered releases (4.8, 4.10, 4.12, 4.14, 4.16, etc.)
+  - **OCP 5.x**: Every third release (5.2, 5.5, 5.8, etc.)
+- **EUS-to-EUS upgrade path**: Streamlined upgrade with reduced worker node reboots
+
+**What EUS does NOT provide:**
+- ❌ **Version skipping**: Must still upgrade sequentially through all intermediate versions
+- ❌ **Control plane version skipping**: Control plane goes through every version (4.12→4.13→4.14→4.15→4.16)
+
+**EUS-to-EUS upgrade process** (e.g., 4.12 to 4.16):
+1. Switch from `eus-4.12` channel to `eus-4.16` channel
+2. Cluster upgrades sequentially: 4.12 → 4.13 → 4.14 → 4.15 → 4.16
+3. Worker node reboots optimized (not control plane version steps)
+
+**References:**
+- [Red Hat OpenShift EUS Policy](https://access.redhat.com/support/policy/updates/openshift-eus) - Official EUS support policy
+- [EUS Upgrades MVP Enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/update/eus-upgrades-mvp.md) - "does not attempt to remove *any* steps along the serial upgrade path from 4.6 to 4.7 to 4.8 to 4.9 to 4.10"
 
 ### Upgrade Paths
 
 ```yaml
-# Valid upgrade graph
+# Valid upgrade graph (arrows show valid upgrade paths)
 4.14.0 → 4.14.1 → 4.14.2
   ↓         ↓         ↓
-4.15.0 ← 4.15.1 ← 4.15.2
+4.15.0 → 4.15.1 → 4.15.2
   ↓         ↓         ↓
-4.16.0 ← 4.16.1 ← 4.16.2
+4.16.0 → 4.16.1 → 4.16.2
 ```
 
 **CVO validates**: Upgrade path exists in Cincinnati graph
-
-## Pausing Upgrades
-
-```bash
-# Pause cluster upgrades (for maintenance)
-oc adm upgrade --pause
-
-# Resume upgrades
-oc adm upgrade --resume
-```
 
 ## Upgrade Conditions
 
@@ -194,17 +208,25 @@ status:
 
 ## CVO Operator Ordering
 
-```yaml
-# manifests/0000_*.yaml files in release image
-0000_00_cluster-version-operator_*.yaml
-0000_50_cluster-etcd-operator_*.yaml
-0000_60_cluster-kube-apiserver-operator_*.yaml
-0000_70_cluster-kube-controller-manager-operator_*.yaml
-0000_80_cluster-kube-scheduler-operator_*.yaml
-0000_90_*  # All other operators (parallel)
-```
+CVO applies manifests in lexicographic order by filename during upgrades. Manifests use the naming convention:
+`0000_<runlevel>_<component>_<manifest>.yaml`
 
-**Ordering ensures**: etcd → API server → controllers → operators
+**Assigned runlevels** (from [CVO dev docs](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md)):
+- **00-04**: CVO itself
+- **05**: cluster-config-operator
+- **07**: Network operator
+- **08**: DNS operator
+- **09**: Service certificate authority, machine approver
+- **10-29**: Kubernetes operators (e.g., kube-apiserver, kube-controller-manager, kube-scheduler)
+- **30-39**: Machine API
+- **50-59**: Operator Lifecycle Manager (OLM)
+- **60-69**: OpenShift core operators
+
+**Key behaviors**:
+- Components at same runlevel execute in **parallel**
+- Lower runlevels complete before higher runlevels start
+- Ordering only applies during **upgrades** (not initial install or reconciliation)
+- Within a component, manifests apply in alphabetical order
 
 ## Overrides
 
@@ -217,7 +239,13 @@ spec:
     unmanaged: true  # CVO won't update this
 ```
 
-**Use case**: Prevent CVO from managing specific resources (debugging only)
+**⚠️ WARNING**: 
+- Setting `unmanaged: true` prevents CVO from updating the resource
+- **Blocks cluster upgrades** until override is removed
+- Per [upgrade-acknowledgment-gate enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/update/upgrades-blocking-on-ack.md): "CVO currently blocks minor level upgrades when overrides are set"
+- Puts cluster in unsupported state
+- **Use only for emergency debugging**
+- Remove all overrides before attempting upgrades
 
 ## Examples
 

--- a/ai-docs/domain/openshift/index.md
+++ b/ai-docs/domain/openshift/index.md
@@ -1,0 +1,14 @@
+# OpenShift Domain Concepts
+
+Core OpenShift platform APIs.
+
+## APIs
+
+- [clusteroperator.md](clusteroperator.md) - Platform component status and health reporting
+- [clusterversion.md](clusterversion.md) - Cluster upgrade orchestration and version management
+
+## Related
+
+- **Full API reference**: `oc api-resources | grep openshift` 
+- **Field details**: `oc explain <resource>` (e.g., `oc explain clusteroperator`)
+- **Kubernetes APIs**: [../kubernetes/](../kubernetes/)

--- a/ai-docs/platform/openshift-specifics/upgrade-strategies.md
+++ b/ai-docs/platform/openshift-specifics/upgrade-strategies.md
@@ -32,19 +32,23 @@ OpenShift upgrades are orchestrated by the Cluster Version Operator (CVO). Every
 
 ## CVO Orchestration
 
+CVO applies manifests in lexicographic order by filename prefix during upgrades.
+
+**Runlevel ordering** (from [CVO dev docs](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md)):
 ```
-CVO upgrade order:
-1. etcd operator
-2. kube-apiserver operator
-3. kube-controller-manager operator
-4. kube-scheduler operator
-5. All other operators (parallel)
+Runlevel 00-09: Core platform (CVO, network, DNS, certs)
+Runlevel 10-29: Kubernetes operators (API server, controllers, scheduler)  
+Runlevel 30-39: Machine API
+Runlevel 50-59: Operator Lifecycle Manager
+Runlevel 60-69: OpenShift core operators
 ```
 
-**Why this order?**
-- etcd must be healthy before API server updates
-- API server must be upgraded before controllers (version skew)
-- Operators depend on API server, so upgrade last
+**Key behaviors**:
+- Components at same runlevel execute in **parallel**
+- Runlevel ordering provides deterministic apply sequence
+- Generally ensures core components are ready before dependent operators
+- **In practice**: Strict ordering rarely critical; most components tolerate version skew during upgrades
+- Ordering is conservative to handle rare edge cases, not strict runtime dependencies
 
 ## Implementation
 
@@ -52,19 +56,22 @@ CVO upgrade order:
 
 ```go
 func (r *Reconciler) checkUpgradeable(ctx context.Context) (bool, string, string) {
-    // Check if upgrade would be unsafe
+    // Check if upgrade would be unsafe based on current cluster state
     
-    // Example: Block if custom config is set
+    // Example: Block if unsupported configuration requires manual intervention
     if hasUnsupportedConfig() {
-        return false, "UnsupportedConfig", 
-            "Custom configuration detected, manual intervention required"
+        return false, "UnsupportedConfiguration", 
+            "Unsupported configuration requires manual steps before upgrade. See documentation for migration path."
     }
     
-    // Example: Block if degraded
-    if isDegraded() {
-        return false, "Degraded",
-            "Component is degraded, fix issues before upgrading"
+    // Example: Block if upgrade would fail due to missing prerequisites
+    if missingUpgradePrerequisites() {
+        return false, "MissingPrerequisites",
+            "Required migration steps not completed. Run 'oc adm upgrade --check' for details."
     }
+    
+    // Note: Degraded state alone should NOT set Upgradeable=False
+    // Only set Upgradeable=False if upgrade would make things worse or fail
     
     // Safe to upgrade
     return true, "AsExpected", "Ready for upgrade"
@@ -80,34 +87,48 @@ func (r *Reconciler) updateStatus(ctx context.Context, co *configv1.ClusterOpera
 }
 ```
 
-### Handling Version Skew
+### Handling Version Skew (Level-Driven Reconciliation)
 
 ```go
+// Level-driven: This reconcile function runs continuously (every N seconds or on watch events)
+// It always converges toward the desired state, not reacting to state changes
 func (r *Reconciler) reconcile(ctx context.Context, obj *MyResource) error {
-    // Get desired version from CVO
+    // Desired state (level): what should exist
     desiredVersion := os.Getenv("RELEASE_VERSION")
     
-    // Get current version from status
+    // Current state (level): what actually exists
     currentVersion := obj.Status.Version
     
+    // Continuous reconciliation: always ensure current matches desired
+    // This check runs on every reconcile loop, not just when version changes
     if desiredVersion != currentVersion {
-        // Upgrade in progress
-        if err := r.upgradeWorkload(ctx, obj, desiredVersion); err != nil {
+        // Converge toward desired state
+        if err := r.ensureVersion(ctx, obj, desiredVersion); err != nil {
+            // Requeue - will retry on next reconcile
             return err
         }
         
-        // Update status
+        // Update status to reflect progress
         obj.Status.Version = desiredVersion
         setCondition(&obj.Status.Conditions,
             configv1.OperatorProgressing,
             configv1.ConditionTrue,
             "RollingOut",
-            fmt.Sprintf("Upgrading to %s", desiredVersion))
+            fmt.Sprintf("Converging to %s", desiredVersion))
     }
     
-    return nil
+    // Continue reconciling other aspects - level-driven means
+    // we continuously ensure ALL desired state, not just version
+    return r.ensureWorkloadState(ctx, obj)
 }
+
+// ❌ Anti-pattern: Edge-driven (don't do this)
+// func (r *Reconciler) onVersionChange(old, new string) {
+//     // Only runs when version changes - misses corrections needed
+// }
 ```
+
+**Level-driven reconciliation pattern**: Per [controller-runtime documentation](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile), "Reconciliation is level-based, meaning action isn't driven off changes in individual Events, but instead is driven by actual cluster state read from the apiserver or a local cache." The reconcile function observes current state and continuously converges toward desired state, rather than reacting to specific events. This ensures idempotency and resilience—missed events are automatically corrected on the next reconcile loop.
 
 ### Rolling Update Pattern
 
@@ -194,23 +215,48 @@ type MyResourceSpec struct {
 }
 ```
 
-### Storage Version Migration
+### API Version Transitions (OpenShift Pattern)
+
+**OpenShift approach**: Transition API versions across OpenShift minor releases without serving multiple versions simultaneously (no conversion webhooks needed).
 
 ```yaml
-# Old version (v1alpha1)
-apiVersion: example.com/v1alpha1
-kind: MyResource
-spec:
-  field: value
+# Release N: Serve v1alpha1 only
+versions:
+- name: v1alpha1
+  served: true
+  storage: true
 
-# Hub version (v1)
-apiVersion: example.com/v1
-kind: MyResource
-spec:
-  newField: value
-
-# Use conversion webhooks to handle both
+# Release N+1: Introduce v1, serve both (read-only migration window)
+versions:
+- name: v1
+  served: true
+  storage: true  # New storage version
+- name: v1alpha1
+  served: true   # Still served for read
+  storage: false
+  deprecated: true
+  
+# Release N+2: Stop serving v1alpha1
+versions:
+- name: v1
+  served: true
+  storage: true
+- name: v1alpha1
+  served: false   # No longer served
+  storage: false
 ```
+
+**Migration steps**:
+1. Release N+1: Change storage version, mark old version deprecated
+2. During N+1: All writes go to new version, reads accepted from both
+3. Existing objects migrated during upgrade (touched objects auto-convert)
+4. Release N+2: Stop serving old version entirely
+
+**OpenShift avoids**:
+- ❌ Conversion webhooks (adds complexity, rarely needed)
+- ❌ Serving multiple versions long-term (increases API surface)
+
+See [API evolution](../../practices/development/api-evolution.md) for version transition patterns.
 
 ## Node Upgrades
 
@@ -243,12 +289,28 @@ oc get clusteroperators
 oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
 ```
 
+## Control Plane Upgrade Pattern
+
+**Static Pod + PDB Guard Pattern**: All control plane components use this pattern for upgrades:
+
+1. **Static pod** runs the actual component (etcd, kube-apiserver, kube-controller-manager, kube-scheduler)
+2. **Guard pod** (Deployment) mirrors the static pod state
+3. **PodDisruptionBudget** on guard pod prevents node drain if it would violate availability
+4. Ensures at least N-1 replicas available during node upgrades
+
+**Why this pattern?**
+- Control plane runs as static pods (not managed by scheduler)
+- PDB only works on pods managed by controllers (Deployment, StatefulSet)
+- Guard pods enable PDB protection for static pods
+
 ## Examples in Components
 
 | Component | Upgrade Strategy | Notes |
 |-----------|------------------|-------|
-| etcd | One pod at a time, quorum maintained | Must maintain 2/3 quorum |
-| kube-apiserver | Rolling update, PDB ensures 1+ available | Uses PodDisruptionBudget |
+| etcd | Static pod + PDB guard | Must maintain quorum (2/3 pods) |
+| kube-apiserver | Static pod + PDB guard | PDB ensures 1+ available |
+| kube-controller-manager | Static pod + PDB guard | Same pattern as above |
+| kube-scheduler | Static pod + PDB guard | Same pattern as above |
 | machine-config-operator | Node drain → reboot → uncordon | Can take 30+ minutes per node |
 | cluster-network-operator | Update CNI plugins in rolling fashion | Brief network interruptions possible |
 
@@ -325,9 +387,30 @@ HCP:
 ```
 
 **Design Considerations**:
-- Accept brief downtime during upgrades (unavoidable in SNO)
+- **Platform operator downtime**: Acceptable during node reboot (unavoidable in SNO)
+- **User-facing services** (ingress, router): Aim to minimize interruption
+  - Use graceful shutdown patterns
+  - Pre-pull images to reduce restart time
+  - Minimize unavailability window
 - Ensure rapid reconciliation after reboot
 - Test with `replica: 1` configurations
+
+### HA Cluster Upgrade Expectations
+
+**For HA (3+ control plane node) clusters**:
+
+- **Platform operators**: Brief downtime acceptable during rollout
+  - Operators can restart/upgrade one at a time
+  - Controller temporarily unavailable (reconciliation paused)
+  
+- **User-facing services** (ingress, router, load balancers): **Zero downtime expected**
+  - Must use PodDisruptionBudgets
+  - Rolling updates with N-1 available
+  - Graceful connection draining
+  
+- **Application workloads**: Should not experience interruption
+  - Proper PDB configuration required
+  - Applications must handle pod churn
 
 ### MicroShift Considerations
 

--- a/ai-docs/platform/openshift-specifics/upgrade-strategies.md
+++ b/ai-docs/platform/openshift-specifics/upgrade-strategies.md
@@ -1,0 +1,355 @@
+# Upgrade Strategies
+
+**Category**: OpenShift-Specific Pattern  
+**Applies To**: All ClusterOperators  
+**Last Updated**: 2026-05-26
+**Scope**: Primarily standalone clusters; see [HCP Differences](#hypershift--hosted-control-planes-hcp) section
+
+## Overview
+
+OpenShift upgrades are orchestrated by the Cluster Version Operator (CVO). Every operator must support N→N+1 version skew and coordinate with CVO for zero-downtime upgrades.
+
+**Goal**: Upgrade 1000-node cluster with zero application downtime.
+
+**⚠️ Form Factor Note**: This document describes upgrade behavior in **standalone OpenShift clusters** (self-hosted control plane). For Hypershift/HCP deployments, control plane and data plane upgrade separately—see the HCP section below.
+
+## Key Concepts
+
+- **CVO Ordering**: etcd → kube-apiserver → kube-controller-manager → operators
+- **Version Skew**: N→N+1 support (current and next minor version)
+- **Progressing Condition**: Signals upgrade in progress
+- **Upgradeable Condition**: Blocks upgrade if False
+- **Rolling Updates**: Update nodes one at a time
+
+## Upgrade Phases
+
+| Phase | CVO Action | Operator Responsibility |
+|-------|-----------|------------------------|
+| **Pre-upgrade** | Check Upgradeable=True | Set Upgradeable=False if unsafe |
+| **Upgrade** | Update operator image | Reconcile new version |
+| **Rollout** | Wait for Progressing=False | Update workloads, report progress |
+| **Post-upgrade** | Verify Available=True | Resume normal operation |
+
+## CVO Orchestration
+
+```
+CVO upgrade order:
+1. etcd operator
+2. kube-apiserver operator
+3. kube-controller-manager operator
+4. kube-scheduler operator
+5. All other operators (parallel)
+```
+
+**Why this order?**
+- etcd must be healthy before API server updates
+- API server must be upgraded before controllers (version skew)
+- Operators depend on API server, so upgrade last
+
+## Implementation
+
+### Setting Upgradeable Condition
+
+```go
+func (r *Reconciler) checkUpgradeable(ctx context.Context) (bool, string, string) {
+    // Check if upgrade would be unsafe
+    
+    // Example: Block if custom config is set
+    if hasUnsupportedConfig() {
+        return false, "UnsupportedConfig", 
+            "Custom configuration detected, manual intervention required"
+    }
+    
+    // Example: Block if degraded
+    if isDegraded() {
+        return false, "Degraded",
+            "Component is degraded, fix issues before upgrading"
+    }
+    
+    // Safe to upgrade
+    return true, "AsExpected", "Ready for upgrade"
+}
+
+func (r *Reconciler) updateStatus(ctx context.Context, co *configv1.ClusterOperator) {
+    upgradeable, reason, msg := r.checkUpgradeable(ctx)
+    
+    setCondition(&co.Status.Conditions,
+        configv1.OperatorUpgradeable,
+        boolToStatus(upgradeable),
+        reason, msg)
+}
+```
+
+### Handling Version Skew
+
+```go
+func (r *Reconciler) reconcile(ctx context.Context, obj *MyResource) error {
+    // Get desired version from CVO
+    desiredVersion := os.Getenv("RELEASE_VERSION")
+    
+    // Get current version from status
+    currentVersion := obj.Status.Version
+    
+    if desiredVersion != currentVersion {
+        // Upgrade in progress
+        if err := r.upgradeWorkload(ctx, obj, desiredVersion); err != nil {
+            return err
+        }
+        
+        // Update status
+        obj.Status.Version = desiredVersion
+        setCondition(&obj.Status.Conditions,
+            configv1.OperatorProgressing,
+            configv1.ConditionTrue,
+            "RollingOut",
+            fmt.Sprintf("Upgrading to %s", desiredVersion))
+    }
+    
+    return nil
+}
+```
+
+### Rolling Update Pattern
+
+```go
+func (r *Reconciler) upgradeDeployment(ctx context.Context, desired *appsv1.Deployment) error {
+    current := &appsv1.Deployment{}
+    err := r.Get(ctx, client.ObjectKeyFromObject(desired), current)
+    
+    if err != nil {
+        return err
+    }
+    
+    // Update with RollingUpdate strategy
+    desired.Spec.Strategy = appsv1.DeploymentStrategy{
+        Type: appsv1.RollingUpdateDeploymentStrategyType,
+        RollingUpdate: &appsv1.RollingUpdateDeployment{
+            MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+            MaxSurge:       &intstr.IntOrString{IntVal: 1},
+        },
+    }
+    
+    // Set PodDisruptionBudget for HA components
+    // (separate resource, not shown here)
+    
+    return r.Update(ctx, desired)
+}
+```
+
+## Best Practices
+
+1. **Always Support N→N+1**: Operator version X must work with X-1 and X+1
+   - API compatibility (don't remove fields)
+   - Schema changes must be backward compatible
+   
+2. **Use Progressing Condition**: Set to True during rollout
+   ```yaml
+   conditions:
+   - type: Progressing
+     status: "True"
+     reason: RollingOut
+     message: "Updating to version 4.16.0"
+   ```
+
+3. **Block Unsafe Upgrades**: Set Upgradeable=False if upgrade would break
+   ```yaml
+   conditions:
+   - type: Upgradeable
+     status: "False"
+     reason: UnsupportedConfiguration
+     message: "Remove custom config before upgrading"
+   ```
+
+4. **PodDisruptionBudgets**: Prevent all replicas going down
+   ```yaml
+   apiVersion: policy/v1
+   kind: PodDisruptionBudget
+   metadata:
+     name: my-component
+   spec:
+     minAvailable: 1
+     selector:
+       matchLabels:
+         app: my-component
+   ```
+
+5. **Graceful Shutdown**: Handle SIGTERM properly (30s default grace period)
+
+## Version Skew Scenarios
+
+### API Compatibility
+
+```go
+// ✅ Backward compatible (adding optional field)
+type MyResourceSpec struct {
+    Replicas int  `json:"replicas"`
+    Image    string `json:"image"`
+    NewField *string `json:"newField,omitempty"` // Optional, defaults to nil
+}
+
+// ❌ Not backward compatible (removing field)
+type MyResourceSpec struct {
+    Image string `json:"image"`
+    // Replicas removed - breaks old clients!
+}
+```
+
+### Storage Version Migration
+
+```yaml
+# Old version (v1alpha1)
+apiVersion: example.com/v1alpha1
+kind: MyResource
+spec:
+  field: value
+
+# Hub version (v1)
+apiVersion: example.com/v1
+kind: MyResource
+spec:
+  newField: value
+
+# Use conversion webhooks to handle both
+```
+
+## Node Upgrades
+
+**Machine Config Operator (MCO) pattern**:
+
+1. MCO creates new MachineConfig
+2. Nodes reboot one at a time (drain → reboot → uncordon)
+3. Max 1 node upgrading per pool at a time (configurable)
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker
+spec:
+  maxUnavailable: 1  # Only 1 node at a time
+  paused: false
+```
+
+## Monitoring Upgrades
+
+```bash
+# Check upgrade progress
+oc get clusterversion
+
+# Watch operator status
+oc get clusteroperators
+
+# View progressing operators
+oc get co -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Progressing" and .status=="True")) | .metadata.name'
+```
+
+## Examples in Components
+
+| Component | Upgrade Strategy | Notes |
+|-----------|------------------|-------|
+| etcd | One pod at a time, quorum maintained | Must maintain 2/3 quorum |
+| kube-apiserver | Rolling update, PDB ensures 1+ available | Uses PodDisruptionBudget |
+| machine-config-operator | Node drain → reboot → uncordon | Can take 30+ minutes per node |
+| cluster-network-operator | Update CNI plugins in rolling fashion | Brief network interruptions possible |
+
+## Antipatterns
+
+❌ **Breaking API changes**: Removing fields in minor version  
+❌ **All replicas down**: No PodDisruptionBudget for HA components  
+❌ **Long rollouts**: Not reporting Progressing condition  
+❌ **Ignoring Upgradeable**: Allowing unsafe upgrades to proceed  
+❌ **Blocking CVO**: Long-running reconciliation preventing other operators from upgrading
+
+## Hypershift / Hosted Control Planes (HCP)
+
+**⚠️ Critical Difference**: In HCP, the control plane and data plane upgrade **independently**.
+
+### HCP Upgrade Model
+
+```
+Standalone:
+  CVO upgrades control plane → operators → workloads (all in same cluster)
+
+HCP:
+  Management Cluster:
+    HyperShift Operator upgrades → Hosted Control Plane components
+  Guest Cluster:
+    CVO in guest upgrades → operators in guest → workloads
+```
+
+### Key Differences
+
+| Aspect | Standalone | HCP |
+|--------|-----------|-----|
+| **Control plane location** | Same cluster as workloads | Management cluster |
+| **Upgrade orchestrator** | CVO in same cluster | HyperShift Operator (mgmt) + CVO (guest) |
+| **Version skew** | N→N+1 within cluster | Control plane and data plane can differ |
+| **Node upgrades** | MCO reboots nodes | Guest MCO manages guest nodes; mgmt cluster nodes managed separately |
+| **Operator location** | Depends—some in mgmt, some in guest | Must explicitly consider |
+
+**Note on node upgrades in HCP**: The control plane runs as **pods** in the management cluster (not on dedicated nodes). The management cluster has its own worker nodes where these control plane pods run. Those management cluster nodes are upgraded by the **management cluster's MCO**, independently from the guest cluster. The **guest cluster's MCO** only manages guest cluster worker nodes.
+
+### HCP Considerations for Operators
+
+**If your operator runs in the management cluster**:
+- ✅ Upgraded by HyperShift Operator, not CVO
+- ✅ Must tolerate guest cluster version skew (guest may be older)
+- ✅ Network access to guest cluster required (via KAS)
+
+**If your operator runs in the guest cluster**:
+- ✅ Upgraded by CVO in guest (same as standalone)
+- ✅ Must tolerate control plane version skew (control plane may be newer)
+- ✅ API calls go through remote KAS (in management cluster)
+
+**If your operator is split across both**:
+- ✅ Coordination required—design for independent upgrade order
+- ✅ Must tolerate partial upgrade state (mgmt upgraded, guest not yet)
+- ✅ Document dependencies in enhancement proposal
+
+### SNO (Single-Node OpenShift) Considerations
+
+**Resource Constraints**:
+- All overhead runs on ONE node (control plane + workloads)
+- No HA—single point of failure during node reboot
+- Node upgrade = full cluster downtime (1 node can't drain itself)
+
+**Upgrade Impact**:
+```yaml
+# Standalone HA cluster
+3 control plane nodes + N worker nodes
+→ Rolling update, zero downtime
+
+# SNO
+1 node
+→ Node reboot = cluster downtime (~5-10 minutes)
+```
+
+**Design Considerations**:
+- Accept brief downtime during upgrades (unavoidable in SNO)
+- Ensure rapid reconciliation after reboot
+- Test with `replica: 1` configurations
+
+### MicroShift Considerations
+
+**Different Upgrade Model**:
+- No CVO—upgrades via RPM/greenboot
+- No MCO—host OS managed separately
+- Operators may not exist (smaller footprint)
+
+**If your enhancement involves**:
+- ✅ New APIs → May not be available in MicroShift
+- ✅ Operators → May not run in MicroShift
+- ✅ CVO coordination → Not applicable to MicroShift
+
+See [topology-considerations-guide.md](../../workflows/topology-considerations-guide.md) for comprehensive form factor guidance.
+
+## References
+
+- **CVO**: [Cluster Version Operator](https://github.com/openshift/cluster-version-operator)
+- **Enhancement**: [Upgrade Ordering](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md)
+- **API**: [ClusterVersion](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go)
+- **Pattern**: Implements "Upgrade Safety" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)
+- **Form Factors**: [topology-considerations-guide.md](../../workflows/topology-considerations-guide.md) - Comprehensive HCP/SNO/MicroShift guidance
+- **HCP Enhancements** (authoritative sources for HCP upgrade behavior):
+  - [hypershift-control-plane-version-status.md](../../../enhancements/hypershift/hypershift-control-plane-version-status.md) - Management vs guest upgrade orchestration
+  - [monitoring.md](../../../enhancements/hypershift/monitoring.md) - Control plane/guest cluster separation

--- a/ai-docs/platform/operator-patterns/status-conditions.md
+++ b/ai-docs/platform/operator-patterns/status-conditions.md
@@ -1,0 +1,236 @@
+# Status Conditions Pattern
+
+**Category**: Platform Pattern  
+**Applies To**: All ClusterOperators, Recommended for all Operators  
+**Last Updated**: 2026-04-28  
+
+## Overview
+
+Status conditions provide standardized health reporting for OpenShift components. Every ClusterOperator must report Available, Progressing, and Degraded conditions.
+
+**Purpose**: Enable cluster-wide health monitoring and upgrade orchestration.
+
+## Key Concepts
+
+- **Condition**: Named state with Type, Status, Reason, Message
+- **Available**: Component is functioning and serving requests
+- **Progressing**: Component is reconciling changes (upgrade, config change)
+- **Degraded**: Component is running but functionality is impaired
+- **ObservedGeneration**: Detect spec changes requiring reconciliation
+
+## Condition Types
+
+### Required for ClusterOperators
+
+| Type | Meaning | True When | False When |
+|------|---------|-----------|------------|
+| **Available** | Component is functional | API serving, pods ready | Pods not ready, API down |
+| **Progressing** | Reconciliation in progress | Upgrade/rollout active | Desired state reached |
+| **Degraded** | Impaired but functional | Partial failure, degraded mode | Fully healthy |
+
+### Optional Conditions
+
+| Type | Use Case |
+|------|----------|
+| **Upgradeable** | Blocks cluster upgrade if False |
+| **Disabled** | Component intentionally disabled |
+
+## Implementation
+
+```go
+import (
+    configv1 "github.com/openshift/api/config/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Update condition helper
+func setCondition(conditions *[]configv1.ClusterOperatorStatusCondition, 
+                  condType configv1.ClusterStatusConditionType,
+                  status configv1.ConditionStatus,
+                  reason, message string) {
+    now := metav1.Now()
+    
+    for i := range *conditions {
+        if (*conditions)[i].Type == condType {
+            // Update existing
+            if (*conditions)[i].Status != status {
+                (*conditions)[i].LastTransitionTime = now
+            }
+            (*conditions)[i].Status = status
+            (*conditions)[i].Reason = reason
+            (*conditions)[i].Message = message
+            (*conditions)[i].LastHeartbeatTime = now
+            return
+        }
+    }
+    
+    // Add new condition
+    *conditions = append(*conditions, configv1.ClusterOperatorStatusCondition{
+        Type:               condType,
+        Status:             status,
+        Reason:             reason,
+        Message:            message,
+        LastTransitionTime: now,
+        LastHeartbeatTime:  now,
+    })
+}
+```
+
+## Best Practices
+
+1. **Always Set All Three**: Available, Progressing, Degraded must always be set
+   
+2. **Heartbeat Updates**: Update LastHeartbeatTime even if condition unchanged
+   - Shows controller is alive
+   - Stale heartbeat triggers alerts
+   
+3. **Reason vs Message**:
+   - **Reason**: Machine-readable CamelCase token (e.g., `PodsNotReady`)
+   - **Message**: Human-readable sentence (e.g., "2 of 3 pods are not ready")
+   
+4. **ObservedGeneration**: Track spec changes
+   ```go
+   status.ObservedGeneration = obj.Generation
+   ```
+
+5. **Transition Timing**: LastTransitionTime changes only when Status changes
+
+## Common Patterns
+
+### Healthy State
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+    message: "All pods are ready"
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+    message: "Desired state reached"
+  - type: Degraded
+    status: "False"
+    reason: AsExpected
+    message: "Component is healthy"
+```
+
+### Upgrade in Progress
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: AsExpected
+    message: "3 of 3 pods ready"
+  - type: Progressing
+    status: "True"
+    reason: RollingOut
+    message: "Rolling out new version 4.16.0"
+  - type: Degraded
+    status: "False"
+    reason: AsExpected
+    message: "Rollout is healthy"
+```
+
+### Degraded State
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "True"
+    reason: DegradedMode
+    message: "Serving requests with reduced capacity"
+  - type: Progressing
+    status: "False"
+    reason: AsExpected
+    message: "No changes in progress"
+  - type: Degraded
+    status: "True"
+    reason: PodCrashLooping
+    message: "Pod api-server-xyz is crash looping, 1 of 3 replicas unavailable"
+```
+
+### Unavailable State
+```yaml
+status:
+  conditions:
+  - type: Available
+    status: "False"
+    reason: NoPodsReady
+    message: "0 of 3 pods are ready"
+  - type: Progressing
+    status: "True"
+    reason: Reconciling
+    message: "Attempting to start pods"
+  - type: Degraded
+    status: "True"
+    reason: AllPodsDown
+    message: "Component is not serving requests"
+```
+
+## Decision Logic
+
+```go
+func computeConditions(deployment *appsv1.Deployment) []configv1.ClusterOperatorStatusCondition {
+    available := false
+    progressing := false
+    degraded := false
+    
+    // Available: at least 1 pod ready
+    if deployment.Status.AvailableReplicas > 0 {
+        available = true
+    }
+    
+    // Progressing: rollout in progress
+    if deployment.Status.UpdatedReplicas < deployment.Status.Replicas {
+        progressing = true
+    }
+    
+    // Degraded: some pods not ready
+    if deployment.Status.AvailableReplicas < deployment.Status.Replicas {
+        degraded = true
+    }
+    
+    return []configv1.ClusterOperatorStatusCondition{
+        makeCondition(configv1.OperatorAvailable, available, ...),
+        makeCondition(configv1.OperatorProgressing, progressing, ...),
+        makeCondition(configv1.OperatorDegraded, degraded, ...),
+    }
+}
+```
+
+## Monitoring
+
+```promql
+# Alert on unavailable ClusterOperator
+cluster_operator_conditions{type="Available", status="False"}
+
+# Alert on prolonged Degraded
+cluster_operator_conditions{type="Degraded", status="True"}
+
+# Alert on stale heartbeat
+time() - cluster_operator_conditions_last_heartbeat > 300
+```
+
+## Examples in Components
+
+| Component | Typical States | Notes |
+|-----------|---------------|-------|
+| kube-apiserver | Available during rollout | Uses PodDisruptionBudget |
+| machine-config-operator | Progressing during node updates | Can take 30+ minutes |
+| cluster-network-operator | Degraded if SDN pods crash | Network still partially functional |
+
+## Antipatterns
+
+❌ **Skipping conditions**: All three (Available/Progressing/Degraded) must be set  
+❌ **Stale status**: Not updating heartbeat regularly  
+❌ **Unclear messages**: "Error occurred" (not useful) vs "Pod xyz crash looping: OOMKilled"  
+❌ **Wrong semantics**: Available=False during normal upgrade (should be True)
+
+## References
+
+- **API**: [github.com/openshift/api/config/v1](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go)
+- **Enhancement**: [cluster-operator-conditions](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md)
+- **Command**: `oc get clusteroperators` to view all conditions
+- **Pattern**: Implements "Observability by Default" from [DESIGN_PHILOSOPHY.md](../../DESIGN_PHILOSOPHY.md)

--- a/ai-docs/platform/operator-patterns/status-conditions.md
+++ b/ai-docs/platform/operator-patterns/status-conditions.md
@@ -33,7 +33,6 @@ Status conditions provide standardized health reporting for OpenShift components
 | Type | Use Case |
 |------|----------|
 | **Upgradeable** | Blocks cluster upgrade if False |
-| **Disabled** | Component intentionally disabled |
 
 ## Implementation
 
@@ -59,7 +58,6 @@ func setCondition(conditions *[]configv1.ClusterOperatorStatusCondition,
             (*conditions)[i].Status = status
             (*conditions)[i].Reason = reason
             (*conditions)[i].Message = message
-            (*conditions)[i].LastHeartbeatTime = now
             return
         }
     }
@@ -71,7 +69,6 @@ func setCondition(conditions *[]configv1.ClusterOperatorStatusCondition,
         Reason:             reason,
         Message:            message,
         LastTransitionTime: now,
-        LastHeartbeatTime:  now,
     })
 }
 ```
@@ -80,20 +77,16 @@ func setCondition(conditions *[]configv1.ClusterOperatorStatusCondition,
 
 1. **Always Set All Three**: Available, Progressing, Degraded must always be set
    
-2. **Heartbeat Updates**: Update LastHeartbeatTime even if condition unchanged
-   - Shows controller is alive
-   - Stale heartbeat triggers alerts
-   
-3. **Reason vs Message**:
+2. **Reason vs Message**:
    - **Reason**: Machine-readable CamelCase token (e.g., `PodsNotReady`)
    - **Message**: Human-readable sentence (e.g., "2 of 3 pods are not ready")
    
-4. **ObservedGeneration**: Track spec changes
+3. **ObservedGeneration**: Track spec changes
    ```go
    status.ObservedGeneration = obj.Generation
    ```
 
-5. **Transition Timing**: LastTransitionTime changes only when Status changes
+4. **Transition Timing**: LastTransitionTime changes only when Status changes
 
 ## Common Patterns
 
@@ -204,14 +197,13 @@ func computeConditions(deployment *appsv1.Deployment) []configv1.ClusterOperator
 
 ```promql
 # Alert on unavailable ClusterOperator
-cluster_operator_conditions{type="Available", status="False"}
+cluster_operator_conditions{condition="Available"} == 0
 
 # Alert on prolonged Degraded
-cluster_operator_conditions{type="Degraded", status="True"}
-
-# Alert on stale heartbeat
-time() - cluster_operator_conditions_last_heartbeat > 300
+cluster_operator_conditions{condition="Degraded"} == 1
 ```
+
+**Note**: The metric uses numeric values (0 = False, 1 = True) and `condition` label. See [CVO metrics documentation](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/metrics.md).
 
 ## Examples in Components
 
@@ -224,9 +216,9 @@ time() - cluster_operator_conditions_last_heartbeat > 300
 ## Antipatterns
 
 ❌ **Skipping conditions**: All three (Available/Progressing/Degraded) must be set  
-❌ **Stale status**: Not updating heartbeat regularly  
 ❌ **Unclear messages**: "Error occurred" (not useful) vs "Pod xyz crash looping: OOMKilled"  
-❌ **Wrong semantics**: Available=False during normal upgrade (should be True)
+❌ **Wrong semantics**: Available=False during normal upgrade (should be True)  
+❌ **Unnecessary updates**: Updating conditions when state hasn't changed
 
 ## References
 

--- a/ai-docs/references/api-reference.md
+++ b/ai-docs/references/api-reference.md
@@ -1,0 +1,141 @@
+# API Reference
+
+**Purpose**: Pointers to authoritative API documentation  
+**Last Updated**: 2026-04-29  
+
+## Primary API Sources
+
+### oc explain (Authoritative)
+
+```bash
+# View resource schema
+oc explain <resource>
+
+# Examples:
+oc explain pod
+oc explain clusteroperator
+oc explain machine
+
+# View specific field
+oc explain pod.spec.containers
+
+# Show all fields recursively
+oc explain pod --recursive
+```
+
+**Why use `oc explain`?**
+- Always up-to-date with cluster version
+- Shows exact schema (required fields, types, validation)
+- Matches what API server validates
+
+### GitHub API Repository
+
+[github.com/openshift/api](https://github.com/openshift/api)
+
+**Structure**:
+```
+api/
+├── config/v1/              # Platform config APIs
+│   ├── types_cluster_operator.go
+│   └── types_cluster_version.go
+├── machine/v1beta1/        # Machine API
+├── operator/v1/            # Operator APIs
+└── ...
+```
+
+### List All APIs
+
+```bash
+# All resource types
+oc api-resources
+
+# OpenShift-specific resources
+oc api-resources | grep openshift
+
+# By API group
+oc api-resources --api-group=config.openshift.io
+```
+
+## Core API Groups
+
+| API Group | Purpose | Example Resources |
+|-----------|---------|------------------|
+| `config.openshift.io` | Platform configuration | ClusterOperator, ClusterVersion |
+| `machine.openshift.io` | Node lifecycle | Machine, MachineSet |
+| `machineconfiguration.openshift.io` | Node config | MachineConfig, MachineConfigPool |
+| `operator.openshift.io` | Operator configs | KubeAPIServer, Etcd |
+| `apps` | Kubernetes workloads | Deployment, StatefulSet |
+| `core` (v1) | Kubernetes primitives | Pod, Service, ConfigMap |
+
+## API Discovery
+
+### Find API Group for Resource
+
+```bash
+# Get API group
+oc api-resources | grep <resource-name>
+
+# Example:
+$ oc api-resources | grep clusteroperator
+clusteroperators     co       config.openshift.io/v1    false   ClusterOperator
+```
+
+### Get Full Resource Schema
+
+```bash
+# Get as YAML
+oc get crd <resource-plural>.<group> -o yaml
+
+# Example:
+oc get crd clusteroperators.config.openshift.io -o yaml
+```
+
+## Documentation Locations
+
+### Kubernetes APIs
+
+- **Upstream Docs**: [kubernetes.io/docs/reference/kubernetes-api/](https://kubernetes.io/docs/reference/kubernetes-api/)
+- **Source**: [github.com/kubernetes/api](https://github.com/kubernetes/api)
+
+### OpenShift APIs
+
+- **Source**: [github.com/openshift/api](https://github.com/openshift/api)
+- **Product Docs**: [docs.openshift.com](https://docs.openshift.com/container-platform/latest/)
+
+## Common Queries
+
+### View CRD Schema
+
+```bash
+oc get crd myresources.example.com -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema}' | jq
+```
+
+### List API Versions
+
+```bash
+oc api-versions
+```
+
+### Get Resource from Specific API Version
+
+```bash
+oc get clusteroperator kube-apiserver -o yaml --show-managed-fields=false
+```
+
+## Anti-Staleness Strategy
+
+**Don't include** (gets stale):
+- ❌ Full API field documentation
+- ❌ All available resources list
+- ❌ Every API group
+
+**Do include** (stays current):
+- ✅ How to discover APIs (`oc explain`, `oc api-resources`)
+- ✅ Core stable API groups only
+- ✅ Links to authoritative sources
+
+## Related
+
+- **Glossary**: [glossary.md](glossary.md) - Core terminology
+- **Domain Concepts**: [../domain/](../domain/) - Key API documentation
+- **CRD Guide**: [../domain/kubernetes/crds.md](../domain/kubernetes/crds.md)

--- a/ai-docs/references/api-reference.md
+++ b/ai-docs/references/api-reference.md
@@ -116,11 +116,26 @@ oc get crd myresources.example.com -o jsonpath='{.spec.versions[0].schema.openAP
 oc api-versions
 ```
 
-### Get Resource from Specific API Version
+### Get Resource Without Managed Fields
 
 ```bash
+# Cleaner output (hides metadata.managedFields)
 oc get clusteroperator kube-apiserver -o yaml --show-managed-fields=false
 ```
+
+**Why use `--show-managed-fields=false`?**
+
+The `metadata.managedFields` section tracks field ownership for [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/). While useful for understanding which controllers/users own which fields, it makes YAML output verbose and hard to read.
+
+**Use cases**:
+- **Human-readable output**: Easier to read resource specs without field manager metadata
+- **Cleaner diffs**: Comparing resources without managedFields noise
+- **Documentation/examples**: Showing resource structure without implementation details
+
+**When to include managed fields**:
+- Debugging field ownership conflicts
+- Understanding which controller modified a field
+- Server-side apply troubleshooting
 
 ## Anti-Staleness Strategy
 

--- a/ai-docs/references/glossary.md
+++ b/ai-docs/references/glossary.md
@@ -1,0 +1,80 @@
+# Glossary
+
+Core stable terms for OpenShift platform. Only includes terms that won't change frequently.
+
+## Platform Terms
+
+| Term | Definition |
+|------|------------|
+| **ClusterOperator** | Status resource for platform components (Available/Progressing/Degraded reporting) |
+| **CVO** | Cluster Version Operator - orchestrates cluster upgrades |
+| **CRD** | CustomResourceDefinition - extends Kubernetes API with new resource types |
+| **etcd** | Distributed key-value store, backend for Kubernetes API server |
+| **Machine** | API resource representing a node in the cluster (via Machine API) |
+| **MachineConfig** | Configuration applied to nodes (files, systemd units, kernel args) |
+| **MCO** | Machine Config Operator - manages node configuration |
+| **Operator** | Controller + CRD, manages lifecycle of applications/services |
+| **RHCOS** | Red Hat CoreOS - immutable operating system for OpenShift nodes |
+| **rpm-ostree** | Package/update system for immutable operating systems |
+
+## Kubernetes Terms
+
+| Term | Definition |
+|------|------------|
+| **Admission Controller** | Plugin that intercepts API requests (validation, mutation) |
+| **controller-runtime** | Go library for building Kubernetes controllers/operators |
+| **envtest** | Integration testing framework (API server + etcd) |
+| **Reconciliation** | Controller loop that converges current state to desired state |
+| **Watch** | Mechanism to receive notifications when resources change |
+
+## API Terms
+
+| Term | Definition |
+|------|------------|
+| **Hub Version** | Storage version for API (other versions convert to this) |
+| **ObservedGeneration** | Status field tracking last reconciled spec version |
+| **Spec** | Desired state (user input) |
+| **Status** | Current state (controller output) |
+| **Subresource** | Secondary API endpoint (e.g., `/status`, `/scale`) |
+
+## Upgrade Terms
+
+| Term | Definition |
+|------|------------|
+| **Channel** | Update stream (stable, fast, candidate, eus) |
+| **Cincinnati** | Update recommendation service (provides upgrade graph) |
+| **EUS** | Extended Update Support - long-term stable releases |
+| **N→N+1** | Version skew policy (support current and next minor version) |
+| **Version Skew** | Difference between component versions during upgrade |
+
+## Testing Terms
+
+| Term | Definition |
+|------|------------|
+| **E2E Test** | End-to-end test on full cluster |
+| **Flaky Test** | Test that intermittently fails |
+| **Integration Test** | Test with multiple components (e.g., envtest) |
+| **Unit Test** | Test of single function/method (mocked dependencies) |
+
+## Status Conditions
+
+| Term | Definition |
+|------|------------|
+| **Available** | Component is functional and serving requests |
+| **Degraded** | Component is impaired but still functioning |
+| **Progressing** | Component is reconciling changes (upgrade, config) |
+| **Upgradeable** | Safe to upgrade (False blocks cluster upgrade) |
+
+## Anti-Staleness Note
+
+This glossary includes only **stable core terms** that are unlikely to change. Avoid adding:
+- Release-specific features
+- Component-specific terminology
+- Temporary or experimental terms
+
+For detailed API documentation, use `oc explain <resource>`.
+
+## Related
+
+- **API Reference**: [api-reference.md](api-reference.md)
+- **Full API Docs**: [Kubernetes API Reference](https://kubernetes.io/docs/reference/kubernetes-api/)

--- a/ai-docs/references/index.md
+++ b/ai-docs/references/index.md
@@ -1,0 +1,23 @@
+# References
+
+Pointer-based navigation to authoritative sources.
+
+## Reference Guides
+
+- [repo-index.md](repo-index.md) - Finding OpenShift component repositories (GitHub org search)
+- [api-reference.md](api-reference.md) - API documentation sources (`oc explain`, GitHub)
+- [glossary.md](glossary.md) - Core stable terminology
+
+## Anti-Staleness Strategy
+
+References use pointers (GitHub search links, `oc` commands) not exhaustive lists:
+- ✅ Search strategies
+- ✅ Command examples
+- ✅ Naming conventions
+- ❌ Complete repository lists
+- ❌ All API field documentation
+
+## Related
+
+- **Domain Concepts**: [../domain/](../domain/) - Core API guides
+- **Workflows**: [../workflows/](../workflows/) - Process guides

--- a/ai-docs/references/repo-index.md
+++ b/ai-docs/references/repo-index.md
@@ -1,0 +1,95 @@
+# Repository Index
+
+**Purpose**: Discover OpenShift component repositories  
+**Last Updated**: 2026-04-29  
+
+## Finding Repositories
+
+**Primary Method**: [GitHub Organization Search](https://github.com/orgs/openshift/repositories)
+
+**Common Patterns**:
+- `openshift/<component>-operator` - Operators
+- `openshift/<component>` - Core components
+- `openshift/api` - API definitions
+- `openshift/enhancements` - Design docs
+
+## Core Platform Components
+
+| Component | Repository | Description |
+|-----------|-----------|-------------|
+| **Cluster Version Operator** | [cluster-version-operator](https://github.com/openshift/cluster-version-operator) | Upgrade orchestration |
+| **Machine API** | [machine-api-operator](https://github.com/openshift/machine-api-operator) | Node lifecycle |
+| **Kube API Server** | [cluster-kube-apiserver-operator](https://github.com/openshift/cluster-kube-apiserver-operator) | API server operator |
+| **etcd** | [cluster-etcd-operator](https://github.com/openshift/cluster-etcd-operator) | etcd cluster operator |
+| **Networking** | [cluster-network-operator](https://github.com/openshift/cluster-network-operator) | SDN/OVN orchestration |
+
+## API Definitions
+
+| Repository | Purpose |
+|-----------|---------|
+| [openshift/api](https://github.com/openshift/api) | All OpenShift API types |
+| [kubernetes/api](https://github.com/kubernetes/api) | Kubernetes core APIs |
+
+## Search Strategies
+
+### By Keyword
+
+```bash
+# Search GitHub org
+https://github.com/orgs/openshift/repositories?q=<keyword>
+
+# Example: storage-related repos
+https://github.com/orgs/openshift/repositories?q=storage
+```
+
+### By Topic
+
+```bash
+# Operator repos
+https://github.com/orgs/openshift/repositories?q=operator
+
+# API repos
+https://github.com/orgs/openshift/repositories?q=api
+```
+
+### By Language
+
+```bash
+# Go repos (most operators)
+https://github.com/orgs/openshift/repositories?language=go
+```
+
+## Operator Naming Conventions
+
+| Pattern | Example | Component Type |
+|---------|---------|---------------|
+| `cluster-<component>-operator` | `cluster-etcd-operator` | Core platform |
+| `<component>-operator` | `machine-api-operator` | Platform feature |
+| `<component>` | `installer` | Tool/utility |
+
+## Finding Component Ownership
+
+**OWNERS Files**: Each repo has `OWNERS` file with approvers/reviewers
+
+```bash
+# View owners
+curl https://raw.githubusercontent.com/openshift/<repo>/master/OWNERS
+```
+
+## Anti-Staleness Strategy
+
+**Don't maintain exhaustive lists** (they go stale):
+- ❌ List of all 200+ repositories
+- ❌ Component ownership mapping
+- ❌ Repository statistics
+
+**Do provide search strategies**:
+- ✅ GitHub org search links
+- ✅ Naming conventions
+- ✅ Core platform components only
+
+## Related
+
+- **GitHub Org**: [github.com/openshift](https://github.com/openshift)
+- **API Reference**: [api-reference.md](api-reference.md)
+- **Enhancement Repo**: [openshift/enhancements](https://github.com/openshift/enhancements)

--- a/ai-docs/references/repo-index.md
+++ b/ai-docs/references/repo-index.md
@@ -32,48 +32,44 @@
 
 ## Search Strategies
 
-### By Keyword
+**GitHub Organization Search**: `https://github.com/orgs/openshift/repositories?q=<keyword>`
 
+**Examples**:
 ```bash
-# Search GitHub org
-https://github.com/orgs/openshift/repositories?q=<keyword>
-
-# Example: storage-related repos
+# By component name
 https://github.com/orgs/openshift/repositories?q=storage
-```
+https://github.com/orgs/openshift/repositories?q=network
 
-### By Topic
-
-```bash
-# Operator repos
+# By type
 https://github.com/orgs/openshift/repositories?q=operator
+https://github.com/orgs/openshift/repositories?q=library
 
-# API repos
-https://github.com/orgs/openshift/repositories?q=api
-```
-
-### By Language
-
-```bash
-# Go repos (most operators)
+# By language
 https://github.com/orgs/openshift/repositories?language=go
+https://github.com/orgs/openshift/repositories?language=python
 ```
 
 ## Operator Naming Conventions
 
-| Pattern | Example | Component Type |
-|---------|---------|---------------|
-| `cluster-<component>-operator` | `cluster-etcd-operator` | Core platform |
-| `<component>-operator` | `machine-api-operator` | Platform feature |
-| `<component>` | `installer` | Tool/utility |
+| Pattern | Example | Notes |
+|---------|---------|-------|
+| `cluster-<component>-operator` | `cluster-etcd-operator` | Historical naming (directory grouping) |
+| `<component>-operator` | `machine-api-operator` | Standard operator naming |
+| `<component>` | `installer` | Tool/utility (non-operator) |
+
+**Note**: The `cluster-` prefix was historically used for directory organization in early OpenShift development, not to indicate semantic differences between operator types. Do not infer component type or importance from naming patterns alone.
 
 ## Finding Component Ownership
 
 **OWNERS Files**: Each repo has `OWNERS` file with approvers/reviewers
 
 ```bash
-# View owners
-curl https://raw.githubusercontent.com/openshift/<repo>/master/OWNERS
+# View owners (most repos use 'main', some older repos use 'master')
+curl https://raw.githubusercontent.com/openshift/<repo>/main/OWNERS
+
+# Or use GitHub API to auto-detect default branch:
+gh api repos/openshift/<repo> --jq '.default_branch' | \
+  xargs -I {} curl https://raw.githubusercontent.com/openshift/<repo>/{}/OWNERS
 ```
 
 ## Anti-Staleness Strategy

--- a/ai-docs/workflows/topology-considerations-guide.md
+++ b/ai-docs/workflows/topology-considerations-guide.md
@@ -1,0 +1,355 @@
+# Topology Considerations Guide
+
+**Purpose**: Guide enhancement authors and reviewers through deployment topology sections  
+**Target Audience**: EP authors, reviewers, approvers  
+**Template Section**: "Topology Considerations" in enhancement_template.md  
+**Last Updated**: 2026-05-14
+
+---
+
+## Overview
+
+OpenShift supports multiple deployment topologies, each with different architectural constraints, resource profiles, and operational models. Enhancement proposals must explicitly address how changes affect each topology.
+
+**Key principle**: If unsure, research and ask questions. "Not applicable" without explanation is insufficient.
+
+---
+
+## Quick Decision Tree
+
+```mermaid
+graph TD
+    A[Does your enhancement affect...] --> B{Control plane components?}
+    B -->|Yes| C[MUST address Hypershift split]
+    B -->|No| D{Node-level resources?}
+    D -->|Yes| E[MUST address SNO constraints]
+    D -->|No| F{New APIs or operators?}
+    F -->|Yes| G[MUST address MicroShift compatibility]
+    F -->|No| H{Changes configuration?}
+    H -->|Yes| I[MUST address OKE feature availability]
+    H -->|No| J[Document why all are N/A]
+```
+
+---
+
+## Hypershift / Hosted Control Planes
+
+**Architecture**: Control plane runs in management cluster; workloads run in guest cluster
+
+**When to consider**:
+- ✅ Changes to control plane components (kube-apiserver, etcd, controllers)
+- ✅ New operators or controllers
+- ✅ API extensions (CRDs, webhooks)
+- ✅ Certificate or authentication changes
+- ✅ Networking between control plane and data plane
+
+**Key questions for authors**:
+
+| Question | Why it matters | Example |
+|----------|----------------|---------|
+| **Where does this component run?** | Management vs. guest cluster determines RBAC, networking, resource accounting | Operator in management, webhook in guest |
+| **Does it need cross-cluster communication?** | Impacts networking policies and certificate management | KAS in management serves guest kubelets |
+| **What RBAC is needed in each cluster?** | Management cluster may need federated identity; guest uses service accounts | HO pod needs Network Contributor on mgmt cluster |
+| **How does upgrade orchestration work?** | HCP upgrades management-side components separately from guest | CVO runs in guest; HO orchestrates mgmt components |
+| **Are there separate control plane/data plane versions?** | Version skew tolerance becomes critical | N→N+1 skew during rolling upgrade |
+
+**Good example**:
+> This enhancement is specific to HyperShift. The `controlPlaneVersion` field is added to `HostedClusterStatus` and `HostedControlPlaneStatus`. The reconciliation logic runs in the CPO on the management cluster and inspects `ControlPlaneComponent` resources in the HCP namespace.
+>
+> **Management cluster impact**: CPO resource consumption increases by ~50MB per hosted cluster.  
+> **Guest cluster impact**: None; status is reflected via existing CVO.
+
+**Bad example**:
+> This works with Hypershift.
+>
+> *Missing: WHERE components run, networking implications, upgrade orchestration*
+
+---
+
+## Standalone Clusters
+
+**Architecture**: Traditional self-hosted control plane; all components in same cluster
+
+**When to consider**:
+- ✅ Always applicable unless enhancement is Hypershift-specific
+- ✅ Most enhancements should work here by default
+
+**Key questions**:
+- Is this Hypershift-only? (standalone won't have Hypershift CRDs/controllers)
+- Does it depend on Hypershift-specific features? (may need alternative)
+
+**Good example**:
+> This change applies to standalone clusters. The new webhook runs as a pod in the openshift-authentication namespace and validates authentication CRs.
+
+**Bad example**:
+> No special considerations for standalone clusters.
+>
+> *Better: Explain WHY (e.g., "Component runs identically in standalone; no control-plane split to handle")*
+
+---
+
+## Single-Node Deployments (SNO)
+
+**Architecture**: Single node acts as both control plane and worker; no high availability
+
+**Resource constraints**:
+- **CPU**: 8 vCPUs typical (vs. 3×4 in HA)
+- **Memory**: 16-32 GB typical (vs. 3×16 in HA)
+- **Storage**: Local disk only; no distributed storage
+
+**When to consider**:
+- ✅ New daemons or operators that consume memory/CPU
+- ✅ Features requiring quorum or leader election
+- ✅ Storage-intensive workloads
+- ✅ Features assuming multiple nodes exist
+
+**Key questions for authors**:
+
+| Question | Why it matters | Example |
+|----------|----------------|---------|
+| **What is the per-node resource overhead?** | In SNO, ALL overhead is on one node | +200MB per node = +200MB total in SNO |
+| **Does it assume multiple nodes?** | Pod anti-affinity, zone spreading, quorum | 3-replica StatefulSet can't schedule |
+| **Does it require high availability?** | SNO has no HA; single point of failure | Leader election still works but no failover |
+| **Does it use local storage?** | SNO often uses hostPath or local PVs | Database needs fsync; can't assume network storage |
+| **How does it behave during node reboot?** | Entire cluster goes down | Must tolerate full cluster restart |
+
+**Common scenarios**:
+
+| Scenario | SNO Impact | Mitigation |
+|----------|------------|------------|
+| **New DaemonSet** | N×overhead becomes 1×overhead (good) | Document actual resource usage |
+| **Replica requirements** | Can't schedule 3 replicas | Allow replica=1 via SNO detection |
+| **Distributed quorum** | No quorum with 1 member | Use single-member mode or disable |
+| **Network partitions** | Can't happen (1 node) | Simplifies some failure modes |
+
+**Topology detection**:
+```bash
+oc get node -l node.openshift.io/single-node-cluster
+```
+
+**Good example**:
+> **SNO impact**: This adds a DaemonSet consuming 100MB RAM and 50m CPU per node. In SNO, this is 100MB total. The feature detects single-node topology (via `node.openshift.io/single-node-cluster` label) and reduces replica count from 3 to 1 for the StatefulSet.
+
+**Bad example**:
+> No special considerations for single-node deployments.
+>
+> *Missing: Memory/CPU overhead, replica adjustments, HA assumptions*
+
+---
+
+## MicroShift
+
+**Architecture**: Minimal OpenShift for edge; subset of operators and APIs
+
+**Key differences from OCP**:
+- **No CNO**: Network config via MicroShift config file, not `network.config.openshift.io`
+- **No CVO**: No cluster-version-operator; updates via rpm-ostree
+- **Subset of operators**: Only essential operators run
+- **Config file driven**: `/etc/microshift/config.yaml` instead of CRs
+- **Smaller footprint**: Optimized for 2-4 GB RAM
+
+**When to consider**:
+- ✅ New APIs (MicroShift may not include them)
+- ✅ Operators or controllers (may not run in MicroShift)
+- ✅ Configuration via CRs (may need config file alternative)
+- ✅ Features depending on other operators (check dependencies)
+
+**Operators in MicroShift**:
+- ✅ Service CA operator
+- ✅ DNS operator  
+- ✅ Ingress operator (route controller)
+- ❌ CNO (cluster-network-operator)
+- ❌ CVO (cluster-version-operator)
+- ❌ Marketplace
+- ❌ Monitoring stack (Prometheus)
+
+**Key questions**:
+- Does this depend on an operator not in MicroShift?
+- Does this add a new API? (MicroShift has limited CRD set)
+- Can config be exposed via config file?
+- What is the memory overhead? (target: <500MB)
+
+**Good example**:
+> **MicroShift**: This feature depends on the Cluster Network Operator (CNO), which does not run in MicroShift. MicroShift users configure networking via `/etc/microshift/config.yaml`. This enhancement does **not** apply to MicroShift.
+
+**Config file alternative example**:
+> **MicroShift**: The `maxPods` field is added to the kubelet configuration. In OCP, this is set via `KubeletConfig` CR. In MicroShift, users should set:
+>
+> ```yaml
+> # /etc/microshift/config.yaml
+> kubelet:
+>   maxPods: 250
+> ```
+
+**Reference**: https://github.com/openshift/microshift
+
+---
+
+## OpenShift Kubernetes Engine (OKE)
+
+**Architecture**: Upstream Kubernetes with minimal OpenShift additions; no platform operators
+
+**Key differences from OCP**:
+- **No platform operators**: monitoring, console, registry, etc.
+- **Upstream components**: Uses upstream Kubernetes releases
+- **Minimal API extensions**: Subset of `config.openshift.io` APIs
+
+**When to consider**:
+- ✅ Features depending on OCP-specific operators (console, monitoring, etc.)
+- ✅ Features using `config.openshift.io` APIs not in OKE
+- ✅ Features requiring OpenShift-specific integrations
+
+**Good example**:
+> **OKE**: This enhancement adds a console plugin, which depends on the OpenShift web console. OKE does not include the console, so this feature is **not available in OKE**.
+
+**Reference**: [OKE comparison doc](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/oke-about#about_oke_similarities_and_differences)
+
+---
+
+## Decision Matrix Template
+
+Use this checklist when writing the Topology Considerations section:
+
+| Topology | Questions to Answer | Your Answer |
+|----------|---------------------|-------------|
+| **Hypershift** | - Where do components run (mgmt/guest)?<br>- Cross-cluster networking needed?<br>- Separate upgrade orchestration? | |
+| **Standalone** | - Works identically to Hypershift?<br>- Hypershift-only feature? | |
+| **SNO** | - Resource overhead (MB/CPU)?<br>- Replica count adjustments?<br>- HA assumptions? | |
+| **MicroShift** | - Depends on missing operators?<br>- Config file alternative needed?<br>- Memory overhead acceptable? | |
+| **OKE** | - Depends on OCP-only features?<br>- Uses upstream APIs only? | |
+
+---
+
+## Common Anti-Patterns
+
+### ❌ "Not applicable" without explanation
+
+**Bad**:
+> Not applicable to Hypershift.
+
+**Good**:
+> Not applicable to Hypershift. This enhancement modifies the in-cluster storage operator, which runs identically in both standalone and Hypershift guest clusters. The management cluster is unaffected.
+
+---
+
+### ❌ "No special considerations"
+
+**Bad**:
+> No special considerations for SNO.
+
+**Good**:
+> SNO is supported. This adds a Deployment (not DaemonSet), consuming 200MB RAM total regardless of node count. In SNO, this is the same 200MB. No replica adjustments needed.
+
+---
+
+### ❌ Ignoring resource constraints
+
+**Bad**:
+> Adds a new monitoring sidecar to all pods.
+
+**Good**:
+> Adds a 50MB monitoring sidecar to all pods in the `openshift-*` namespaces. In SNO with ~100 system pods, this is ~5GB additional memory (~30% increase on 16GB node). We mitigate by making the sidecar opt-in via annotation.
+
+---
+
+## Reviewer Checklist
+
+When reviewing enhancement PRs, verify:
+
+**Hypershift**:
+- [ ] Identifies which cluster(s) components run in
+- [ ] Addresses cross-cluster communication if applicable
+- [ ] Considers version skew during upgrades
+- [ ] Quantifies management cluster resource impact
+
+**SNO**:
+- [ ] Quantifies per-node memory/CPU overhead
+- [ ] Addresses replica count assumptions (if any)
+- [ ] Documents behavior if HA is assumed
+- [ ] Tests with `node.openshift.io/single-node-cluster` label
+
+**MicroShift**:
+- [ ] Lists operator dependencies (are they in MicroShift?)
+- [ ] Proposes config file alternative if adding new API
+- [ ] Quantifies memory overhead (is it <500MB?)
+
+**OKE**:
+- [ ] Identifies OCP-specific dependencies (console, monitoring, etc.)
+- [ ] Links to OKE comparison doc if unclear
+
+**General**:
+- [ ] No section says "N/A" or "no special considerations" without explanation
+- [ ] Author can articulate WHY each topology is/isn't affected
+
+---
+
+## Examples from Real Enhancements
+
+### Hypershift-specific feature
+
+From `hypershift-gcp-platform-support.md`:
+
+> **Hypershift / Hosted Control Planes**  
+> This enhancement is HyperShift-specific. It adds GCP as a new platform type for hosted control planes to enable a managed OpenShift service on GCP. Management clusters running on GKE are specific to the managed service architecture and are not intended for self-managed OCP deployments.
+>
+> **Standalone Clusters**  
+> Not applicable. This enhancement is specific to the HyperShift topology.
+
+---
+
+### MicroShift incompatibility
+
+From `configurable-network-diagnostics-pod-placement.md`:
+
+> **Single-node Deployments or MicroShift**  
+> MicroShift doesn't run CNO and network diagnostics.  
+> No special considerations for single-node deployments.
+
+---
+
+---
+
+## For Agentic Docs Contributors
+
+**Context**: When documenting form factor behavior in `ai-docs/`, use authoritative enhancements as primary sources.
+
+### Critical Rule
+
+**ALWAYS cite authoritative enhancements when documenting HCP/SNO/MicroShift behavior.**
+
+❌ **DON'T**: Rely on training data or general Kubernetes knowledge for form factor specifics
+✅ **DO**: Read relevant enhancements, extract facts, cite sources
+
+### Process
+
+1. **Find authoritative source** - Search `enhancements/hypershift/`, topology sections in EPs
+2. **Extract facts** - Quote specific lines, note architecture details
+3. **Cite in docs** - Add references section linking to enhancements
+4. **Mark inferences** - Distinguish verified facts from logical inferences
+
+### Authoritative Sources by Topic
+
+| Topic | Enhancement | Key Facts |
+|-------|-------------|-----------|
+| **HCP upgrade orchestration** | enhancements/hypershift/hypershift-control-plane-version-status.md | CPO (mgmt) vs CVO (guest), separate version tracking |
+| **HCP networking** | enhancements/hypershift/hosted-control-plane-metrics-exposure.md, monitoring.md | Management/guest network separation |
+| **HCP operator placement** | enhancements/hypershift/node-tuning.md | Split operator pattern, two kubeconfigs |
+| **SNO constraints** | Search topology sections in EPs | Single node, no HA, resource limits |
+| **MicroShift differences** | Search topology sections in EPs | No CVO/CNO, RPM-based upgrades |
+
+---
+
+## Related Documentation
+
+- **Enhancement template**: [../../guidelines/enhancement_template.md](../../guidelines/enhancement_template.md)
+- **MicroShift repo**: https://github.com/openshift/microshift
+- **OKE comparison**: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/oke-about#about_oke_similarities_and_differences
+- **HCP enhancements**: [../../enhancements/hypershift/](../../enhancements/hypershift/)
+
+---
+
+## Feedback
+
+For questions or suggestions on this guide:
+- **Slack**: #forum-ocp-arch
+- **Issues**: https://github.com/openshift/enhancements/issues


### PR DESCRIPTION
Introduce ai-docs/ directory with foundational navigation and core platform concepts to enable AI-assisted development workflows.

Foundation (Navigation & Principles):
- AGENTS.md: Navigation index with task-based flows
- CLAUDE.md: Symlink for AI agent compatibility
- ai-docs/DESIGN_PHILOSOPHY.md: Core principles and patterns
- ai-docs/KNOWLEDGE_GRAPH.md: Visual concept map
- ai-docs/references/: Glossary and reference index

Domain Knowledge (Platform Concepts):
- ai-docs/domain/kubernetes/: Pod, Service, CRD patterns
- ai-docs/domain/openshift/: ClusterOperator, ClusterVersion APIs
- ai-docs/platform/operator-patterns/status-conditions.md: Condition patterns
- ai-docs/platform/openshift-specifics/upgrade-strategies.md: Upgrade safety

Workflows:
- ai-docs/workflows/topology-considerations-guide.md: SNO, MicroShift, Hypershift

This establishes the framework for subsequent operator patterns, workflows, and practices documentation.

Related: #1992