### PR TITLE
CNTRLPLANE-4012: Configurable log levels for Hosted Control Plane components

### DIFF
--- a/enhancements/hypershift/configurable-log-levels-for-hosted-control-plane-components.md
+++ b/enhancements/hypershift/configurable-log-levels-for-hosted-control-plane-components.md
@@ -1,0 +1,746 @@
+---
+title: configurable-log-levels-for-hosted-control-plane-components
+authors:
+  - "@rutvik23"
+  - "@dhgautam99"
+  - "@amogh-redhat"
+  - "@PoornimaSingour"
+  - "@vismishr"
+  - "@vsolanki12"
+reviewers:
+  - "@ahmed"
+approvers:
+  - "@csrwng"
+  - "@ahmed"
+api-approvers:
+  - "@joelspeed"
+creation-date: 2026-06-09
+last-updated: 2026-06-15
+status: provisional
+tracking-link:
+  - https://issues.redhat.com/browse/OCPSTRAT-3156
+see-also:
+  - https://issues.redhat.com/browse/RFE-7777
+  - https://issues.redhat.com/browse/CNTRLPLANE-3290
+  - https://issues.redhat.com/browse/CNTRLPLANE-3291
+  - https://issues.redhat.com/browse/OSDOCS-19157
+replaces: []
+superseded-by: []
+---
+
+# Configurable Log Levels for Hosted Control Plane Components
+
+## Summary
+
+This enhancement introduces structured, per-component log level configuration for hosted
+control plane components managed by the Control Plane Operator (CPO) in HyperShift.
+Administrators will be able to set intent-based log levels (`Normal`, `Debug`, `Trace`,
+`TraceAll`) on the HostedCluster Custom Resource for kube-apiserver,
+kube-controller-manager, kube-scheduler, etcd, openshift-apiserver,
+openshift-controller-manager, openshift-oauth-apiserver, and oauth-server. The CPO will
+translate these intent-based levels into component-specific mechanisms (`--v=N` for
+klog-based components, `ETCD_LOG_LEVEL` env var for etcd), achieving operational parity
+with standard OCP's `operatorv1.OperatorSpec.LogLevel` pattern. The new fields are added
+as structured `*ComponentLogLevelSpec` pointers in the existing `OperatorConfiguration`
+type. The design is intentionally generic to extend to all remaining CPO-managed components
+in future phases. This feature ships ungated (no feature gate) as a low-risk operational
+knob that extends an already-GA framework.
+
+## Motivation
+
+HyperShift administrators and support engineers currently cannot adjust log verbosity for
+hosted control plane components during troubleshooting. In standard OCP, changing log
+levels is a routine operation via `oc patch` on operator resources, but in HyperShift the
+control plane runs in a management cluster namespace with no user-facing logging
+configuration.
+
+This gap creates significant operational pain:
+
+- **Slower incident resolution:** Without verbose logs, diagnosing obscure control plane
+  failures requires escalation and often cluster recreation, extending MTTR from hours to
+  days.
+- **No proactive debugging:** Teams cannot temporarily increase verbosity in pre-production
+  to gather data about component behavior before promoting changes.
+- **Operational gap vs standard OCP:** Customers managing both standalone and hosted
+  clusters face inconsistent tooling, increasing training burden and operational complexity.
+- **Support burden:** CEE engineers cannot guide customers through standard log-level-based
+  troubleshooting workflows, leading to more escalations to engineering.
+
+Currently only kube-apiserver has a verbosity annotation
+(`hypershift.openshift.io/kube-apiserver-verbosity-level`), which is ad-hoc, unvalidated
+(raw integer), and inconsistent with the OCP operator pattern. All other components managed
+by CPO have no user-facing logging configuration.
+
+This was reported via [RFE-7777](https://issues.redhat.com/browse/RFE-7777) and accepted
+as "crucial even for the most minimal troubleshooting."
+
+### User Stories
+
+- As a **HyperShift cluster administrator**, I want to increase the log verbosity of
+  kube-apiserver on my hosted cluster so that I can diagnose API request failures without
+  escalating to engineering.
+
+- As a **CEE support engineer**, I want to instruct customers to set `Debug` log level on
+  specific hosted control plane components via the HostedCluster CR so that I can follow
+  the same troubleshooting playbooks used for standard OCP clusters.
+
+- As a **platform engineer** managing hosted clusters in pre-production, I want to
+  temporarily set `Trace` level on openshift-apiserver and openshift-controller-manager so
+  that I can capture detailed component behavior before promoting changes to production.
+
+- As an **SRE** operating hosted clusters at scale, I want to monitor which hosted clusters
+  have non-default log levels active so that I can identify clusters with elevated log
+  volume and ensure log storage capacity is not exceeded.
+
+### Goals
+
+This enhancement is delivered in phases:
+
+**Phase 1 — kube-apiserver (initial delivery)**
+
+1. Enable administrators to configure log verbosity for kube-apiserver via the HostedCluster
+   CR, replacing the existing ad-hoc annotation-based mechanism.
+2. Establish the `ComponentLogLevelSpec` pattern and `LogLevelToKlogVerbosity()` utility
+   that all subsequent phases reuse.
+3. Provide a deprecation path for the existing
+   `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation.
+4. Achieve operational parity with standard OCP's `operatorv1.LogLevel` pattern using
+   intent-based log levels (`Normal`, `Debug`, `Trace`, `TraceAll`).
+5. Ensure log level changes take effect via rolling restart without cluster disruption or
+   downtime.
+
+**Phase 2 — remaining core control plane components**
+
+6. Extend log level configuration to: kube-controller-manager, kube-scheduler, etcd,
+   openshift-apiserver, openshift-controller-manager, openshift-oauth-apiserver, and
+   oauth-server, using the same pattern established in Phase 1.
+
+**Phase 3 — all remaining CPO-managed components (future)**
+
+7. Extend log level configuration to all remaining klog-based CPO-managed components,
+   including components with hardcoded `--v=N` values in their asset manifests and
+   components using klog defaults, as well as zap-based operator components (HCCO,
+   PKI-operator) and karpenter via custom level mappings.
+8. The `ComponentLogLevelSpec` API design is intentionally generic to enable this extension
+   with only additive, backward-compatible changes to `OperatorConfiguration`.
+
+### Non-Goals
+
+1. **Configuring all ~50 CPO-managed components in Phases 1 and 2.** Phases 1 and 2 cover
+   the 8 core control plane components. Phase 3 (future) covers remaining components.
+
+2. **The following components are permanently out of scope** due to their logging model not
+   supporting a standard configurable verbosity interface compatible with the
+   `Normal/Debug/Trace/TraceAll` abstraction:
+   - `control-plane-operator` self-log-level: the CPO binary is deployed by the
+     *hypershift-operator*, not by CPO's own reconciliation loop. CPO cannot configure its
+     own log level through its own reconciliation.
+   - Catalog images (`certified-operators-catalog`, `community-operators-catalog`,
+     `redhat-operators-catalog`, `redhat-marketplace-catalog`): use opm/gRPC serving with
+     no standard verbosity flag.
+   - HAProxy-based components (`router`, `ignition-server-proxy`): log level is
+     configuration-file-based, not flag-based.
+   - `aws-node-termination-handler`: upstream AWS daemon with a custom logging model not
+     compatible with intent-based log level mapping.
+   - `olm-collect-profiles`, `featuregate-generator`: cronjob/generator workloads, not
+     long-running operators with persistent log level state.
+   - `metrics-proxy`: internal sidecar with no user-facing verbosity interface.
+
+3. Implementing log aggregation, forwarding, or retention policies for hosted control plane
+   component logs.
+
+4. Providing a real-time log streaming interface or console-based log viewer for hosted
+   control plane components.
+
+## Proposal
+
+Introduce a new log level configuration section in the HostedCluster API that allows
+per-component log level overrides. The CPO will reconcile these settings and propagate them
+to the appropriate control plane component deployments and statefulsets.
+
+HyperShift already defines a `LogLevel` type identical to OCP's `operatorv1.LogLevel`,
+mapping to the following glog/klog verbosity levels:
+
+| LogLevel         | klog `--v` | etcd `ETCD_LOG_LEVEL` | Use Case                                          |
+|------------------|------------|----------------------|---------------------------------------------------|
+| Normal (default) | 2          | info                 | Production                                        |
+| Debug            | 4          | debug                | Troubleshooting                                   |
+| Trace            | 6          | debug                | Deep investigation                                |
+| TraceAll         | 8          | debug                | Full dumps — perf impact, may expose secrets      |
+
+The chosen API design is **Option B — Structured fields** in `OperatorConfiguration`. This
+extends the existing pattern (which already has `ClusterVersionOperator`,
+`ClusterNetworkOperator`, and `IngressOperator` fields) with new optional
+`*ComponentLogLevelSpec` pointer fields. Each component uses `*ComponentLogLevelSpec`
+directly.
+
+> **Why etcd uses `ETCD_LOG_LEVEL` env var and not `--log-level` flag:** etcd is started
+> via a shell one-liner (`/bin/sh -c "... /usr/bin/etcd"`). Injecting a CLI flag means
+> string-manipulating the shell command — fragile and breaks if the command format changes.
+> `ETCD_LOG_LEVEL` matches all 15 existing etcd config values and uses the existing
+> `util.UpsertEnvVar()` utility (from `support/util/containers.go`). etcd internally maps
+> `ETCD_*` env vars to their `--*` flag equivalents.
+
+> **Why Trace and TraceAll both map to `debug` for etcd:** etcd uses zap, which supports:
+> debug, info, warn, error, panic, fatal. There is no finer granularity below debug. klog
+> has numeric levels (2/4/6/8) giving four distinct settings; etcd only gives two useful
+> ones (info and debug).
+
+When no log level is specified for a component, the default (`Normal`) is used, preserving
+backward compatibility.
+
+### Workflow Description
+
+**cluster administrator** is a human user responsible for managing a hosted cluster via the
+HostedCluster CR.
+
+**Control Plane Operator (CPO)** is the operator running in the management cluster that
+reconciles hosted control plane components.
+
+1. The cluster administrator identifies a need to increase log verbosity for a specific
+   control plane component (e.g., kube-apiserver) to diagnose an issue.
+2. The cluster administrator patches the HostedCluster CR to set the desired log level for
+   the target component:
+   ```bash
+   oc patch hostedcluster my-cluster --type=merge -p \
+     '{"spec":{"operatorConfiguration":{
+       "kubeAPIServer":{"logLevel":"Debug"}}}}'
+   ```
+3. The CPO detects the HostedCluster spec change and validates the log level value.
+4. The CPO translates the intent-based log level to the component-specific flag (e.g.,
+   `Debug` → `--v=4` for kube-apiserver).
+5. The CPO updates the component's deployment/statefulset with the new verbosity flag,
+   triggering a rolling restart.
+6. The component pods restart with the updated verbosity level.
+7. The CPO sets a `NonDefaultLogLevel` status condition on the HostedCluster indicating
+   that non-default log levels are active.
+8. The cluster administrator collects the verbose logs for diagnosis.
+9. After troubleshooting, the administrator resets the log level to `Normal` (or removes
+   the override), and the CPO triggers another rolling restart to restore default verbosity.
+
+#### Entry Point & Data Flow
+
+```mermaid
+flowchart TD
+    A["Cluster Administrator\nPatches HostedCluster CR with desired log level"]
+    B["HostedCluster CR\nUser-facing entry point — spec.operatorConfiguration"]
+    C["HostedControlPlane CR\nInternal resource in management cluster namespace"]
+    D["Deployment / StatefulSet\nContainer args (--v=N) or env vars (ETCD_LOG_LEVEL) updated"]
+    E["Rolling Restart\nZero downtime on HA — 3 replicas for KAS/etcd, 2 for controllers"]
+
+    A -->|"oc patch"| B
+    B -->|"hypershift-operator: DeepCopy"| C
+    C -->|"CPO: reads LogLevel, maps to flag/env var"| D
+    D -->|"Kubernetes: spec changed"| E
+```
+
+#### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Admin as Cluster Administrator
+    participant HC as HostedCluster CR
+    participant CPO as Control Plane Operator
+    participant Deploy as Component Deployment
+    participant Pod as Component Pod
+
+    Admin->>HC: Patch operatorConfiguration (e.g. kubeAPIServer.logLevel=Debug)
+    HC->>CPO: Reconcile event
+    CPO->>CPO: Validate log level value
+    CPO->>CPO: Map LogLevel to component flag (Debug → --v=4)
+    CPO->>Deploy: Update container args
+    Deploy->>Pod: Rolling restart
+    Pod-->>Pod: Starts with new verbosity
+    CPO-->>HC: Set NonDefaultLogLevel condition = True
+    Admin->>Pod: Collect verbose logs for diagnosis
+    Admin->>HC: Reset log level to Normal
+    HC->>CPO: Reconcile event
+    CPO->>Deploy: Restore default args (--v=2)
+    Deploy->>Pod: Rolling restart
+    CPO-->>HC: Clear NonDefaultLogLevel condition
+```
+
+### API Extensions
+
+This enhancement modifies the `HostedCluster` and `HostedControlPlane` CRDs by adding new
+optional pointer fields to the existing `OperatorConfiguration` struct. The existing
+`hypershift.openshift.io/kube-apiserver-verbosity-level` annotation is deprecated in favor
+of the new structured API.
+
+#### New Type: ComponentLogLevelSpec
+
+Added to `api/hypershift/v1beta1/operator.go` (where `LogLevel` is already defined):
+
+```go
+// ComponentLogLevelSpec specifies the log verbosity for a control plane component.
+type ComponentLogLevelSpec struct {
+    // logLevel configures the log verbosity for the component.
+    // Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+    // Defaults to "Normal".
+    //
+    // +optional
+    // +kubebuilder:default=Normal
+    // +kubebuilder:validation:Enum="";Normal;Debug;Trace;TraceAll
+    LogLevel LogLevel `json:"logLevel,omitempty"`
+}
+```
+
+#### New Fields in OperatorConfiguration
+
+Added to `api/hypershift/v1beta1/hostedcluster_types.go`, extending the existing
+`OperatorConfiguration` struct (which already has CVO, CNO, and Ingress fields):
+
+```go
+type OperatorConfiguration struct {
+    // ...existing ClusterVersionOperator, ClusterNetworkOperator, IngressOperator fields...
+
+    // kubeAPIServer configures the log verbosity of the kube-apiserver component.
+    // +optional
+    KubeAPIServer *ComponentLogLevelSpec `json:"kubeAPIServer,omitempty"`
+
+    // kubeControllerManager configures the log verbosity of the kube-controller-manager component.
+    // +optional
+    KubeControllerManager *ComponentLogLevelSpec `json:"kubeControllerManager,omitempty"`
+
+    // kubeScheduler configures the log verbosity of the kube-scheduler component.
+    // +optional
+    KubeScheduler *ComponentLogLevelSpec `json:"kubeScheduler,omitempty"`
+
+    // etcd configures the log verbosity of the etcd component.
+    // +optional
+    Etcd *ComponentLogLevelSpec `json:"etcd,omitempty"`
+
+    // openShiftAPIServer configures the log verbosity of the openshift-apiserver component.
+    // +optional
+    OpenShiftAPIServer *ComponentLogLevelSpec `json:"openShiftAPIServer,omitempty"`
+
+    // openShiftControllerManager configures the log verbosity of the openshift-controller-manager component.
+    // +optional
+    OpenShiftControllerManager *ComponentLogLevelSpec `json:"openShiftControllerManager,omitempty"`
+
+    // openShiftOAuthAPIServer configures the log verbosity of the openshift-oauth-apiserver component.
+    // +optional
+    OpenShiftOAuthAPIServer *ComponentLogLevelSpec `json:"openShiftOAuthAPIServer,omitempty"`
+
+    // oAuthServer configures the log verbosity of the oauth-server component.
+    // +optional
+    OAuthServer *ComponentLogLevelSpec `json:"oAuthServer,omitempty"`
+}
+```
+
+#### N-1/N+1 Compatibility
+
+| Direction                  | Behavior                                                                              |
+|----------------------------|---------------------------------------------------------------------------------------|
+| N+1 (new code, old data)   | Old data has no log level fields → nil pointers → defaults apply                      |
+| N-1 (old code, new data)   | New data has log level fields → old code ignores unknown JSON keys → no error         |
+
+**Propagation is automatic:** `OperatorConfiguration` is already embedded in
+`HostedControlPlaneSpec` and propagated via `DeepCopy()`. Adding new fields requires zero
+propagation code — `make update` regenerates the `DeepCopy` method to include them.
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+This enhancement is specifically designed for HyperShift hosted control planes. The log
+level configuration is set on the HostedCluster CR in the management cluster and propagated
+to the hosted control plane components running in the management cluster namespace. No
+changes are required in the guest cluster.
+
+For managed services (ROSA HCP, ARO HCP), service-level guardrails may be needed to
+restrict `TraceAll` log level, as glog level 8 can dump sensitive data including request
+bodies and secrets in component logs.
+
+#### Standalone Clusters
+
+This enhancement does not apply to standalone clusters. Standalone OCP clusters already
+have log level configuration via the `operatorv1.OperatorSpec.LogLevel` field on each
+operator's CR.
+
+#### Single-node Deployments or MicroShift
+
+This enhancement does not apply to single-node deployments or MicroShift. These topologies
+use standalone control plane components with existing log level configuration mechanisms.
+
+#### OpenShift Kubernetes Engine
+
+This enhancement applies to OKE deployments that use HyperShift for hosted control planes.
+The log level configuration behavior is identical to standard HyperShift deployments. OKE
+does not exclude any functionality required by this enhancement.
+
+### Implementation Details/Notes/Constraints
+
+The implementation follows a phased approach.
+
+#### Phase 1: kube-apiserver (first)
+
+kube-apiserver is implemented and validated first because it is the most requested
+component for log level tuning, has an existing annotation-based mechanism to deprecate,
+and establishes the pattern for all subsequent components.
+
+Log level changes apply to the **main container only**, not sidecars. This matches OCP
+behavior — sidecars have different logging models, and `UpdateContainer(ComponentName)`
+already targets the main container.
+
+Phase 1 delivers:
+
+1. **API types:** `ComponentLogLevelSpec` struct and the `KubeAPIServer` field in
+   `OperatorConfiguration`.
+2. **Mapping utility:** `LogLevelToKlogVerbosity()` in `support/util/loglevel.go`.
+3. **CPO integration for KAS:** Replace the existing annotation logic at
+   `v2/kas/deployment.go` with structured API field reading. Annotation fallback with lower
+   precedence during transition.
+4. **Annotation deprecation:** Both annotation and API field honored; new field wins.
+   Deprecation warning condition emitted when annotation is used.
+5. **Status reporting:** `NonDefaultLogLevel` condition on HostedCluster when any component
+   has a non-default log level.
+6. **Unit + E2E tests** for KAS log level propagation, annotation precedence, and HA
+   rolling restart.
+
+#### Phase 2: remaining 7 components (in parallel, after Phase 1 approval)
+
+Once Phase 1 is approved and merged, the remaining 7 components are implemented in parallel
+since they all follow the same pattern established by KAS:
+
+- kube-controller-manager, kube-scheduler, openshift-apiserver,
+  openshift-controller-manager, openshift-oauth-apiserver, oauth-server — all use klog
+  (`--v=N`), same `LogLevelToKlogVerbosity()` utility.
+- etcd — uses `ETCD_LOG_LEVEL` env var, requires a `LogLevelToEtcdLevel()` mapping
+  utility.
+
+#### CPO Integration by Component
+
+| Component                    | Phase | Logging Model  | File                                    | Mechanism                                    |
+|------------------------------|-------|----------------|-----------------------------------------|----------------------------------------------|
+| **kube-apiserver**           | **1** | klog           | `v2/kas/deployment.go`                  | `--v=N` (replaces annotation logic)          |
+| kube-controller-manager      | 2     | klog           | `v2/kcm/deployment.go`                  | `--v=N` appended to args                     |
+| kube-scheduler               | 2     | klog           | `v2/kube_scheduler/deployment.go`       | `--v=N` appended to args                     |
+| etcd                         | 2     | zap (non-klog) | `v2/etcd/statefulset.go`                | `ETCD_LOG_LEVEL` env var                     |
+| openshift-apiserver          | 2     | klog           | `v2/oapi/deployment.go`                 | `--v=N` appended to args                     |
+| openshift-controller-manager | 2     | klog           | `v2/ocm/component.go`                   | `--v=N` appended to args via adapt function  |
+| openshift-oauth-apiserver    | 2     | klog           | `v2/oauth_apiserver/deployment.go`      | `--v=N` (overrides hardcoded `--v=2`)        |
+| oauth-server                 | 2     | klog           | `v2/oauth/deployment.go`                | `--v=N` appended to args                     |
+
+#### Full Component Scope by Phase
+
+The table below captures the holistic scope of log level configurability across all
+CPO-managed components, per the architect's guidance to design this feature comprehensively.
+This enhancement covers all phases end-to-end; the initial implementation (this EP) delivers
+Phases 1 and 2. Phase 3 components are explicitly in scope for the enhancement at the
+holistic level and are deferred only as a sequencing decision. The `ComponentLogLevelSpec`
+API is designed to accommodate all phases with only additive, backward-compatible changes to
+`OperatorConfiguration`. The logging model column explains the per-component translation
+mechanism — it is an implementation detail, not a scope boundary.
+
+| Phase | Components | Logging Model | Count |
+|---|---|---|---|
+| **Phase 1** | kube-apiserver | klog (`--v=N`) | 1 |
+| **Phase 2** | kube-controller-manager, kube-scheduler, etcd, openshift-apiserver, openshift-controller-manager, openshift-oauth-apiserver, oauth-server | klog (`--v=N`) / zap (`ETCD_LOG_LEVEL` env var for etcd) | 7 |
+| **Phase 3 — klog-based managed components** | cluster-network-operator, cluster-version-operator, cluster-autoscaler, cluster-image-registry-operator, cluster-storage-operator, cluster-node-tuning-operator, cluster-policy-controller, csi-snapshot-controller-operator, dns-operator, ingress-operator, cloud-credential-operator, capi-provider, capi-manager, cluster-api, kubevirt-cloud-controller-manager, gcp-cloud-controller-manager, powervs-cloud-controller-manager, openstack-cloud-controller-manager, aws-cloud-controller-manager, azure-cloud-controller-manager, kubevirt-csi-controller, machine-approver, karpenter-operator, konnectivity-agent, olm-operator, catalog-operator, packageserver, openshift-route-controller-manager, endpoint-resolver | klog (`--v=N`); same `LogLevelToKlogVerbosity()` utility as Phases 1 & 2 | ~29 |
+| **Phase 3 — zap-based managed components** | hosted-cluster-config-operator (HCCO), control-plane-pki-operator, karpenter, ignition-server | zap (`--zap-log-level` / `--log-level`); requires `LogLevelToZapLevel()` mapping utility, analogous to `LogLevelToEtcdLevel()` introduced in Phase 2. ignition-server uses controller-runtime's zap integration via `ctrl.SetLogger(zap.New(...))` | 4 |
+| **Permanent non-goals** | `control-plane-operator` self, `certified-operators-catalog`, `community-operators-catalog`, `redhat-operators-catalog`, `redhat-marketplace-catalog`, `router`, `ignition-server-proxy`, `aws-node-termination-handler`, `olm-collect-profiles`, `featuregate-generator`, `metrics-proxy` | No standard configurable verbosity interface — excluded by design, not by sequencing | 11 |
+
+#### Phase 3 API Note: Components with Existing OperatorConfiguration Fields
+
+Three Phase 3 klog-based components — `cluster-version-operator`, `cluster-network-operator`,
+and `ingress-operator` — already have dedicated typed configuration structs in
+`OperatorConfiguration` (`ClusterVersionOperatorSpec`, `ClusterNetworkOperatorSpec`,
+`IngressOperatorSpec`). For these components, log level configuration will be added by
+embedding a `LogLevel` field within their existing typed structs rather than introducing
+parallel `*ComponentLogLevelSpec` fields. This avoids creating two configuration entry points
+for the same component while keeping a single, natural location for all per-component
+configuration. The `LogLevel` field will use the same `LogLevel` type and follow the same
+semantics as `ComponentLogLevelSpec.LogLevel`, ensuring uniform behavior across all phases.
+
+#### HA Rolling Restart — Zero Downtime
+
+| Component                    | Replicas (HA) | Why No Impact                                          |
+|------------------------------|---------------|--------------------------------------------------------|
+| kube-apiserver               | 3             | Load balanced — 2 still serving while 1 restarts       |
+| kube-controller-manager      | 2             | Leader election — standby takes over in seconds        |
+| kube-scheduler               | 2             | Leader election                                        |
+| etcd                         | 3             | Raft quorum — 2 of 3 healthy during rolling update     |
+| openshift-apiserver          | 3             | Load balanced                                          |
+| openshift-controller-manager | 2             | Leader election                                        |
+| openshift-oauth-apiserver    | 3             | Load balanced                                          |
+| oauth-server                 | 3             | Load balanced — request-serving component              |
+
+**ROSA HCP / ARO HCP:** Always HighlyAvailable. `SingleReplica` is never used. Zero
+downtime guaranteed.
+
+### Risks and Mitigations
+
+**Risk:** `TraceAll` (glog level 8) can dump sensitive data including request bodies and
+secrets in component logs.
+**Mitigation:** Document operational warnings for `TraceAll` in API docs and release notes.
+Consider adding validation warnings or status conditions when `TraceAll` is set. Managed
+services may restrict this level via admission webhooks.
+
+**Risk:** High verbosity levels significantly increase log volume, potentially impacting log
+storage and cluster performance.
+**Mitigation:** Add status conditions when non-default log levels are active so SREs can
+monitor and alert on elevated verbosity. Document storage impact guidance per log level.
+
+**Risk:** `TraceAll` on managed services (ROSA HCP, ARO HCP) could expose secrets in logs
+flowing to CloudWatch or Azure Monitor (customer-visible).
+**Mitigation:** Add admission policy or CEL rule blocking `TraceAll` on managed service
+clusters. Access model (customer self-service vs SRE/CEE only) to be decided with PM.
+
+**Risk:** High verbosity on managed services (ROSA HCP, ARO HCP) increases log volume
+flowing to CloudWatch or Azure Monitor, potentially impacting storage costs.
+**Mitigation:** Assess cost impact of `Debug` and `Trace` levels per component. Consider
+auto-revert to `Normal` after a configurable timeout if needed.
+
+**Risk:** Rolling restarts during log level changes could cause brief API unavailability if
+multiple components are changed simultaneously.
+**Mitigation:** The CPO should apply changes sequentially across components to avoid
+simultaneous restarts.
+
+### Drawbacks
+
+- Adds API surface to the HostedCluster CRD that requires ongoing maintenance and
+  documentation.
+- The mapping between intent-based log levels and component-specific flags is not a perfect
+  abstraction — etcd uses a different logging model (level-based vs. numeric verbosity) and
+  some nuance is lost in translation.
+- Log level changes trigger rolling restarts, which is a heavier operation than the in-place
+  dynamic reconfiguration some users might expect.
+
+## Alternatives (Not Implemented)
+
+1. **Extend the existing annotation pattern:** Add per-component annotations similar to the
+   existing KAS verbosity annotation. This was rejected because annotations are unvalidated,
+   not discoverable via `oc explain`, and inconsistent with OCP operator conventions.
+
+2. **Expose raw numeric verbosity levels:** Allow users to set raw `--v=N` values directly.
+   This was rejected because it does not provide operational parity with OCP's intent-based
+   `LogLevel` pattern, requires users to know component-specific verbosity semantics, and
+   does not translate well to etcd's level-based logging.
+
+3. **Dynamic log level reconfiguration without restart:** Some components support runtime
+   log level changes. This was considered but rejected for the initial implementation
+   because not all target components support it, and the rolling restart approach provides
+   consistent behavior across all components.
+
+## Open Questions
+
+1. Should managed services (ROSA HCP, ARO HCP) expose log level configuration to customers
+   via ROSA CLI / OCM, or restrict it to SRE/CEE only? Access model to be decided with PM.
+
+2. What is the appropriate deprecation timeline for the existing
+   `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation? Current
+   recommendation: deprecated on merge, removed in N+2.
+
+## Test Plan
+
+The testing strategy covers the following areas:
+
+- **Unit tests:** Validate `LogLevelToKlogVerbosity()` mapping for all enum values + nil
+  (klog `--v=N`).
+- **Unit tests:** Validate `LogLevelToEtcdLevel()` mapping for all enum values + nil
+  (`ETCD_LOG_LEVEL`).
+- **Serialization compat tests:** N-1/N+1 roundtrip for `OperatorConfiguration` with new
+  fields set, mixed, and empty.
+- **Envtest (CEL) tests:** Valid log levels accepted, invalid values rejected by enum
+  validation.
+- **Unit tests per component:** Each of the 8 CPO integration points tested with all log
+  level values.
+- **KAS-specific unit tests:** Annotation fallback, API field precedence over annotation,
+  invalid annotation handling.
+- **E2E tests:** Set KAS LogLevel to Debug → verify pod restarts with `--v=4`; cluster
+  stays healthy.
+- **E2E tests:** Remove KAS LogLevel (nil) → verify pod rolls back to `--v=2`.
+- **E2E tests:** Set etcd LogLevel to Debug → verify pod restarts with
+  `ETCD_LOG_LEVEL=debug`.
+- **E2E tests:** KAS annotation deprecation path — annotation works, API field overrides,
+  annotation ignored when both set.
+- **E2E tests:** HA rolling restart — no API downtime during rollout (health checks pass
+  continuously).
+
+Tests should include `[Jira:"Hosted Control Planes"]` labels for the component. Since this
+feature ships ungated, no `[OCPFeatureGate:...]` label is needed.
+
+## Graduation Criteria
+
+This feature ships **GA in the target release** with no feature gate. Dev Preview and Tech
+Preview stages are skipped because this enhancement adds optional, backward-compatible fields
+to an already-GA API surface (`OperatorConfiguration`) using an already-GA type (`LogLevel`).
+The feature is a low-risk operational knob — nil fields preserve existing behavior, and the
+CPO reconciliation path is well-established. There is no new controller, no new CRD, and no
+behavioral change for clusters that do not opt in.
+
+### Dev Preview -> Tech Preview
+
+N/A. This feature skips Dev Preview and Tech Preview. See rationale above.
+
+### Tech Preview -> GA
+
+N/A. This feature ships directly as GA. See rationale above.
+
+### GA Criteria
+
+- Ability to set log levels for all 8 core control plane components via the HostedCluster
+  CR end to end.
+- Log level changes propagate correctly and components restart with the expected verbosity.
+- Unit tests for LogLevel-to-flag mapping (klog and etcd).
+- Serialization compatibility tests (N-1/N+1 roundtrip).
+- Envtest cases for CEL/enum validation.
+- E2E tests for propagation, reset, annotation deprecation path, and HA rolling restart
+  with zero downtime.
+- Deprecation notice published for the existing KAS verbosity annotation.
+- Verification on all supported platforms: AWS/ROSA, Azure/ARO, KubeVirt, IBM, OpenStack,
+  and Agent.
+- CEE validation with [RFE-7777](https://issues.redhat.com/browse/RFE-7777) reporter
+  confirms the feature solves their problem.
+- User-facing documentation created in
+  [openshift-docs](https://github.com/openshift/openshift-docs/)
+  ([OSDOCS-19157](https://issues.redhat.com/browse/OSDOCS-19157)).
+
+### Removing a deprecated feature
+
+The existing `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation is
+deprecated on merge of this feature and will be removed in N+2 (two minor releases after
+GA).
+
+## Upgrade / Downgrade Strategy
+
+**Upgrade:** The new log level fields are optional pointer types with `omitempty`. Clusters
+upgrading from a version without this feature will have `nil` log level fields, and the CPO
+will continue to use default verbosity (`Normal`). No action is required from the
+administrator to maintain previous behavior. The existing KAS verbosity annotation will
+continue to be honored during the transition period; if both the annotation and the new API
+field are set, the API field takes precedence.
+
+**Downgrade:** If a cluster is downgraded to a version that does not support the new log
+level fields, the fields will be ignored by the older CPO. Components will revert to
+default verbosity on the next reconciliation. Administrators should reset log levels to
+`Normal` before downgrading to avoid unexpected behavior during the transition.
+
+Each component remains available during log level changes because the CPO uses rolling
+restarts with proper pod disruption budgets.
+
+## Version Skew Strategy
+
+During an upgrade, the management cluster CPO may be at version N+1 while some hosted
+control plane components are still at version N. This is safe because:
+
+- The log level configuration is applied at the deployment/statefulset level by the CPO.
+  The CPO at N+1 will set the verbosity flags on component containers regardless of their
+  version.
+- The `--v=N` flag and `ETCD_LOG_LEVEL` env var are stable across Kubernetes and etcd
+  versions and are not version-specific.
+- If the CPO at N+1 sets a log level field that a component at version N does not
+  recognize, the flag is still a valid command line argument and the component will honor
+  it.
+
+## Operational Aspects of API Extensions
+
+This enhancement adds optional fields to the existing `HostedCluster` and
+`HostedControlPlane` CRDs. No new webhooks, aggregated API servers, or finalizers are
+introduced.
+
+**SLIs — detecting health of log level configuration:**
+
+The CPO reports a `NonDefaultLogLevel` status condition on the HostedCluster:
+
+- `HostedCluster` condition `NonDefaultLogLevel=True` — one or more components are running
+  with elevated verbosity. Administrators and SREs can alert on this to track clusters with
+  non-standard log volume.
+- `HostedCluster` condition `NonDefaultLogLevel=False` — all components running at default
+  verbosity.
+
+**Impact on existing SLIs:**
+
+- No impact at `Normal` log level.
+- Higher verbosity levels increase log volume proportionally. This may affect log storage
+  consumption but does not affect API availability, control plane latency, or scheduling
+  performance at `Debug` or `Trace` levels under normal workloads.
+- Expected use cases require short-lived non-default log level windows (minutes to hours
+  during incident investigation), not permanent elevation.
+
+**How impact is measured:**
+
+- Log volume per component per verbosity level should be characterized by the QE team
+  during validation testing.
+- No performance team review required — this is a per-cluster operational configuration
+  that does not affect management cluster API throughput or scheduling.
+
+**Failure modes:**
+
+- If an invalid log level is specified, CRD enum validation rejects the value at admission
+  time. The component continues running at its current verbosity.
+- If a log level change causes a failed rolling restart (e.g., resource constraints prevent
+  new pod scheduling), the CPO reports a degraded condition on the HostedCluster. Standard
+  rollback procedures apply — the previous pod generation remains running.
+- If the CPO itself is unavailable during a log level change, the change is queued and
+  applied on CPO recovery. No component restarts occur without CPO orchestration.
+
+**Escalation:** The HyperShift / Hosted Control Planes team is responsible for issues
+related to log level configuration.
+
+## Support Procedures
+
+**Detecting non-default log levels:**
+
+Check the HostedCluster status conditions for `NonDefaultLogLevel=True`:
+
+```bash
+oc get hostedcluster my-cluster -o jsonpath='{.status.conditions[?(@.type=="NonDefaultLogLevel")]}'
+```
+
+Alternatively, inspect the spec directly:
+
+```bash
+oc get hostedcluster my-cluster -o jsonpath='{.spec.operatorConfiguration}'
+```
+
+**Symptoms of excessive verbosity:**
+
+Increased log volume in the management cluster namespace, potential log storage pressure,
+and slightly increased CPU usage on control plane pods. Check pod log rates with:
+
+```bash
+oc logs -n <hcp-namespace> deployment/kube-apiserver --tail=100
+```
+
+**Resetting to defaults:**
+
+Patch the HostedCluster CR to remove a specific component's log level override:
+
+```bash
+oc patch hostedcluster my-cluster --type=json -p \
+  '[{"op":"remove",
+    "path":"/spec/operatorConfiguration/kubeAPIServer"}]'
+```
+
+To reset all components at once:
+
+```bash
+oc patch hostedcluster my-cluster --type=json -p \
+  '[{"op":"remove","path":"/spec/operatorConfiguration/kubeAPIServer"},
+    {"op":"remove","path":"/spec/operatorConfiguration/etcd"}]'
+```
+
+**Graceful degradation:**
+
+If log level configuration fields are removed or reset, the CPO restores default verbosity
+on the next reconciliation. No data loss or cluster instability results from changing or
+removing log level settings. The feature fails safely — components continue running at
+their current verbosity until the CPO successfully applies the new setting.
+
+**Disabling the feature:**
+
+This enhancement does not introduce a webhook or aggregated API server that can be disabled
+independently. Log level configuration is part of the standard CPO reconciliation loop. To
+effectively disable the feature, reset all log level fields to `Normal` or remove them from
+the HostedCluster spec.
+
+## Implementation History
+
+- 2026-06-09: EP created (provisional)
+
+## Infrastructure Needed
+
+No new infrastructure is required. This enhancement uses existing HyperShift CI
+infrastructure and Prow job configurations for testing.

