### PR TITLE
CNTRLPLANE-3553: getRHELStream returns rhel-9 for pre-5.0 releases

### DIFF
--- a/enhancements/hypershift/dual-stream-rhel-nodepool.md
+++ b/enhancements/hypershift/dual-stream-rhel-nodepool.md
@@ -379,10 +379,13 @@ Implementation steps:
    - **Explicit value set** → return it as-is
    - **Unset + release >= 5.0 + runc** → return `"rhel-9"` (fallback)
    - **Unset + release >= 5.0** → return `"rhel-10"` (default)
-   - **Unset + release < 5.0** → return `""` (no stream, legacy behavior)
+   - **Unset + release < 5.0** → return `"rhel-9"`
 
-   When the function returns `""`, the system uses the existing single-stream code path — no OSImageStream CR is generated,
-   no stream is included in the hash, and the MCC uses `BaseOSContainerImage` from ControllerConfig as-is.
+   Returning an explicit `"rhel-9"` for pre-5.0 releases (rather than an empty string) ensures that
+   downstream consumers such as `StreamForName()` always receive a concrete stream name. This avoids
+   errors when the legacy `StreamMetadata` field is eventually removed (> 5.3). The hash normalization
+   in `NewConfigGenerator` keeps `rolloutConfig.rhelStream` empty when the resolved stream matches the
+   version-derived default, so returning `"rhel-9"` here does not cause spurious rollouts.
 
 3. **Call `getRHELStream()` from `NewToken()`** — `NewToken()` (`token.go`) already receives the `ConfigGenerator`
    (which has `usesRunc` and `releaseImage.Version()`), and has access to the NodePool spec.


### PR DESCRIPTION
## Summary

- Update the dual-stream-rhel-nodepool enhancement to specify that `getRHELStream` returns `"rhel-9"` (instead of `""`) for the implicit pre-5.0 case.
- This aligns the enhancement with the implementation in [openshift/hypershift#8730](https://github.com/openshift/hypershift/pull/8730), where the change was requested by @enxebre during review.
- Returning a concrete stream name ensures downstream consumers like `StreamForName()` never receive an empty string, avoiding errors when the legacy `StreamMetadata` field is removed (> 5.3).
- Hash normalization in `NewConfigGenerator` keeps `rolloutConfig.rhelStream` empty when the resolved stream matches the version-derived default, so this does not cause spurious rollouts.

## Test plan

- [ ] No code changes — enhancement text only.
- [ ] Verify the decision tree in the enhancement matches the implementation in `stream.go:GetRHELStream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)