### PR TITLE
NO-JIRA: Update OWNERS files for NI&D Areas

### DIFF
--- a/enhancements/dns/OWNERS
+++ b/enhancements/dns/OWNERS
@@ -1,15 +1,30 @@
 approvers:
-- alebedev87
 - candita
-- frobware
-- knobunc
-- Miciah
-reviewers:
-- alebedev87
-- candita
-- frobware
 - gcs278
 - knobunc
 - Miciah
-- miheer
 - rfredette
+- Thealisyed
+- grzpiotrowski
+- rikatz
+- davidesalerno
+- bentito
+- jcmoraisjr
+- aswinsuryan
+- melvinjoseph86
+- rhamini3
+reviewers:
+- candita
+- gcs278
+- knobunc
+- Miciah
+- rfredette
+- Thealisyed
+- grzpiotrowski
+- rikatz
+- davidesalerno
+- bentito
+- jcmoraisjr
+- aswinsuryan
+- melvinjoseph86
+- rhamini3

--- a/enhancements/ingress/OWNERS
+++ b/enhancements/ingress/OWNERS
@@ -1,15 +1,30 @@
 approvers:
-- alebedev87
 - candita
-- frobware
-- knobunc
-- Miciah
-reviewers:
-- alebedev87
-- candita
-- frobware
 - gcs278
 - knobunc
 - Miciah
-- miheer
 - rfredette
+- Thealisyed
+- grzpiotrowski
+- rikatz
+- davidesalerno
+- bentito
+- jcmoraisjr
+- aswinsuryan
+- melvinjoseph86
+- rhamini3
+reviewers:
+- candita
+- gcs278
+- knobunc
+- Miciah
+- rfredette
+- Thealisyed
+- grzpiotrowski
+- rikatz
+- davidesalerno
+- bentito
+- jcmoraisjr
+- aswinsuryan
+- melvinjoseph86
+- rhamini3


### PR DESCRIPTION
Sync approvers and reviewers with the current NID team roster to match cluster-ingress-operator OWNERS. Previously, approvers were a smaller subset; this update aligns both lists.