--- a/enhancements/hypershift/configurable-log-levels-for-hosted-control-plane-components.md
+++ b/enhancements/hypershift/configurable-log-levels-for-hosted-control-plane-components.md
@@ -8,14 +8,16 @@ authors:
   - "@vismishr"
   - "@vsolanki12"
 reviewers:
-  - "@ahmed"
+  - "@devguyio"
+  - "@celebdor"
 approvers:
   - "@csrwng"
-  - "@ahmed"
+  - "@devguyio"
 api-approvers:
   - "@joelspeed"
+  - "@enxebre"
 creation-date: 2026-06-09
-last-updated: 2026-06-15
+last-updated: 2026-07-26
 status: provisional
 tracking-link:
   - https://issues.redhat.com/browse/OCPSTRAT-3156
@@ -40,11 +42,12 @@ kube-controller-manager, kube-scheduler, etcd, openshift-apiserver,
 openshift-controller-manager, openshift-oauth-apiserver, and oauth-server. The CPO will
 translate these intent-based levels into component-specific mechanisms (`--v=N` for
 klog-based components, `ETCD_LOG_LEVEL` env var for etcd), achieving operational parity
-with standard OCP's `operatorv1.OperatorSpec.LogLevel` pattern. The new fields are added
-as structured `*ComponentLogLevelSpec` pointers in the existing `OperatorConfiguration`
-type. The design is intentionally generic to extend to all remaining CPO-managed components
-in future phases. This feature ships ungated (no feature gate) as a low-risk operational
-knob that extends an already-GA framework.
+with standard OCP's `operatorv1.OperatorSpec.LogLevel` pattern. Each component gets a
+dedicated per-component type (e.g., `KubeAPIServerOperatorSpec`) that embeds the shared
+`ComponentLogLevelSpec` via struct embedding, added to the existing `OperatorConfiguration`
+type. This design is future-proof — each component type can be independently extended
+without breaking changes. The new fields are gated behind a feature gate and follow a
+**gate first, promote when ready** lifecycle.
 
 ## Motivation
 
@@ -88,20 +91,13 @@ as "crucial even for the most minimal troubleshooting."
   temporarily set `Trace` level on openshift-apiserver and openshift-controller-manager so
   that I can capture detailed component behavior before promoting changes to production.
 
-- As an **SRE** operating hosted clusters at scale, I want to monitor which hosted clusters
-  have non-default log levels active so that I can identify clusters with elevated log
-  volume and ensure log storage capacity is not exceeded.
-
 ### Goals
 
-This enhancement is delivered in phases:
-
-**Phase 1 — kube-apiserver (initial delivery)**
-
-1. Enable administrators to configure log verbosity for kube-apiserver via the HostedCluster
-   CR, replacing the existing ad-hoc annotation-based mechanism.
+1. Enable administrators to configure log verbosity for all 8 core control plane components
+   via the HostedCluster CR, replacing the existing ad-hoc annotation-based mechanism for
+   kube-apiserver.
 2. Establish the `ComponentLogLevelSpec` pattern and `LogLevelToKlogVerbosity()` utility
-   that all subsequent phases reuse.
+   reused across all klog-based components.
 3. Provide a deprecation path for the existing
    `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation.
 4. Achieve operational parity with standard OCP's `operatorv1.LogLevel` pattern using
@@ -109,28 +105,14 @@ This enhancement is delivered in phases:
 5. Ensure log level changes take effect via rolling restart without cluster disruption or
    downtime.
 
-**Phase 2 — remaining core control plane components**
-
-6. Extend log level configuration to: kube-controller-manager, kube-scheduler, etcd,
-   openshift-apiserver, openshift-controller-manager, openshift-oauth-apiserver, and
-   oauth-server, using the same pattern established in Phase 1.
-
-**Phase 3 — all remaining CPO-managed components (future)**
-
-7. Extend log level configuration to all remaining klog-based CPO-managed components,
-   including components with hardcoded `--v=N` values in their asset manifests and
-   components using klog defaults, as well as zap-based operator components (HCCO,
-   PKI-operator) and karpenter via custom level mappings.
-8. The `ComponentLogLevelSpec` API design is intentionally generic to enable this extension
-   with only additive, backward-compatible changes to `OperatorConfiguration`.
-
 ### Non-Goals
 
-1. **Configuring all ~50 CPO-managed components in Phases 1 and 2.** Phases 1 and 2 cover
-   the 8 core control plane components. Phase 3 (future) covers remaining components.
+1. **Configuring all CPO-managed components in this enhancement.** This enhancement covers
+   the 8 core control plane components. Additional components may be addressed in follow-up
+   enhancements.
 
-2. **The following components are permanently out of scope** due to their logging model not
-   supporting a standard configurable verbosity interface compatible with the
+2. **The following components are out of scope for this enhancement** due to their logging
+   model not supporting a standard configurable verbosity interface compatible with the
    `Normal/Debug/Trace/TraceAll` abstraction:
    - `control-plane-operator` self-log-level: the CPO binary is deployed by the
      *hypershift-operator*, not by CPO's own reconciliation loop. CPO cannot configure its
@@ -165,26 +147,18 @@ mapping to the following glog/klog verbosity levels:
 |------------------|------------|----------------------|---------------------------------------------------|
 | Normal (default) | 2          | info                 | Production                                        |
 | Debug            | 4          | debug                | Troubleshooting                                   |
-| Trace            | 6          | debug                | Deep investigation                                |
-| TraceAll         | 8          | debug                | Full dumps — perf impact, may expose secrets      |
+| Trace            | 6          | debug¹               | Deep investigation                                |
+| TraceAll         | 8          | debug¹               | Full dumps — perf impact, may expose secrets      |
 
-The chosen API design is **Option B — Structured fields** in `OperatorConfiguration`. This
-extends the existing pattern (which already has `ClusterVersionOperator`,
-`ClusterNetworkOperator`, and `IngressOperator` fields) with new optional
-`*ComponentLogLevelSpec` pointer fields. Each component uses `*ComponentLogLevelSpec`
-directly.
+¹ etcd uses zap logging which has no granularity below `debug` — Trace and TraceAll both
+map to `debug`.
 
-> **Why etcd uses `ETCD_LOG_LEVEL` env var and not `--log-level` flag:** etcd is started
-> via a shell one-liner (`/bin/sh -c "... /usr/bin/etcd"`). Injecting a CLI flag means
-> string-manipulating the shell command — fragile and breaks if the command format changes.
-> `ETCD_LOG_LEVEL` matches all 15 existing etcd config values and uses the existing
-> `util.UpsertEnvVar()` utility (from `support/util/containers.go`). etcd internally maps
-> `ETCD_*` env vars to their `--*` flag equivalents.
-
-> **Why Trace and TraceAll both map to `debug` for etcd:** etcd uses zap, which supports:
-> debug, info, warn, error, panic, fatal. There is no finer granularity below debug. klog
-> has numeric levels (2/4/6/8) giving four distinct settings; etcd only gives two useful
-> ones (info and debug).
+The chosen API design uses **structured per-component fields** in `OperatorConfiguration`.
+This extends the existing pattern (which already has `ClusterVersionOperator`,
+`ClusterNetworkOperator`, and `IngressOperator` fields) with new per-component types, each
+embedding the shared `ComponentLogLevelSpec` via `json:",inline"`. Each component gets a
+dedicated Go type (e.g., `KubeAPIServerOperatorSpec`) that can be independently extended in
+the future without breaking vendoring consumers.
 
 When no log level is specified for a component, the default (`Normal`) is used, preserving
 backward compatibility.
@@ -212,10 +186,8 @@ reconciles hosted control plane components.
 5. The CPO updates the component's deployment/statefulset with the new verbosity flag,
    triggering a rolling restart.
 6. The component pods restart with the updated verbosity level.
-7. The CPO sets a `NonDefaultLogLevel` status condition on the HostedCluster indicating
-   that non-default log levels are active.
-8. The cluster administrator collects the verbose logs for diagnosis.
-9. After troubleshooting, the administrator resets the log level to `Normal` (or removes
+7. The cluster administrator collects the verbose logs for diagnosis.
+8. After troubleshooting, the administrator resets the log level to `Normal` (or removes
    the override), and the CPO triggers another rolling restart to restore default verbosity.
 
 #### Entry Point & Data Flow
@@ -251,19 +223,17 @@ sequenceDiagram
     CPO->>Deploy: Update container args
     Deploy->>Pod: Rolling restart
     Pod-->>Pod: Starts with new verbosity
-    CPO-->>HC: Set NonDefaultLogLevel condition = True
     Admin->>Pod: Collect verbose logs for diagnosis
     Admin->>HC: Reset log level to Normal
     HC->>CPO: Reconcile event
     CPO->>Deploy: Restore default args (--v=2)
     Deploy->>Pod: Rolling restart
-    CPO-->>HC: Clear NonDefaultLogLevel condition
 ```
 
 ### API Extensions
 
 This enhancement modifies the `HostedCluster` and `HostedControlPlane` CRDs by adding new
-optional pointer fields to the existing `OperatorConfiguration` struct. The existing
+fields to the existing `OperatorConfiguration` struct. The existing
 `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation is deprecated in favor
 of the new structured API.
 
@@ -273,15 +243,64 @@ Added to `api/hypershift/v1beta1/operator.go` (where `LogLevel` is already defin
 
 ```go
 // ComponentLogLevelSpec specifies the log verbosity for a control plane component.
+// +kubebuilder:validation:MinProperties=1
 type ComponentLogLevelSpec struct {
-    // logLevel configures the log verbosity for the component.
+    // logLevel sets the log verbosity for the component.
     // Valid values are: "Normal", "Debug", "Trace", "TraceAll".
-    // Defaults to "Normal".
-    //
+    // Setting this field triggers a rolling restart of the component.
+    // When omitted, this means the user has no opinion and the platform
+    // defaults to Normal, which is subject to change over time.
     // +optional
-    // +kubebuilder:default=Normal
-    // +kubebuilder:validation:Enum="";Normal;Debug;Trace;TraceAll
-    LogLevel LogLevel `json:"logLevel,omitempty"`
+    LogLevel *LogLevel `json:"logLevel,omitempty"`
+}
+```
+
+#### Per-Component Wrapper Types
+
+Each component gets a dedicated type that embeds `ComponentLogLevelSpec`. This allows
+future per-component extension (e.g., adding `resourceOverrides` to
+`KubeAPIServerOperatorSpec`) without breaking Go types for vendoring consumers. The YAML
+wire format is unchanged.
+
+```go
+// KubeAPIServerOperatorSpec configures the kube-apiserver component.
+type KubeAPIServerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// KubeControllerManagerOperatorSpec configures the kube-controller-manager component.
+type KubeControllerManagerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// KubeSchedulerOperatorSpec configures the kube-scheduler component.
+type KubeSchedulerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// EtcdOperatorSpec configures the etcd component.
+type EtcdOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// OpenShiftAPIServerOperatorSpec configures the openshift-apiserver component.
+type OpenShiftAPIServerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// OpenShiftControllerManagerOperatorSpec configures the openshift-controller-manager component.
+type OpenShiftControllerManagerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// OpenShiftOAuthAPIServerOperatorSpec configures the openshift-oauth-apiserver component.
+type OpenShiftOAuthAPIServerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
+}
+
+// OAuthServerOperatorSpec configures the oauth-server component.
+type OAuthServerOperatorSpec struct {
+    ComponentLogLevelSpec `json:",inline"`
 }
 ```
 
@@ -294,37 +313,53 @@ Added to `api/hypershift/v1beta1/hostedcluster_types.go`, extending the existing
 type OperatorConfiguration struct {
     // ...existing ClusterVersionOperator, ClusterNetworkOperator, IngressOperator fields...
 
-    // kubeAPIServer configures the log verbosity of the kube-apiserver component.
+    // kubeAPIServer configures the kube-apiserver component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // kube-apiserver runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
     // +optional
-    KubeAPIServer *ComponentLogLevelSpec `json:"kubeAPIServer,omitempty"`
+    KubeAPIServer KubeAPIServerOperatorSpec `json:"kubeAPIServer,omitzero"`
 
-    // kubeControllerManager configures the log verbosity of the kube-controller-manager component.
+    // kubeControllerManager configures the kube-controller-manager component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // kube-controller-manager uses leader election — the standby takes over during restart.
     // +optional
-    KubeControllerManager *ComponentLogLevelSpec `json:"kubeControllerManager,omitempty"`
+    KubeControllerManager KubeControllerManagerOperatorSpec `json:"kubeControllerManager,omitzero"`
 
-    // kubeScheduler configures the log verbosity of the kube-scheduler component.
+    // kubeScheduler configures the kube-scheduler component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // kube-scheduler uses leader election — the standby takes over during restart.
     // +optional
-    KubeScheduler *ComponentLogLevelSpec `json:"kubeScheduler,omitempty"`
+    KubeScheduler KubeSchedulerOperatorSpec `json:"kubeScheduler,omitzero"`
 
-    // etcd configures the log verbosity of the etcd component.
+    // etcd configures the etcd component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // etcd runs with 3 replicas — Raft quorum is maintained during rolling update.
     // +optional
-    Etcd *ComponentLogLevelSpec `json:"etcd,omitempty"`
+    Etcd EtcdOperatorSpec `json:"etcd,omitzero"`
 
-    // openShiftAPIServer configures the log verbosity of the openshift-apiserver component.
+    // openShiftAPIServer configures the openshift-apiserver component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // openshift-apiserver runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
     // +optional
-    OpenShiftAPIServer *ComponentLogLevelSpec `json:"openShiftAPIServer,omitempty"`
+    OpenShiftAPIServer OpenShiftAPIServerOperatorSpec `json:"openShiftAPIServer,omitzero"`
 
-    // openShiftControllerManager configures the log verbosity of the openshift-controller-manager component.
+    // openShiftControllerManager configures the openshift-controller-manager component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // openshift-controller-manager uses leader election — the standby takes over during restart.
     // +optional
-    OpenShiftControllerManager *ComponentLogLevelSpec `json:"openShiftControllerManager,omitempty"`
+    OpenShiftControllerManager OpenShiftControllerManagerOperatorSpec `json:"openShiftControllerManager,omitzero"`
 
-    // openShiftOAuthAPIServer configures the log verbosity of the openshift-oauth-apiserver component.
+    // openShiftOAuthAPIServer configures the openshift-oauth-apiserver component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // openshift-oauth-apiserver runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
     // +optional
-    OpenShiftOAuthAPIServer *ComponentLogLevelSpec `json:"openShiftOAuthAPIServer,omitempty"`
+    OpenShiftOAuthAPIServer OpenShiftOAuthAPIServerOperatorSpec `json:"openShiftOAuthAPIServer,omitzero"`
 
-    // oAuthServer configures the log verbosity of the oauth-server component.
+    // oauthServer configures the oauth-server component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // oauth-server runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
     // +optional
-    OAuthServer *ComponentLogLevelSpec `json:"oAuthServer,omitempty"`
+    OAuthServer OAuthServerOperatorSpec `json:"oauthServer,omitzero"`
 }
 ```
 
@@ -332,7 +367,7 @@ type OperatorConfiguration struct {
 
 | Direction                  | Behavior                                                                              |
 |----------------------------|---------------------------------------------------------------------------------------|
-| N+1 (new code, old data)   | Old data has no log level fields → nil pointers → defaults apply                      |
+| N+1 (new code, old data)   | Old data has no log level fields → zero-value structs → defaults apply                |
 | N-1 (old code, new data)   | New data has log level fields → old code ignores unknown JSON keys → no error         |
 
 **Propagation is automatic:** `OperatorConfiguration` is already embedded in
@@ -348,9 +383,11 @@ level configuration is set on the HostedCluster CR in the management cluster and
 to the hosted control plane components running in the management cluster namespace. No
 changes are required in the guest cluster.
 
-For managed services (ROSA HCP, ARO HCP), service-level guardrails may be needed to
-restrict `TraceAll` log level, as glog level 8 can dump sensitive data including request
-bodies and secrets in component logs.
+For managed services (ROSA HCP, ARO HCP), service-level guardrails are required before
+promoting this feature to GA. The feature gate prevents the fields from being available on
+managed service clusters until promoted. The `TraceAll` access policy (CEL rule or
+admission webhook) for managed services is a promotion prerequisite — see Graduation
+Criteria.
 
 #### Standalone Clusters
 
@@ -385,18 +422,15 @@ already targets the main container.
 
 Phase 1 delivers:
 
-1. **API types:** `ComponentLogLevelSpec` struct and the `KubeAPIServer` field in
-   `OperatorConfiguration`.
+1. **API types:** `ComponentLogLevelSpec` struct, `KubeAPIServerOperatorSpec` wrapper type,
+   and the `KubeAPIServer` field in `OperatorConfiguration`.
 2. **Mapping utility:** `LogLevelToKlogVerbosity()` in `support/util/loglevel.go`.
 3. **CPO integration for KAS:** Replace the existing annotation logic at
    `v2/kas/deployment.go` with structured API field reading. Annotation fallback with lower
    precedence during transition.
 4. **Annotation deprecation:** Both annotation and API field honored; new field wins.
    Deprecation warning condition emitted when annotation is used.
-5. **Status reporting:** `NonDefaultLogLevel` condition on HostedCluster when any component
-   has a non-default log level.
-6. **Unit + E2E tests** for KAS log level propagation, annotation precedence, and HA
-   rolling restart.
+5. **Unit tests** for KAS log level propagation and annotation precedence.
 
 #### Phase 2: remaining 7 components (in parallel, after Phase 1 approval)
 
@@ -415,43 +449,12 @@ since they all follow the same pattern established by KAS:
 |------------------------------|-------|----------------|-----------------------------------------|----------------------------------------------|
 | **kube-apiserver**           | **1** | klog           | `v2/kas/deployment.go`                  | `--v=N` (replaces annotation logic)          |
 | kube-controller-manager      | 2     | klog           | `v2/kcm/deployment.go`                  | `--v=N` appended to args                     |
-| kube-scheduler               | 2     | klog           | `v2/kube_scheduler/deployment.go`       | `--v=N` appended to args                     |
+| kube-scheduler               | 2     | klog           | `v2/kube_scheduler/deployment.go`       | `--v=N` (replaces hardcoded `--v=2`)         |
 | etcd                         | 2     | zap (non-klog) | `v2/etcd/statefulset.go`                | `ETCD_LOG_LEVEL` env var                     |
 | openshift-apiserver          | 2     | klog           | `v2/oapi/deployment.go`                 | `--v=N` appended to args                     |
 | openshift-controller-manager | 2     | klog           | `v2/ocm/component.go`                   | `--v=N` appended to args via adapt function  |
 | openshift-oauth-apiserver    | 2     | klog           | `v2/oauth_apiserver/deployment.go`      | `--v=N` (overrides hardcoded `--v=2`)        |
 | oauth-server                 | 2     | klog           | `v2/oauth/deployment.go`                | `--v=N` appended to args                     |
-
-#### Full Component Scope by Phase
-
-The table below captures the holistic scope of log level configurability across all
-CPO-managed components, per the architect's guidance to design this feature comprehensively.
-This enhancement covers all phases end-to-end; the initial implementation (this EP) delivers
-Phases 1 and 2. Phase 3 components are explicitly in scope for the enhancement at the
-holistic level and are deferred only as a sequencing decision. The `ComponentLogLevelSpec`
-API is designed to accommodate all phases with only additive, backward-compatible changes to
-`OperatorConfiguration`. The logging model column explains the per-component translation
-mechanism — it is an implementation detail, not a scope boundary.
-
-| Phase | Components | Logging Model | Count |
-|---|---|---|---|
-| **Phase 1** | kube-apiserver | klog (`--v=N`) | 1 |
-| **Phase 2** | kube-controller-manager, kube-scheduler, etcd, openshift-apiserver, openshift-controller-manager, openshift-oauth-apiserver, oauth-server | klog (`--v=N`) / zap (`ETCD_LOG_LEVEL` env var for etcd) | 7 |
-| **Phase 3 — klog-based managed components** | cluster-network-operator, cluster-version-operator, cluster-autoscaler, cluster-image-registry-operator, cluster-storage-operator, cluster-node-tuning-operator, cluster-policy-controller, csi-snapshot-controller-operator, dns-operator, ingress-operator, cloud-credential-operator, capi-provider, capi-manager, cluster-api, kubevirt-cloud-controller-manager, gcp-cloud-controller-manager, powervs-cloud-controller-manager, openstack-cloud-controller-manager, aws-cloud-controller-manager, azure-cloud-controller-manager, kubevirt-csi-controller, machine-approver, karpenter-operator, konnectivity-agent, olm-operator, catalog-operator, packageserver, openshift-route-controller-manager, endpoint-resolver | klog (`--v=N`); same `LogLevelToKlogVerbosity()` utility as Phases 1 & 2 | ~29 |
-| **Phase 3 — zap-based managed components** | hosted-cluster-config-operator (HCCO), control-plane-pki-operator, karpenter, ignition-server | zap (`--zap-log-level` / `--log-level`); requires `LogLevelToZapLevel()` mapping utility, analogous to `LogLevelToEtcdLevel()` introduced in Phase 2. ignition-server uses controller-runtime's zap integration via `ctrl.SetLogger(zap.New(...))` | 4 |
-| **Permanent non-goals** | `control-plane-operator` self, `certified-operators-catalog`, `community-operators-catalog`, `redhat-operators-catalog`, `redhat-marketplace-catalog`, `router`, `ignition-server-proxy`, `aws-node-termination-handler`, `olm-collect-profiles`, `featuregate-generator`, `metrics-proxy` | No standard configurable verbosity interface — excluded by design, not by sequencing | 11 |
-
-#### Phase 3 API Note: Components with Existing OperatorConfiguration Fields
-
-Three Phase 3 klog-based components — `cluster-version-operator`, `cluster-network-operator`,
-and `ingress-operator` — already have dedicated typed configuration structs in
-`OperatorConfiguration` (`ClusterVersionOperatorSpec`, `ClusterNetworkOperatorSpec`,
-`IngressOperatorSpec`). For these components, log level configuration will be added by
-embedding a `LogLevel` field within their existing typed structs rather than introducing
-parallel `*ComponentLogLevelSpec` fields. This avoids creating two configuration entry points
-for the same component while keeping a single, natural location for all per-component
-configuration. The `LogLevel` field will use the same `LogLevel` type and follow the same
-semantics as `ComponentLogLevelSpec.LogLevel`, ensuring uniform behavior across all phases.
 
 #### HA Rolling Restart — Zero Downtime
 
@@ -466,26 +469,46 @@ semantics as `ComponentLogLevelSpec.LogLevel`, ensuring uniform behavior across 
 | openshift-oauth-apiserver    | 3             | Load balanced                                          |
 | oauth-server                 | 3             | Load balanced — request-serving component              |
 
-**ROSA HCP / ARO HCP:** Always HighlyAvailable. `SingleReplica` is never used. Zero
-downtime guaranteed.
+**ROSA HCP / ARO HCP:** `controllerAvailabilityPolicy` is always `HighlyAvailable` for
+managed services — control plane components run with full HA replica counts. Zero downtime
+guaranteed during rolling restarts.
+
+**Multi-component changes:** When multiple components are changed in a single `oc patch`,
+the CPO does not explicitly serialize rollouts across all components. Instead, the CPOv2
+dependency graph provides natural layer-based ordering:
+
+- **Layer 0:** etcd (no dependencies) — updated immediately
+- **Layer 1:** kube-apiserver (depends on etcd `Available=True` + `RolloutComplete=True`)
+- **Layer 2:** KCM, kube-scheduler, openshift-apiserver (implicit KAS dependency)
+- **Layer 3:** oauth-apiserver, oauth-server, openshift-controller-manager (depend on
+  openshift-apiserver)
+
+Components at the same dependency layer are updated in the same reconciliation pass. HA
+safety is guaranteed **per-component** — each component has sufficient replicas (3 for
+load-balanced, 2 for leader-elected) to handle rolling restarts without downtime.
+Cross-component serialization is not required because each component's rollout is
+independent, handled by Kubernetes' own rolling update strategy with proper pod disruption
+budgets.
 
 ### Risks and Mitigations
 
 **Risk:** `TraceAll` (glog level 8) can dump sensitive data including request bodies and
 secrets in component logs.
-**Mitigation:** Document operational warnings for `TraceAll` in API docs and release notes.
-Consider adding validation warnings or status conditions when `TraceAll` is set. Managed
-services may restrict this level via admission webhooks.
+**Mitigation:** The feature is gated — `TraceAll` cannot reach managed service clusters
+until promoted. The `TraceAll` access policy for managed services (CEL rule or admission
+webhook) is a prerequisite for promotion to GA. Document operational warnings for
+`TraceAll` in API docs and release notes.
 
 **Risk:** High verbosity levels significantly increase log volume, potentially impacting log
 storage and cluster performance.
-**Mitigation:** Add status conditions when non-default log levels are active so SREs can
-monitor and alert on elevated verbosity. Document storage impact guidance per log level.
+**Mitigation:** Document storage impact guidance per log level. Administrators can inspect
+the HostedCluster spec directly to identify clusters with non-default log levels.
 
 **Risk:** `TraceAll` on managed services (ROSA HCP, ARO HCP) could expose secrets in logs
 flowing to CloudWatch or Azure Monitor (customer-visible).
-**Mitigation:** Add admission policy or CEL rule blocking `TraceAll` on managed service
-clusters. Access model (customer self-service vs SRE/CEE only) to be decided with PM.
+**Mitigation:** The feature gate prevents exposure on managed services until promoted.
+Before promotion, the specific enforcement mechanism (CEL rule or admission webhook
+blocking `TraceAll` on managed clusters) must be implemented and validated.
 
 **Risk:** High verbosity on managed services (ROSA HCP, ARO HCP) increases log volume
 flowing to CloudWatch or Azure Monitor, potentially impacting storage costs.
@@ -494,8 +517,10 @@ auto-revert to `Normal` after a configurable timeout if needed.
 
 **Risk:** Rolling restarts during log level changes could cause brief API unavailability if
 multiple components are changed simultaneously.
-**Mitigation:** The CPO should apply changes sequentially across components to avoid
-simultaneous restarts.
+**Mitigation:** The CPOv2 dependency graph provides natural layer-based ordering across
+components (etcd → KAS → controllers → remaining). Each component's HA guarantees (3
+replicas for load-balanced, 2 for leader-elected) ensure zero downtime during its own
+rolling restart. See "Multi-component changes" under HA Rolling Restart for details.
 
 ### Drawbacks
 
@@ -523,14 +548,17 @@ simultaneous restarts.
    because not all target components support it, and the rolling restart approach provides
    consistent behavior across all components.
 
+4. **Flat scalar fields (e.g., `kubeAPIServerLogLevel *LogLevel`):** Simpler for users but
+   inconsistent with the existing CVO/CNO/Ingress nested pattern in `OperatorConfiguration`,
+   and creates a namespace problem if per-component configuration needs to grow beyond just
+   log level. The per-component wrapper type approach was chosen for consistency and
+   future-proofing.
+
 ## Open Questions
 
 1. Should managed services (ROSA HCP, ARO HCP) expose log level configuration to customers
-   via ROSA CLI / OCM, or restrict it to SRE/CEE only? Access model to be decided with PM.
-
-2. What is the appropriate deprecation timeline for the existing
-   `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation? Current
-   recommendation: deprecated on merge, removed in N+2.
+   via ROSA CLI / OCM, or restrict it to SRE/CEE only? Access model to be resolved before
+   feature promotion to GA.
 
 ## Test Plan
 
@@ -548,69 +576,79 @@ The testing strategy covers the following areas:
   level values.
 - **KAS-specific unit tests:** Annotation fallback, API field precedence over annotation,
   invalid annotation handling.
-- **E2E tests:** Set KAS LogLevel to Debug → verify pod restarts with `--v=4`; cluster
-  stays healthy.
-- **E2E tests:** Remove KAS LogLevel (nil) → verify pod rolls back to `--v=2`.
-- **E2E tests:** Set etcd LogLevel to Debug → verify pod restarts with
-  `ETCD_LOG_LEVEL=debug`.
-- **E2E tests:** KAS annotation deprecation path — annotation works, API field overrides,
-  annotation ignored when both set.
-- **E2E tests:** HA rolling restart — no API downtime during rollout (health checks pass
-  continuously).
 
-Tests should include `[Jira:"Hosted Control Planes"]` labels for the component. Since this
-feature ships ungated, no `[OCPFeatureGate:...]` label is needed.
+Tests should include `[Jira:"Hosted Control Planes"]` and
+`[OCPFeatureGate:HCPUserFacingOperatorLogs]` labels for the component.
 
 ## Graduation Criteria
 
-This feature ships **GA in the target release** with no feature gate. Dev Preview and Tech
-Preview stages are skipped because this enhancement adds optional, backward-compatible fields
-to an already-GA API surface (`OperatorConfiguration`) using an already-GA type (`LogLevel`).
-The feature is a low-risk operational knob — nil fields preserve existing behavior, and the
-CPO reconciliation path is well-established. There is no new controller, no new CRD, and no
-behavioral change for clusters that do not opt in.
+This feature follows a **gate first, promote when ready** lifecycle. The new fields are
+gated behind the `HCPUserFacingOperatorLogs` feature gate, consistent with the existing `ClusterVersionOperator` field in
+`OperatorConfiguration` which is gated behind
+`+openshift:enable:FeatureGate=ClusterVersionOperatorConfiguration`.
+
+Under the continuous release model, promotion does not need to wait for the next OCP
+release — it happens when the feature is validated. This is already practiced in OCP
+(e.g., dualstack support, Karpenter).
 
 ### Dev Preview -> Tech Preview
 
-N/A. This feature skips Dev Preview and Tech Preview. See rationale above.
+N/A. This feature ships directly as Tech Preview behind the
+`HCPUserFacingOperatorLogs` feature gate.
+
+### Tech Preview
+
+- All 8 per-component wrapper types and `ComponentLogLevelSpec` merged behind feature gate.
+- `LogLevelToKlogVerbosity()` and `LogLevelToEtcdLevel()` mapping utilities implemented.
+- CPO integration for all 8 components complete, including KAS annotation deprecation path.
+- Unit tests for all mapping utilities and per-component integration points.
+- Envtest (CEL) validation tests pass.
 
 ### Tech Preview -> GA
-
-N/A. This feature ships directly as GA. See rationale above.
-
-### GA Criteria
-
-- Ability to set log levels for all 8 core control plane components via the HostedCluster
-  CR end to end.
-- Log level changes propagate correctly and components restart with the expected verbosity.
-- Unit tests for LogLevel-to-flag mapping (klog and etcd).
-- Serialization compatibility tests (N-1/N+1 roundtrip).
-- Envtest cases for CEL/enum validation.
-- E2E tests for propagation, reset, annotation deprecation path, and HA rolling restart
-  with zero downtime.
-- Deprecation notice published for the existing KAS verbosity annotation.
-- Verification on all supported platforms: AWS/ROSA, Azure/ARO, KubeVirt, IBM, OpenStack,
-  and Agent.
+- Serialization compatibility tests (N-1/N+1 roundtrip) pass.
+- `TraceAll` access policy for managed services resolved and implemented (CEL rule or
+  admission webhook blocking `TraceAll` on ROSA HCP / ARO HCP clusters).
+- Managed service access model resolved (customer self-service vs SRE/CEE only).
+- Verification on all supported platforms.
 - CEE validation with [RFE-7777](https://issues.redhat.com/browse/RFE-7777) reporter
   confirms the feature solves their problem.
 - User-facing documentation created in
   [openshift-docs](https://github.com/openshift/openshift-docs/)
   ([OSDOCS-19157](https://issues.redhat.com/browse/OSDOCS-19157)).
+- Deprecation notice published for the existing KAS verbosity annotation.
+- Feature gate promoted — fields available on all cluster types including managed services.
 
 ### Removing a deprecated feature
 
 The existing `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation is
-deprecated on merge of this feature and will be removed in N+2 (two minor releases after
-GA).
+deprecated in OCP 5.0 and will be removed in OCP 5.2.
+
+**Deprecation phase (5.0):** Both the annotation and the new
+`operatorConfiguration.kubeAPIServer.logLevel` field are honored. When the annotation is
+present, the CPO emits a deprecation warning condition on the HostedCluster. If both the
+annotation and the API field are set, the API field takes precedence.
+
+**Removal (5.2):** A follow-up PR will:
+
+1. Delete the annotation-reading code path in the KAS reconciler
+   (`v2/kas/deployment.go`) — the fallback that checks
+   `hypershift.openshift.io/kube-apiserver-verbosity-level` and maps it to `--v=N`.
+2. Remove the deprecation warning condition logic that fires when the annotation is
+   detected.
+3. Update release notes to state the annotation is no longer honored.
+
+After removal, the annotation becomes inert metadata on any HostedCluster that still
+carries it — the CPO simply stops reading it. No CRD schema change is required since
+annotations are not schema-defined.
 
 ## Upgrade / Downgrade Strategy
 
-**Upgrade:** The new log level fields are optional pointer types with `omitempty`. Clusters
-upgrading from a version without this feature will have `nil` log level fields, and the CPO
-will continue to use default verbosity (`Normal`). No action is required from the
-administrator to maintain previous behavior. The existing KAS verbosity annotation will
-continue to be honored during the transition period; if both the annotation and the new API
-field are set, the API field takes precedence.
+**Upgrade:** The new log level fields use `omitzero` (non-pointer struct with
+`json:",omitzero"`). Clusters upgrading from a version without this feature will have
+zero-value structs, and the CPO will continue to use default verbosity (`Normal`). No
+action is required from the administrator to maintain previous behavior. The existing KAS
+verbosity annotation will continue to be honored during the transition period; if both the
+annotation and the new API field are set, the API field takes precedence.
 
 **Downgrade:** If a cluster is downgraded to a version that does not support the new log
 level fields, the fields will be ignored by the older CPO. Components will revert to
@@ -639,16 +677,6 @@ control plane components are still at version N. This is safe because:
 This enhancement adds optional fields to the existing `HostedCluster` and
 `HostedControlPlane` CRDs. No new webhooks, aggregated API servers, or finalizers are
 introduced.
-
-**SLIs — detecting health of log level configuration:**
-
-The CPO reports a `NonDefaultLogLevel` status condition on the HostedCluster:
-
-- `HostedCluster` condition `NonDefaultLogLevel=True` — one or more components are running
-  with elevated verbosity. Administrators and SREs can alert on this to track clusters with
-  non-standard log volume.
-- `HostedCluster` condition `NonDefaultLogLevel=False` — all components running at default
-  verbosity.
 
 **Impact on existing SLIs:**
 
@@ -683,13 +711,7 @@ related to log level configuration.
 
 **Detecting non-default log levels:**
 
-Check the HostedCluster status conditions for `NonDefaultLogLevel=True`:
-
-```bash
-oc get hostedcluster my-cluster -o jsonpath='{.status.conditions[?(@.type=="NonDefaultLogLevel")]}'
-```
-
-Alternatively, inspect the spec directly:
+Inspect the spec directly:
 
 ```bash
 oc get hostedcluster my-cluster -o jsonpath='{.spec.operatorConfiguration}'
@@ -736,9 +758,23 @@ independently. Log level configuration is part of the standard CPO reconciliatio
 effectively disable the feature, reset all log level fields to `Normal` or remove them from
 the HostedCluster spec.
 
+## Future Work
+
+Additional CPO-managed components (e.g., cluster-autoscaler, dns-operator, cloud
+controller managers) can be added via follow-up enhancements using the same
+`ComponentLogLevelSpec` embedding pattern. Components that already have dedicated typed
+structs in `OperatorConfiguration` (CVO, CNO, Ingress) would add a `LogLevel` field within
+their existing struct. The per-component wrapper type approach scales to these additions
+with only additive, backward-compatible changes.
+
 ## Implementation History
 
 - 2026-06-09: EP created (provisional)
+- 2026-07-22: EP updated to address API review feedback — feature gating, per-component
+  wrapper types, Phase 3 removed
+- 2026-07-26: Removed NonDefaultLogLevel status condition, removed E2E tests, removed Dev
+  Preview phase, consolidated Goals into single delivery, updated feature gate name to
+  HCPUserFacingOperatorLogs
 
 ## Infrastructure Needed
 

--- a/enhancements/hypershift/configurable-log-levels-for-hosted-control-plane-components.md
+++ b/enhancements/hypershift/configurable-log-levels-for-hosted-control-plane-components.md
@@ -10,6 +10,8 @@ authors:
 reviewers:
   - "@devguyio"
   - "@celebdor"
+  - "@muraee"
+  - "@saschagrunert" 
 approvers:
   - "@csrwng"
   - "@devguyio"
@@ -17,7 +19,7 @@ api-approvers:
   - "@joelspeed"
   - "@enxebre"
 creation-date: 2026-06-09
-last-updated: 2026-07-26
+last-updated: 2026-08-25
 status: provisional
 tracking-link:
   - https://issues.redhat.com/browse/OCPSTRAT-3156
@@ -38,8 +40,9 @@ This enhancement introduces structured, per-component log level configuration fo
 control plane components managed by the Control Plane Operator (CPO) in HyperShift.
 Administrators will be able to set intent-based log levels (`Normal`, `Debug`, `Trace`,
 `TraceAll`) on the HostedCluster Custom Resource for kube-apiserver,
-kube-controller-manager, kube-scheduler, etcd, openshift-apiserver,
-openshift-controller-manager, openshift-oauth-apiserver, and oauth-server. The CPO will
+kube-controller-manager, kube-scheduler, openshift-apiserver,
+openshift-controller-manager, openshift-oauth-apiserver, and oauth-server; and `Normal`
+or `Debug` for etcd (etcd's logging model does not support `Trace` or `TraceAll`). The CPO will
 translate these intent-based levels into component-specific mechanisms (`--v=N` for
 klog-based components, `ETCD_LOG_LEVEL` env var for etcd), achieving operational parity
 with standard OCP's `operatorv1.OperatorSpec.LogLevel` pattern. Each component gets a
@@ -79,17 +82,14 @@ as "crucial even for the most minimal troubleshooting."
 
 ### User Stories
 
-- As a **HyperShift cluster administrator**, I want to increase the log verbosity of
-  kube-apiserver on my hosted cluster so that I can diagnose API request failures without
-  escalating to engineering.
+- As a **service provider engineer** (SRE or CEE) managing hosted control plane components
+  on the management cluster, I want to set `Debug` log level on specific components via the
+  HostedCluster CR so that I can diagnose control plane issues using standard klog-based
+  troubleshooting playbooks.
 
-- As a **CEE support engineer**, I want to instruct customers to set `Debug` log level on
-  specific hosted control plane components via the HostedCluster CR so that I can follow
-  the same troubleshooting playbooks used for standard OCP clusters.
-
-- As a **platform engineer** managing hosted clusters in pre-production, I want to
-  temporarily set `Trace` level on openshift-apiserver and openshift-controller-manager so
-  that I can capture detailed component behavior before promoting changes to production.
+- As a **platform engineer** running self-managed HyperShift, I want to temporarily set
+  `Trace` level on openshift-apiserver and openshift-controller-manager so that I can
+  capture detailed component behavior before promoting changes to production.
 
 ### Goals
 
@@ -97,13 +97,14 @@ as "crucial even for the most minimal troubleshooting."
    via the HostedCluster CR, replacing the existing ad-hoc annotation-based mechanism for
    kube-apiserver.
 2. Establish the `ComponentLogLevelSpec` pattern and `LogLevelToKlogVerbosity()` utility
-   reused across all klog-based components.
+   reused across all klog-based components, and `LogLevelToEtcdLevel()` for etcd.
 3. Provide a deprecation path for the existing
    `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation.
 4. Achieve operational parity with standard OCP's `operatorv1.LogLevel` pattern using
    intent-based log levels (`Normal`, `Debug`, `Trace`, `TraceAll`).
-5. Ensure log level changes take effect via rolling restart without cluster disruption or
-   downtime.
+5. Ensure log level changes take effect via rolling restart without downtime on
+   HighlyAvailable clusters (SingleReplica clusters will experience a brief service
+   interruption during the restart).
 
 ### Non-Goals
 
@@ -147,11 +148,13 @@ mapping to the following glog/klog verbosity levels:
 |------------------|------------|----------------------|---------------------------------------------------|
 | Normal (default) | 2          | info                 | Production                                        |
 | Debug            | 4          | debug                | Troubleshooting                                   |
-| Trace            | 6          | debug¹               | Deep investigation                                |
-| TraceAll         | 8          | debug¹               | Full dumps — perf impact, may expose secrets      |
+| Trace            | 6          | — (rejected)¹        | Deep investigation                                |
+| TraceAll         | 8          | — (rejected)¹        | Full dumps — perf impact, may expose secrets      |
 
-¹ etcd uses zap logging which has no granularity below `debug` — Trace and TraceAll both
-map to `debug`.
+¹ etcd uses zap logging which has no granularity below `debug`. Since `Trace` and
+`TraceAll` would silently clamp to `debug` with no additional diagnostic value, they are
+rejected at admission for etcd via a CEL rule on `EtcdOperatorSpec`. Only `Normal` and
+`Debug` are valid for etcd.
 
 The chosen API design uses **structured per-component fields** in `OperatorConfiguration`.
 This extends the existing pattern (which already has `ClusterVersionOperator`,
@@ -180,7 +183,7 @@ reconciles hosted control plane components.
      '{"spec":{"operatorConfiguration":{
        "kubeAPIServer":{"logLevel":"Debug"}}}}'
    ```
-3. The CPO detects the HostedCluster spec change and validates the log level value.
+3. The CRD validates the log level value at admission time via CEL enum validation.
 4. The CPO translates the intent-based log level to the component-specific flag (e.g.,
    `Debug` → `--v=4` for kube-apiserver).
 5. The CPO updates the component's deployment/statefulset with the new verbosity flag,
@@ -242,16 +245,21 @@ of the new structured API.
 Added to `api/hypershift/v1beta1/operator.go` (where `LogLevel` is already defined):
 
 ```go
-// ComponentLogLevelSpec specifies the log verbosity for a control plane component.
+// ComponentLogLevelSpec configures the log verbosity for a hosted control plane component.
 // +kubebuilder:validation:MinProperties=1
 type ComponentLogLevelSpec struct {
     // logLevel sets the log verbosity for the component.
     // Valid values are: "Normal", "Debug", "Trace", "TraceAll".
-    // Setting this field triggers a rolling restart of the component.
+    // When set to Normal, standard operational log messages are produced for auditing and common operations.
+    // When set to Debug, more verbose logging is enabled for diagnosing problems.
+    // When set to Trace, very verbose logging is enabled including function-level tracing.
+    // When set to TraceAll, the most verbose logging is used, including full API body content,
+    // this can cause significant performance impact and produce large volumes of logs.
     // When omitted, this means the user has no opinion and the platform
-    // defaults to Normal, which is subject to change over time.
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
-    LogLevel *LogLevel `json:"logLevel,omitempty"`
+    LogLevel LogLevel `json:"logLevel,omitempty"`
 }
 ```
 
@@ -263,42 +271,51 @@ future per-component extension (e.g., adding `resourceOverrides` to
 wire format is unchanged.
 
 ```go
-// KubeAPIServerOperatorSpec configures the kube-apiserver component.
+// KubeAPIServerOperatorSpec specifies the configuration for the Kube API Server.
+// +kubebuilder:validation:MinProperties=1
 type KubeAPIServerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// KubeControllerManagerOperatorSpec configures the kube-controller-manager component.
+// KubeControllerManagerOperatorSpec specifies the configuration for the Kube Controller Manager.
+// +kubebuilder:validation:MinProperties=1
 type KubeControllerManagerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// KubeSchedulerOperatorSpec configures the kube-scheduler component.
+// KubeSchedulerOperatorSpec specifies the configuration for the Kube Scheduler.
+// +kubebuilder:validation:MinProperties=1
 type KubeSchedulerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// EtcdOperatorSpec configures the etcd component.
+// EtcdOperatorSpec specifies the configuration for the etcd.
+// +kubebuilder:validation:MinProperties=1
+// +kubebuilder:validation:XValidation:rule="!has(self.logLevel) || self.logLevel in ['Normal', 'Debug']",message="etcd only supports Normal and Debug log levels; Trace and TraceAll are not valid for etcd"
 type EtcdOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// OpenShiftAPIServerOperatorSpec configures the openshift-apiserver component.
+// OpenShiftAPIServerOperatorSpec specifies the configuration for the OpenShift API Server.
+// +kubebuilder:validation:MinProperties=1
 type OpenShiftAPIServerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// OpenShiftControllerManagerOperatorSpec configures the openshift-controller-manager component.
+// OpenShiftControllerManagerOperatorSpec specifies the configuration for the OpenShift Controller Manager.
+// +kubebuilder:validation:MinProperties=1
 type OpenShiftControllerManagerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// OpenShiftOAuthAPIServerOperatorSpec configures the openshift-oauth-apiserver component.
+// OpenShiftOAuthAPIServerOperatorSpec specifies the configuration for the OpenShift OAuth API Server.
+// +kubebuilder:validation:MinProperties=1
 type OpenShiftOAuthAPIServerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
 
-// OAuthServerOperatorSpec configures the oauth-server component.
+// OAuthServerOperatorSpec specifies the configuration for the OAuth Server.
+// +kubebuilder:validation:MinProperties=1
 type OAuthServerOperatorSpec struct {
     ComponentLogLevelSpec `json:",inline"`
 }
@@ -315,50 +332,76 @@ type OperatorConfiguration struct {
 
     // kubeAPIServer configures the kube-apiserver component.
     // Setting the logLevel field triggers a rolling restart of the component.
-    // kube-apiserver runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
     KubeAPIServer KubeAPIServerOperatorSpec `json:"kubeAPIServer,omitzero"`
+
+    // etcd configures the etcd component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // Note: etcd supports fewer log levels than klog-based components,
+    // etcd supports only Normal and Debug log levels.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
+    // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
+    Etcd EtcdOperatorSpec `json:"etcd,omitzero"`
 
     // kubeControllerManager configures the kube-controller-manager component.
     // Setting the logLevel field triggers a rolling restart of the component.
-    // kube-controller-manager uses leader election — the standby takes over during restart.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
     KubeControllerManager KubeControllerManagerOperatorSpec `json:"kubeControllerManager,omitzero"`
 
     // kubeScheduler configures the kube-scheduler component.
     // Setting the logLevel field triggers a rolling restart of the component.
-    // kube-scheduler uses leader election — the standby takes over during restart.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
     KubeScheduler KubeSchedulerOperatorSpec `json:"kubeScheduler,omitzero"`
-
-    // etcd configures the etcd component.
-    // Setting the logLevel field triggers a rolling restart of the component.
-    // etcd runs with 3 replicas — Raft quorum is maintained during rolling update.
-    // +optional
-    Etcd EtcdOperatorSpec `json:"etcd,omitzero"`
-
-    // openShiftAPIServer configures the openshift-apiserver component.
-    // Setting the logLevel field triggers a rolling restart of the component.
-    // openshift-apiserver runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
-    // +optional
-    OpenShiftAPIServer OpenShiftAPIServerOperatorSpec `json:"openShiftAPIServer,omitzero"`
 
     // openShiftControllerManager configures the openshift-controller-manager component.
     // Setting the logLevel field triggers a rolling restart of the component.
-    // openshift-controller-manager uses leader election — the standby takes over during restart.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
     OpenShiftControllerManager OpenShiftControllerManagerOperatorSpec `json:"openShiftControllerManager,omitzero"`
+
+    // openShiftAPIServer configures the openshift-apiserver component.
+    // Setting the logLevel field triggers a rolling restart of the component.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
+    // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
+    OpenShiftAPIServer OpenShiftAPIServerOperatorSpec `json:"openShiftAPIServer,omitzero"`
 
     // openShiftOAuthAPIServer configures the openshift-oauth-apiserver component.
     // Setting the logLevel field triggers a rolling restart of the component.
-    // openshift-oauth-apiserver runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
     OpenShiftOAuthAPIServer OpenShiftOAuthAPIServerOperatorSpec `json:"openShiftOAuthAPIServer,omitzero"`
 
     // oauthServer configures the oauth-server component.
     // Setting the logLevel field triggers a rolling restart of the component.
-    // oauth-server runs with 3 replicas (HA) — 2 continue serving while 1 restarts.
+    // When omitted, this means the user has no opinion and the platform
+    // chooses a reasonable default, which is subject to change over time.
+    // The current default log level is Normal.
     // +optional
+    // +openshift:enable:FeatureGate=HCPUserFacingOperatorLogs
     OAuthServer OAuthServerOperatorSpec `json:"oauthServer,omitzero"`
 }
 ```
@@ -383,11 +426,9 @@ level configuration is set on the HostedCluster CR in the management cluster and
 to the hosted control plane components running in the management cluster namespace. No
 changes are required in the guest cluster.
 
-For managed services (ROSA HCP, ARO HCP), service-level guardrails are required before
-promoting this feature to GA. The feature gate prevents the fields from being available on
-managed service clusters until promoted. The `TraceAll` access policy (CEL rule or
-admission webhook) for managed services is a promotion prerequisite — see Graduation
-Criteria.
+For managed services (ROSA HCP, ARO HCP), log level configuration is restricted to service
+providers (SRE/CEE). Customers do not have direct access to HostedCluster CR fields in
+ROSA HCP/ARO HCP. The feature gate governs availability until the feature is promoted to GA.
 
 #### Standalone Clusters
 
@@ -408,53 +449,51 @@ does not exclude any functionality required by this enhancement.
 
 ### Implementation Details/Notes/Constraints
 
-The implementation follows a phased approach.
-
-#### Phase 1: kube-apiserver (first)
-
-kube-apiserver is implemented and validated first because it is the most requested
-component for log level tuning, has an existing annotation-based mechanism to deprecate,
-and establishes the pattern for all subsequent components.
+All 8 components are implemented in a single deliverable.
 
 Log level changes apply to the **main container only**, not sidecars. This matches OCP
 behavior — sidecars have different logging models, and `UpdateContainer(ComponentName)`
 already targets the main container.
 
-Phase 1 delivers:
+The implementation delivers:
 
-1. **API types:** `ComponentLogLevelSpec` struct, `KubeAPIServerOperatorSpec` wrapper type,
-   and the `KubeAPIServer` field in `OperatorConfiguration`.
-2. **Mapping utility:** `LogLevelToKlogVerbosity()` in `support/util/loglevel.go`.
-3. **CPO integration for KAS:** Replace the existing annotation logic at
-   `v2/kas/deployment.go` with structured API field reading. Annotation fallback with lower
-   precedence during transition.
-4. **Annotation deprecation:** Both annotation and API field honored; new field wins.
-   Deprecation warning condition emitted when annotation is used.
-5. **Unit tests** for KAS log level propagation and annotation precedence.
-
-#### Phase 2: remaining 7 components (in parallel, after Phase 1 approval)
-
-Once Phase 1 is approved and merged, the remaining 7 components are implemented in parallel
-since they all follow the same pattern established by KAS:
-
-- kube-controller-manager, kube-scheduler, openshift-apiserver,
-  openshift-controller-manager, openshift-oauth-apiserver, oauth-server — all use klog
-  (`--v=N`), same `LogLevelToKlogVerbosity()` utility.
-- etcd — uses `ETCD_LOG_LEVEL` env var, requires a `LogLevelToEtcdLevel()` mapping
-  utility.
+1. **API types:** `ComponentLogLevelSpec` struct, per-component wrapper types
+   (`KubeAPIServerOperatorSpec`, etc.), and new fields in `OperatorConfiguration`.
+2. **Mapping utilities:** `LogLevelToKlogVerbosity()` and `LogLevelToEtcdLevel()` in
+   `support/util/loglevel.go`.
+3. **CPO integration for all 8 components:** klog-based components unconditionally inject
+   `--v=N` (defaulting to `--v=2` when no log level is set); etcd unconditionally injects
+   `ETCD_LOG_LEVEL` (defaulting to `info`). This injection is unconditional — it applies
+   regardless of whether the `HCPUserFacingOperatorLogs` feature gate is enabled. The
+   feature gate governs API availability (whether users can set the fields), not the
+   default verbosity injection. KCM, openshift-controller-manager, openshift-apiserver,
+   and oauth-server previously relied on klog's implicit default (level 0) rather than an
+   explicit flag; this PR standardizes them to `--v=2` (Normal), matching KAS and
+   kube-scheduler which were already at that baseline. The one-time rolling restart this
+   causes is intentional — `v=2` is the recommended klog baseline for Kubernetes
+   components and aligns with the API contract ("The current default log level is
+   Normal").
+4. **KAS annotation fallback:** The resolver follows this precedence order: (1) non-empty
+   API field value; (2) legacy annotation
+   (`hypershift.openshift.io/kube-apiserver-verbosity-level`); (3) default `Normal`. Removing
+   the API field restores `Normal` when no annotation is present. Behavior of the annotation
+   path on managed services (ROSA HCP / ARO HCP) is not defined by this EP and is deferred
+   to Future Work. The deprecation warning condition is tracked separately in
+   CNTRLPLANE-3998.
+5. **Per-component unit tests** following the `TestAdaptDeployment` pattern.
 
 #### CPO Integration by Component
 
-| Component                    | Phase | Logging Model  | File                                    | Mechanism                                    |
-|------------------------------|-------|----------------|-----------------------------------------|----------------------------------------------|
-| **kube-apiserver**           | **1** | klog           | `v2/kas/deployment.go`                  | `--v=N` (replaces annotation logic)          |
-| kube-controller-manager      | 2     | klog           | `v2/kcm/deployment.go`                  | `--v=N` appended to args                     |
-| kube-scheduler               | 2     | klog           | `v2/kube_scheduler/deployment.go`       | `--v=N` (replaces hardcoded `--v=2`)         |
-| etcd                         | 2     | zap (non-klog) | `v2/etcd/statefulset.go`                | `ETCD_LOG_LEVEL` env var                     |
-| openshift-apiserver          | 2     | klog           | `v2/oapi/deployment.go`                 | `--v=N` appended to args                     |
-| openshift-controller-manager | 2     | klog           | `v2/ocm/component.go`                   | `--v=N` appended to args via adapt function  |
-| openshift-oauth-apiserver    | 2     | klog           | `v2/oauth_apiserver/deployment.go`      | `--v=N` (overrides hardcoded `--v=2`)        |
-| oauth-server                 | 2     | klog           | `v2/oauth/deployment.go`                | `--v=N` appended to args                     |
+| Component                    | Logging Model  | File                                    | Mechanism                               |
+|------------------------------|----------------|-----------------------------------------|-----------------------------------------|
+| kube-apiserver               | klog           | `v2/kas/deployment.go`                  | `--v=N` (supersedes annotation; annotation honored as fallback) |
+| kube-controller-manager      | klog           | `v2/kcm/deployment.go`                  | `--v=N` appended to args                |
+| kube-scheduler               | klog           | `v2/kube_scheduler/deployment.go`       | `--v=N` (replaces hardcoded `--v=2`)    |
+| etcd                         | zap (non-klog) | `v2/etcd/statefulset.go`                | `ETCD_LOG_LEVEL` env var                |
+| openshift-apiserver          | klog           | `v2/oapi/deployment.go`                 | `--v=N` appended to args                |
+| openshift-controller-manager | klog           | `v2/ocm/deployment.go`                  | `--v=N` appended to args                |
+| openshift-oauth-apiserver    | klog           | `v2/oauth_apiserver/deployment.go`      | `--v=N` (replaces hardcoded `--v=2`)    |
+| oauth-server                 | klog           | `v2/oauth/deployment.go`                | `--v=N` appended to args                |
 
 #### HA Rolling Restart — Zero Downtime
 
@@ -469,9 +508,14 @@ since they all follow the same pattern established by KAS:
 | openshift-oauth-apiserver    | 3             | Load balanced                                          |
 | oauth-server                 | 3             | Load balanced — request-serving component              |
 
-**ROSA HCP / ARO HCP:** `controllerAvailabilityPolicy` is always `HighlyAvailable` for
-managed services — control plane components run with full HA replica counts. Zero downtime
-guaranteed during rolling restarts.
+**HighlyAvailable clusters (including ROSA HCP / ARO HCP):** `controllerAvailabilityPolicy:
+HighlyAvailable` — control plane components run with full HA replica counts as shown in the
+table above. Zero downtime guaranteed during rolling restarts.
+
+**SingleReplica clusters:** `controllerAvailabilityPolicy: SingleReplica` — each control
+plane component runs as a single replica. A log level change triggers a rolling restart of
+that single replica, which will cause a brief service interruption for the affected
+component. Plan log level changes during maintenance windows for SingleReplica clusters.
 
 **Multi-component changes:** When multiple components are changed in a single `oc patch`,
 the CPO does not explicitly serialize rollouts across all components. Instead, the CPOv2
@@ -495,20 +539,15 @@ budgets.
 **Risk:** `TraceAll` (glog level 8) can dump sensitive data including request bodies and
 secrets in component logs.
 **Mitigation:** The feature is gated — `TraceAll` cannot reach managed service clusters
-until promoted. The `TraceAll` access policy for managed services (CEL rule or admission
-webhook) is a prerequisite for promotion to GA. Document operational warnings for
-`TraceAll` in API docs and release notes.
+until promoted. Operational warnings for `TraceAll` are documented in the API field
+godocs and release notes. Since log level configuration is restricted to service providers,
+exposure on managed services is an operational concern for SRE/CEE, not a customer-facing
+risk.
 
 **Risk:** High verbosity levels significantly increase log volume, potentially impacting log
 storage and cluster performance.
 **Mitigation:** Document storage impact guidance per log level. Administrators can inspect
 the HostedCluster spec directly to identify clusters with non-default log levels.
-
-**Risk:** `TraceAll` on managed services (ROSA HCP, ARO HCP) could expose secrets in logs
-flowing to CloudWatch or Azure Monitor (customer-visible).
-**Mitigation:** The feature gate prevents exposure on managed services until promoted.
-Before promotion, the specific enforcement mechanism (CEL rule or admission webhook
-blocking `TraceAll` on managed clusters) must be implemented and validated.
 
 **Risk:** High verbosity on managed services (ROSA HCP, ARO HCP) increases log volume
 flowing to CloudWatch or Azure Monitor, potentially impacting storage costs.
@@ -531,6 +570,9 @@ rolling restart. See "Multi-component changes" under HA Rolling Restart for deta
   some nuance is lost in translation.
 - Log level changes trigger rolling restarts, which is a heavier operation than the in-place
   dynamic reconfiguration some users might expect.
+- Etcd's zap-based logging has no granularity below `debug` — `Trace` and `TraceAll` are
+  rejected at admission for etcd via a CEL rule on `EtcdOperatorSpec`. Only `Normal` and
+  `Debug` are valid for etcd.
 
 ## Alternatives (Not Implemented)
 
@@ -560,6 +602,10 @@ rolling restart. See "Multi-component changes" under HA Rolling Restart for deta
    via ROSA CLI / OCM, or restrict it to SRE/CEE only? Access model to be resolved before
    feature promotion to GA.
 
+   Resolved: The access model for managed services is resolved: log level configuration is
+   restricted to service providers (SRE/CEE). Customers do not have direct access to
+   HostedCluster CR fields in ROSA HCP/ARO HCP or EKS.
+
 ## Test Plan
 
 The testing strategy covers the following areas:
@@ -570,12 +616,16 @@ The testing strategy covers the following areas:
   (`ETCD_LOG_LEVEL`).
 - **Serialization compat tests:** N-1/N+1 roundtrip for `OperatorConfiguration` with new
   fields set, mixed, and empty.
-- **Envtest (CEL) tests:** Valid log levels accepted, invalid values rejected by enum
-  validation.
-- **Unit tests per component:** Each of the 8 CPO integration points tested with all log
-  level values.
-- **KAS-specific unit tests:** Annotation fallback, API field precedence over annotation,
-  invalid annotation handling.
+- **CRD validation test suite (CEL):** Valid log levels accepted, invalid values rejected
+  by enum validation — YAML-based testsuite.yaml under
+  `cmd/install/assets/crds/hypershift-operator/tests/`.
+- **Per-component adapter tests:** Each of the 8 CPO integration points tested via
+  `TestAdaptDeployment*LogLevel` (for deployment-based components) or
+  `TestAdaptStatefulSet*LogLevel` (for etcd) within each component's own package,
+  asserting `--v=N` or `ETCD_LOG_LEVEL` values in the rendered deployment/statefulset.
+- **KAS resolver tests:** `TestResolveKASVerbosity` covers all log level enum values and
+  the no-configuration default case; `TestAdaptDeploymentKASLogLevel` validates end-to-end
+  flag injection including annotation fallback.
 
 Tests should include `[Jira:"Hosted Control Planes"]` and
 `[OCPFeatureGate:HCPUserFacingOperatorLogs]` labels for the component.
@@ -600,15 +650,12 @@ N/A. This feature ships directly as Tech Preview behind the
 
 - All 8 per-component wrapper types and `ComponentLogLevelSpec` merged behind feature gate.
 - `LogLevelToKlogVerbosity()` and `LogLevelToEtcdLevel()` mapping utilities implemented.
-- CPO integration for all 8 components complete, including KAS annotation deprecation path.
+- CPO integration for all 8 components complete; KAS annotation (`hypershift.openshift.io/kube-apiserver-verbosity-level`) honored as fallback with the API field taking precedence.
 - Unit tests for all mapping utilities and per-component integration points.
-- Envtest (CEL) validation tests pass.
+- CRD validation test suite (CEL) passes.
 
 ### Tech Preview -> GA
 - Serialization compatibility tests (N-1/N+1 roundtrip) pass.
-- `TraceAll` access policy for managed services resolved and implemented (CEL rule or
-  admission webhook blocking `TraceAll` on ROSA HCP / ARO HCP clusters).
-- Managed service access model resolved (customer self-service vs SRE/CEE only).
 - Verification on all supported platforms.
 - CEE validation with [RFE-7777](https://issues.redhat.com/browse/RFE-7777) reporter
   confirms the feature solves their problem.
@@ -616,19 +663,21 @@ N/A. This feature ships directly as Tech Preview behind the
   [openshift-docs](https://github.com/openshift/openshift-docs/)
   ([OSDOCS-19157](https://issues.redhat.com/browse/OSDOCS-19157)).
 - Deprecation notice published for the existing KAS verbosity annotation.
-- Feature gate promoted — fields available on all cluster types including managed services.
+- Feature gate promoted — fields available to service providers on all cluster types,
+  including managed services (ROSA HCP / ARO HCP).
 
 ### Removing a deprecated feature
 
 The existing `hypershift.openshift.io/kube-apiserver-verbosity-level` annotation is
-deprecated in OCP 5.0 and will be removed in OCP 5.2.
+deprecated in OCP 5.1 and will be removed in OCP 5.3.
 
-**Deprecation phase (5.0):** Both the annotation and the new
+**Deprecation phase (5.1):** Both the annotation and the new
 `operatorConfiguration.kubeAPIServer.logLevel` field are honored. When the annotation is
-present, the CPO emits a deprecation warning condition on the HostedCluster. If both the
-annotation and the API field are set, the API field takes precedence.
+present, the CPO emits a deprecation warning condition on the HostedCluster
+(tracked separately in CNTRLPLANE-3998). If both the annotation and the API
+field are set, the API field takes precedence.
 
-**Removal (5.2):** A follow-up PR will:
+**Removal (5.3):** A follow-up PR will:
 
 1. Delete the annotation-reading code path in the KAS reconciler
    (`v2/kas/deployment.go`) — the fallback that checks
@@ -645,10 +694,17 @@ annotations are not schema-defined.
 
 **Upgrade:** The new log level fields use `omitzero` (non-pointer struct with
 `json:",omitzero"`). Clusters upgrading from a version without this feature will have
-zero-value structs, and the CPO will continue to use default verbosity (`Normal`). No
-action is required from the administrator to maintain previous behavior. The existing KAS
-verbosity annotation will continue to be honored during the transition period; if both the
-annotation and the new API field are set, the API field takes precedence.
+zero-value structs, and the CPO will apply default verbosity (`Normal`, i.e. `--v=2`).
+
+For kube-apiserver and kube-scheduler, `--v=2` was already explicit — no behavior change.
+For kube-controller-manager, openshift-controller-manager, openshift-apiserver, and
+oauth-server, these components previously relied on klog's implicit level 0. This upgrade
+standardizes them to explicit `--v=2`, triggering a one-time rolling restart per component
+on every HyperShift cluster during CPO upgrade. This is intentional: `v=2` is the
+recommended klog baseline and aligns with the API contract. No administrator action is
+required — the restart is handled automatically by the CPO. The existing KAS verbosity
+annotation will continue to be honored during the transition period; if both the annotation
+and the new API field are set, the API field takes precedence.
 
 **Downgrade:** If a cluster is downgraded to a version that does not support the new log
 level fields, the fields will be ignored by the older CPO. Components will revert to
@@ -682,17 +738,16 @@ introduced.
 
 - No impact at `Normal` log level.
 - Higher verbosity levels increase log volume proportionally. This may affect log storage
-  consumption but does not affect API availability, control plane latency, or scheduling
-  performance at `Debug` or `Trace` levels under normal workloads.
+  consumption, CPU usage, and potentially control plane latency under sustained
+  high-verbosity operation. The resource impact of `Debug` and `Trace` levels has not been
+  measured and may vary by component and workload.
 - Expected use cases require short-lived non-default log level windows (minutes to hours
   during incident investigation), not permanent elevation.
 
 **How impact is measured:**
 
-- Log volume per component per verbosity level should be characterized by the QE team
-  during validation testing.
-- No performance team review required — this is a per-cluster operational configuration
-  that does not affect management cluster API throughput or scheduling.
+- Log volume per component per verbosity level should be characterized during validation
+  testing.
 
 **Failure modes:**
 
@@ -736,14 +791,6 @@ oc patch hostedcluster my-cluster --type=json -p \
     "path":"/spec/operatorConfiguration/kubeAPIServer"}]'
 ```
 
-To reset all components at once:
-
-```bash
-oc patch hostedcluster my-cluster --type=json -p \
-  '[{"op":"remove","path":"/spec/operatorConfiguration/kubeAPIServer"},
-    {"op":"remove","path":"/spec/operatorConfiguration/etcd"}]'
-```
-
 **Graceful degradation:**
 
 If log level configuration fields are removed or reset, the CPO restores default verbosity
@@ -760,12 +807,17 @@ the HostedCluster spec.
 
 ## Future Work
 
-Additional CPO-managed components (e.g., cluster-autoscaler, dns-operator, cloud
-controller managers) can be added via follow-up enhancements using the same
-`ComponentLogLevelSpec` embedding pattern. Components that already have dedicated typed
-structs in `OperatorConfiguration` (CVO, CNO, Ingress) would add a `LogLevel` field within
-their existing struct. The per-component wrapper type approach scales to these additions
-with only additive, backward-compatible changes.
+**KAS annotation path on managed services:** The behavior of the legacy
+`hypershift.openshift.io/kube-apiserver-verbosity-level` annotation on managed service
+clusters (ROSA HCP / ARO HCP) is not defined by this EP. A follow-up should determine
+whether the annotation path should be restricted on managed services (e.g., blocked above
+`Debug`) and implement the appropriate enforcement before the annotation is removed in 5.3.
+
+A future enhancement may introduce a `defaultLogLevel` field in `OperatorConfiguration`
+that sets a baseline verbosity for all components at once. When set, it acts as the default
+for any component whose per-component `logLevel` is unset. Per-component `logLevel` fields
+always take precedence over the default. The shared `LogLevel` type is used for both the
+default and per-component fields, maintaining a unified API type across all components.
 
 ## Implementation History
 
@@ -775,6 +827,28 @@ with only additive, backward-compatible changes.
 - 2026-07-26: Removed NonDefaultLogLevel status condition, removed E2E tests, removed Dev
   Preview phase, consolidated Goals into single delivery, updated feature gate name to
   HCPUserFacingOperatorLogs
+- 2026-08-14: Corrected API types (value-type LogLevel, MinProperties=1 on all wrapper
+  types), collapsed phase split (all 8 components delivered in single PR), updated test
+  plan to per-component adapter tests, added defaultLogLevel Future Work direction;
+  deprecation warning for legacy annotation tracked separately (CNTRLPLANE-3998)
+- 2026-08-24: Addressed coderabbitai review — clarified KAS annotation resolver order and
+  deferred annotation managed-service behavior to Future Work; added SingleReplica rolling
+  restart caveat; softened SLI performance guarantee; updated version references to
+  5.1/5.3; added CEL rule on EtcdOperatorSpec restricting logLevel to Normal and Debug
+  only; updated per-component godocs to match PR #8878 implementation
+- 2026-08-25: Addressed human reviewer comments — synced godocs and field order with
+  PR #8878 (hostedcluster_types.go and operator.go); clarified unconditional --v=2
+  injection rationale and one-time rollout for KCM/OCM/OAPI/oauth-server; resolved
+  CNTRLPLANE-3998 deprecation warning tracked separately; fixed Goals
+  downtime claim to scope zero-downtime guarantee to HighlyAvailable clusters; added
+  Future Work entry for annotation path on managed services; qualified etcd log level
+  limitation (Normal/Debug only) in Summary; fixed stale last-updated date
+- 2026-09-08: Addressed @typeid review — refactored User Stories to two unambiguous
+  personas (service provider engineer and self-managed platform engineer); resolved managed
+  service access model (restricted to SRE/CEE; customers have no direct HostedCluster CR
+  access in ROSA HCP/ARO HCP/EKS); removed stale CEL rule/admission webhook GA
+  prerequisites and guardrail language from Graduation Criteria, Topology Considerations,
+  and Risks and Mitigations; updated Open Questions with resolution
 
 ## Infrastructure Needed
 


### PR DESCRIPTION
## Why
  
  HyperShift administrators and support engineers cannot adjust log
  verbosity for hosted control plane components during troubleshooting.
  Standard OCP has this via operatorv1.LogLevel, but HyperShift has no
  equivalent except an ad-hoc, unvalidated annotation for kube-apiserver.
  This was reported as [RFE-7777](https://redhat.atlassian.net/browse/RFE-7777) and accepted as crucial for minimal
  troubleshooting.
  
  ## What
  
  Enhancement proposal introducing structured per-component log level
  configuration for CPO-managed components via the HostedCluster CR:

  - New `ComponentLogLevelSpec` type with `Normal/Debug/Trace/TraceAll`
    enum (matching operatorv1.LogLevel)
  - New optional pointer fields in `OperatorConfiguration` for 8 core
    control plane components
  - Phased delivery: KAS first (Phase 1), remaining 7 components
    (Phase 2), all remaining CPO-managed components documented
    holistically (Phase 3)
  - Deprecation path for existing kube-apiserver-verbosity-level
    annotation
  - Ships ungated, GA in target release

  ## References
  
  - Tracking: [OCPSTRAT-3156](https://issues.redhat.com/browse/OCPSTRAT-3156)
  - RFE: [RFE-7777](https://issues.redhat.com/browse/RFE-7777)
  - Implementation: [CNTRLPLANE-3290](https://issues.redhat.com/browse/CNTRLPLANE-3290)
  - Docs: [OSDOCS-19157](https://issues.redhat.com/browse/OSDOCS-19157)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined the proposal for configurable log levels across eight hosted control-plane components.
  * Clarified supported levels, including `Normal` and `Debug` for etcd, while rejecting unsupported values.
  * Documented admission-time validation, legacy annotation fallback, upgrade restarts, single-replica interruptions, and high-verbosity performance considerations.
  * Clarified managed-service access restrictions, testing strategy, feature-gate behavior, deprecation timelines, and future work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->