### PR TITLE
enhancements/config: Versioned Config Access

### DIFF
--- a/enhancements/config/featuregate-versioned-config.md
+++ b/enhancements/config/featuregate-versioned-config.md
@@ -1,0 +1,341 @@
+---
+title: featuregate-versioned-config
+authors:
+  - "@sanchezl"
+reviewers:
+  - "@deads2k, for FeatureGateAccess backward compatibility, please review the adapter pattern"
+  - "@everettraven, for openshift/api conventions and feature gate declaration patterns"
+approvers:
+  - "@deads2k"
+api-approvers:
+  - "None"
+creation-date: 2026-08-04
+last-updated: 2026-08-04
+tracking-link:
+  - https://redhat.atlassian.net/browse/OCPSTRAT-2271
+see-also:
+  - "/enhancements/config/versioned-config-access.md"
+  - "/enhancements/installer/feature-sets.md"
+  - "/dev-guide/featuresets.md"
+---
+
+# FeatureGate Versioned Config
+
+## Summary
+
+The existing `FeatureGateAccess` interface in library-go is the original
+implementation of the version-indexed, change-notifying configuration accessor
+pattern. This enhancement refactors `FeatureGateAccess` to become a
+backward-compatible adapter over the generic `VersionedConfigAccess[Features]`
+interface introduced by the
+[Versioned Config Access](versioned-config-access.md) framework.
+The public interface, constructor signatures, and all behavioral contracts
+remain unchanged. No consuming operator requires modification. This refactor
+validates the generic framework in production using the most battle-tested
+domain.
+
+## Motivation
+
+The `FeatureGateAccess` implementation in
+`library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go`
+contains approximately 300 lines of version-matching, startup synchronization,
+and change-detection logic. This logic is not specific to feature gates; it
+applies to any version-indexed configuration domain. By refactoring
+`FeatureGateAccess` to delegate to the generic
+`VersionedConfigAccess[Features]`, the domain-specific implementation shrinks
+to a thin adapter (~50 lines), and the shared infrastructure gains its most
+rigorous validation through the existing FeatureGate test suite.
+
+### User Stories
+
+* As a platform developer maintaining library-go, I want the FeatureGateAccess
+  implementation to share infrastructure with TLS and PKI accessors, so that
+  bug fixes to version matching or change detection apply to all domains
+  automatically.
+
+* As a platform developer consuming FeatureGateAccess in an operator, I want
+  the refactor to be invisible to me (same interface, same constructors, same
+  behavior), so that I do not need to modify my operator code.
+
+* As a platform developer building the TLS or PKI accessor, I want to see the
+  generic framework validated in production first (through the FeatureGate
+  refactor), so that I have confidence the generic handles edge cases correctly.
+
+### Goals
+
+1. Refactor `FeatureGateAccess` to delegate to `VersionedConfigAccess[Features]`
+   internally, preserving the public interface unchanged.
+2. Validate the generic framework using the existing FeatureGate test suite
+   without requiring new test cases.
+3. Reduce the FeatureGate-specific implementation to a thin adapter layer.
+
+### Non-Goals
+
+1. Changing the FeatureGate CRD or its status shape. The FeatureGate CRD
+   already has the correct version-indexed status structure.
+2. Changing the `FeatureGateAccess` public interface or constructor signatures.
+3. Modifying any consuming operator.
+4. Adding new feature gates or changing feature gate behavior.
+
+## Proposal
+
+The `FeatureGateAccess` interface and its constructors (`NewFeatureGateAccess`,
+`NewHardcodedFeatureGateAccess`) remain exactly as they are today. The internal
+implementation changes from a standalone 300-line implementation to a thin
+adapter that delegates to `VersionedConfigAccess[Features]`.
+
+The `FeatureGate` query interface (which provides methods like
+`Enabled(featureName)` with panic-on-unknown semantics) continues to wrap the
+raw `Features` data. This is a clean example of the framework's design
+principle: `T` is data, and query semantics are layered on top by the domain.
+
+### Workflow Description
+
+**platform developer** is an OpenShift engineer who consumes `FeatureGateAccess`
+in an operator.
+
+**library-go maintainer** is the engineer performing the refactor.
+
+#### Refactor Process
+
+1. The library-go maintainer implements `VersionedConfigAccess[Features]` in
+   the new `pkg/operator/versionedconfig/` package (see
+   [versioned-config-access.md](versioned-config-access.md)).
+2. The library-go maintainer modifies `defaultFeatureGateAccess` to hold an
+   inner `VersionedConfigAccess[Features]` and delegate all operations to it.
+3. The library-go maintainer defines a `StatusExtractor[Features]` function
+   (`extractFeaturesFromFeatureGate`) that reads `[]FeatureGateDetails` from
+   FeatureGate CRD status and converts them to `[]VersionedEntry[Features]`.
+4. The library-go maintainer defines an `EqualityFunc[Features]`
+   (`featuresEqual`) that compares enabled/disabled feature lists.
+5. All existing unit tests, integration tests, and e2e tests pass without
+   modification.
+
+#### No Impact on Consuming Operators
+
+1. The platform developer continues to call `NewFeatureGateAccess(...)` with
+   the same parameters.
+2. The platform developer continues to call `Run(ctx)`,
+   `InitialFeatureGatesObserved()`, and `CurrentFeatureGates()` as before.
+3. The `FeatureGate` query interface returned by `CurrentFeatureGates()`
+   continues to provide `Enabled(name)` with panic-on-unknown semantics.
+4. No operator code changes are needed.
+
+### API Extensions
+
+None. The FeatureGate CRD status already has the correct version-indexed shape
+(`[]FeatureGateDetails` keyed by `version`). No CRD changes are made.
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+No change. `FeatureGateAccess` already works correctly in Hypershift. The
+refactor preserves the same `desiredVersion` parameter that allows management
+and guest cluster operators to find their respective entries.
+
+#### Standalone Clusters
+
+Fully applicable. No behavioral change.
+
+#### Single-node Deployments or MicroShift
+
+**SNO**: No behavioral change.
+
+**MicroShift**: Out of scope. MicroShift does not use `FeatureGateAccess`.
+
+### Implementation Details/Notes/Constraints
+
+#### Adapter Pattern
+
+The refactored `FeatureGateAccess` is a thin adapter:
+
+```go
+// FeatureGateAccess interface is UNCHANGED. All existing methods preserved.
+type FeatureGateAccess interface {
+    SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc)
+    Run(ctx context.Context)
+    InitialFeatureGatesObserved() <-chan struct{}
+    CurrentFeatureGates() (FeatureGate, error)
+    AreInitialFeatureGatesObserved() bool
+}
+
+// NewFeatureGateAccess signature is UNCHANGED.
+func NewFeatureGateAccess(
+    desiredVersion, missingVersionMarker string,
+    clusterVersionInformer v1.ClusterVersionInformer,
+    featureGateInformer v1.FeatureGateInformer,
+    eventRecorder events.Recorder,
+) FeatureGateAccess {
+    // Internally delegates to:
+    inner := versionedconfig.NewVersionedConfigAccess[Features](
+        desiredVersion, missingVersionMarker,
+        clusterVersionInformer.Informer(),
+        featureGateInformer.Informer(),
+        "cluster",
+        extractFeaturesFromFeatureGate,
+        featuresEqual,
+        eventRecorder,
+    )
+    return &featureGateAdapter{inner: inner}
+}
+```
+
+The `NewHardcodedFeatureGateAccess` constructor similarly wraps
+`NewHardcodedConfigAccess[Features]`:
+
+```go
+func NewHardcodedFeatureGateAccess(
+    enabled []configv1.FeatureGateName,
+    disabled []configv1.FeatureGateName,
+) FeatureGateAccess {
+    features := Features{Enabled: enabled, Disabled: disabled}
+    inner := versionedconfig.NewHardcodedConfigAccess[Features](features)
+    return &featureGateAdapter{inner: inner}
+}
+```
+
+#### T = Features
+
+The data type for feature gates is:
+
+```go
+type Features struct {
+    Enabled  []configv1.FeatureGateName
+    Disabled []configv1.FeatureGateName
+}
+```
+
+The `FeatureGate` query interface wraps this data to provide `Enabled(name)`
+with panic-on-unknown semantics, exactly as it does today.
+
+#### StatusExtractor
+
+The `extractFeaturesFromFeatureGate` function reads `FeatureGateStatus` from
+the FeatureGate CRD object and converts `[]FeatureGateDetails` (each keyed by
+`version`) into `[]VersionedEntry[Features]`. This is a straightforward field
+mapping with no business logic changes.
+
+### Risks and Mitigations
+
+**Risk: FeatureGateAccess refactor introduces regressions.**
+Mitigation: The refactor is a pure internal restructuring. The public interface
+(`FeatureGateAccess`, `NewFeatureGateAccess`, `NewHardcodedFeatureGateAccess`)
+is unchanged. The same unit tests and integration tests apply. The refactor
+occurs after the generic accessor is validated with its own test suite.
+
+**Risk: Subtle behavioral differences between old and new implementations.**
+Mitigation: Property-based tests can compare old and new implementations for
+identical inputs to confirm behavioral equivalence. The existing integration
+and e2e test suites provide additional coverage.
+
+### Drawbacks
+
+The refactor adds a dependency on the new `versionedconfig` package. If the
+generic package has a bug, it affects FeatureGateAccess (and eventually TLS
+and PKI). However, this is also a benefit: a bug fix in the generic package
+fixes all consumers simultaneously.
+
+## Design Details
+
+### Test Plan
+
+#### Unit Tests
+
+- **Behavioral equivalence**: Property-based tests comparing old implementation
+  output with new adapter output for identical inputs, covering version
+  matching, change detection, and missing version behavior.
+- **Adapter correctness**: Test that `featureGateAdapter` correctly translates
+  between `VersionedConfigAccess[Features]` methods and `FeatureGateAccess`
+  methods.
+- **StatusExtractor**: Test that `extractFeaturesFromFeatureGate` correctly
+  converts `FeatureGateStatus` entries to `VersionedEntry[Features]`.
+
+#### Integration Tests
+
+Run all existing FeatureGate integration tests against the refactored
+implementation. No new test cases needed; the refactor must pass all existing
+tests unchanged.
+
+#### End-to-End Tests
+
+Run all existing FeatureGate e2e tests. No new test cases needed.
+
+### Graduation Criteria
+
+This refactor is a pure internal library-go change with no API surface. It
+ships as GA immediately, validated by the existing FeatureGate test suite.
+
+#### Dev Preview -> Tech Preview
+
+N/A. Ships as GA immediately (internal refactor).
+
+#### Tech Preview -> GA
+
+N/A. Ships as GA immediately (internal refactor).
+
+#### Removing a deprecated feature
+
+N/A. No features are deprecated.
+
+### Upgrade / Downgrade Strategy
+
+**No admin action required.** The refactor is internal to library-go. Operators
+compiled against the new library-go behave identically to operators compiled
+against the old library-go. There is no runtime state change, no CRD change,
+and no configuration change.
+
+On downgrade, operators compiled against the old library-go resume using the
+standalone `FeatureGateAccess` implementation. There is no interaction between
+old and new implementations because they both read the same FeatureGate CRD
+status in the same way.
+
+### Version Skew Strategy
+
+No change from the current FeatureGateAccess behavior. The refactor preserves
+the same version-matching logic. See
+[versioned-config-access.md](versioned-config-access.md) for the general
+version skew strategy.
+
+### Operational Aspects of API Extensions
+
+N/A. No API extensions are added or modified.
+
+#### Failure Modes
+
+No new failure modes. The refactored implementation has the same failure
+characteristics as the current implementation:
+
+- If the FeatureGate CRD status does not contain an entry for the operator's
+  version, the operator blocks at startup until the entry appears.
+- If the FeatureGate CRD is unavailable, the informer watch fails and the
+  operator blocks at startup.
+
+These failure modes exist today and are handled by the same mechanisms
+(startup timeout, operator health monitoring).
+
+#### Support Procedures
+
+No new support procedures. The refactored implementation produces the same
+log messages and events as the current implementation. Existing troubleshooting
+documentation applies unchanged.
+
+## Implementation History
+
+N/A. This enhancement is newly proposed.
+
+## Alternatives
+
+### Leave FeatureGateAccess As-Is
+
+The current standalone implementation works. The argument for refactoring is
+not to fix a bug but to validate the generic framework and reduce long-term
+maintenance burden. If the generic framework is not adopted for TLS and PKI,
+the refactor has less value. However, both TLS and PKI are planned (see
+[tls-versioned-config.md](tls-versioned-config.md) and
+[pki-versioned-config.md](pki-versioned-config.md)), making the refactor
+a worthwhile investment.
+
+## Infrastructure Needed
+
+None. All changes are to the existing openshift/library-go repository.

--- a/enhancements/config/featuregate-versioned-config.md
+++ b/enhancements/config/featuregate-versioned-config.md
@@ -3,10 +3,10 @@ title: featuregate-versioned-config
 authors:
   - "@sanchezl"
 reviewers:
-  - "@deads2k, for FeatureGateAccess backward compatibility, please review the adapter pattern"
+  - "@JoelSpeed, for openshift/api conventions, please review the adapter pattern and feature gate types"
   - "@everettraven, for openshift/api conventions and feature gate declaration patterns"
 approvers:
-  - "@deads2k"
+  - "@JoelSpeed"
 api-approvers:
   - "None"
 creation-date: 2026-08-04

--- a/enhancements/config/pki-versioned-config.md
+++ b/enhancements/config/pki-versioned-config.md
@@ -1,0 +1,599 @@
+---
+title: pki-versioned-config
+authors:
+  - "@sanchezl"
+reviewers:
+  - "@benluddy, for PKI profile resolution and certificate rotation domain expertise"
+  - "@deads2k, for library-go accessor pattern and VersionedConfigAccess design"
+  - "@everettraven, for openshift/api type changes and PKI CRD status additions"
+approvers:
+  - "@deads2k"
+api-approvers:
+  - "@deads2k"
+creation-date: 2026-08-04
+last-updated: 2026-08-04
+tracking-link:
+  - https://redhat.atlassian.net/browse/OCPSTRAT-2271
+see-also:
+  - "/enhancements/config/versioned-config-access.md"
+  - "/enhancements/security/internal-pki-config.md"
+---
+
+# PKI Versioned Config
+
+## Summary
+
+The PKI CRD (`config/v1alpha1/types_pki.go`) defines management modes
+(Unmanaged, Default, Custom) for internal PKI configuration, but it has no
+status subresource with version-indexed resolved profiles, no accessor in
+library-go, and no startup synchronization. Operators must implement their own
+pull-based configuration resolution with no guarantees about when configuration
+is available at startup.
+
+This enhancement adds a status subresource with version-indexed resolved PKI
+profiles to the PKI CRD, provides a `PKIProfileAccess` wrapper in library-go
+built on the generic `VersionedConfigAccess[*PKIProfile]` interface from the
+[Versioned Config Access](versioned-config-access.md) framework, and
+centralizes certificate lifetime fields in the versioned table. The result
+enables PKI configuration to evolve across versions (for example, migrating
+from RSA-2048 to ECDSA P-256 key algorithms), gives operators startup
+synchronization and change notification, and provides administrators with
+visibility into what their PKI management mode resolves to for their cluster
+version.
+
+## Motivation
+
+The PKI CRD is partway through the three-layer pattern described in
+[versioned-config-access.md](versioned-config-access.md). It has a spec with
+management modes but lacks the other two layers:
+
+1. **No status subresource.** There is no version-indexed resolved profile in
+   CRD status. Operators cannot see what "Default" mode concretely means for
+   their cluster version without reading source code.
+
+2. **No version indexing.** PKI profiles are not indexed by cluster version.
+   When the platform needs to evolve key algorithms across versions (for
+   example, introducing ECDSA P-256 in 4.20 while 4.19 uses RSA-2048), there
+   is no mechanism to serve different defaults to different versions during
+   an upgrade.
+
+3. **No accessor in library-go.** Operators implement pull-based configuration
+   resolution with no startup synchronization channel and no change
+   notification.
+
+4. **Hardcoded lifetimes.** Certificate lifetime constants (signer validity,
+   leaf validity, refresh intervals) are scattered across operator code as
+   hardcoded values. There is no central, versioned location where these
+   lifetimes are defined.
+
+5. **Coordinated revendoring required for changes.** PKI defaults (key
+   algorithms, lifetimes) are compiled into operators via library-go constants
+   and per-operator code. Changing defaults requires updating library-go and
+   revendoring it across every certificate-generating operator. With a
+   materialized status approach, only cluster-config-operator needs to
+   revendor; all other operators receive updated PKI profiles at runtime
+   through their informer watch on CRD status.
+
+### User Stories
+
+* As a platform developer evolving PKI key algorithm defaults across OCP
+  versions, I want the PKI CRD status to contain version-indexed resolved
+  profiles, so that operators on different versions during an upgrade each see
+  the correct defaults for their version.
+
+* As a cluster administrator, I want to see what the "Default" PKI management
+  mode concretely resolves to on my cluster's version (key algorithm, key size,
+  signature algorithm, certificate lifetimes), so that I can understand the
+  PKI configuration without reading source code.
+
+* As a platform developer building a certificate-generating operator, I want a
+  standard `PKIProfileAccess` from library-go with startup sync and change
+  notification, so that I do not need to implement my own pull-based
+  configuration resolution.
+
+* As a platform developer, I want certificate lifetimes centralized in the
+  versioned PKI profile table, so that future versions can adjust lifetimes
+  without code changes in each individual operator.
+
+### Goals
+
+1. Add a status subresource with version-indexed resolved profiles to the PKI
+   CRD.
+2. Provide a `PKIProfileAccess` wrapper in library-go that uses
+   `VersionedConfigAccess[*PKIProfile]`.
+3. Centralize certificate lifetime fields in the `PKIProfile` type, replacing
+   hardcoded constants scattered across operators.
+4. Enable per-version PKI configuration evolution (key algorithms, lifetimes).
+5. Provide a materializer controller in cluster-config-operator.
+
+### Non-Goals
+
+1. Changing the admin-facing API for selecting PKI management modes. The
+   `spec.managementState` field on the PKI CRD remains unchanged.
+2. Adding new key algorithms or certificate configurations. This enhancement
+   provides the infrastructure; actual algorithm changes are separate work.
+3. Changing the `ConfigurablePKI` feature gate. This enhancement is gated
+   behind the existing feature gate and graduates alongside it.
+
+## Proposal
+
+This proposal applies the three-layer pattern from
+[versioned-config-access.md](versioned-config-access.md) to PKI profiles:
+
+1. **Declare**: A version-indexed PKI declaration table in openshift/api defines
+   the platform's Default PKI profile for each version range.
+2. **Materialize**: A controller in cluster-config-operator reads the PKI spec,
+   resolves the management mode, and writes version-indexed entries into
+   `pki.status.profiles[]`.
+3. **Access**: A `PKIProfileAccess` type in library-go wraps
+   `VersionedConfigAccess[*PKIProfile]`.
+
+### Workflow Description
+
+**cluster administrator** is a human user who selects a PKI management mode.
+
+**cluster-config-operator** is the controller responsible for materializing
+resolved PKI profiles into PKI status.
+
+**consuming operator** is any OpenShift operator that generates certificates
+and needs the resolved PKI profile.
+
+#### PKI Profile Resolution
+
+1. The cluster administrator configures the PKI CRD with a management mode
+   (Unmanaged, Default, or Custom).
+2. The cluster-config-operator materializer reads the spec and resolves the
+   mode:
+   - **Unmanaged**: Writes a nil profile entry for each version. Operators use
+     their hardcoded defaults.
+   - **Default**: Looks up the version-indexed declaration table for each
+     version in ClusterVersion status. Writes the resolved profile.
+   - **Custom**: Uses the administrator's explicit configuration as-is. Writes
+     it for each version.
+3. The consuming operator instantiates `PKIProfileAccess`, which wraps
+   `VersionedConfigAccess[*PKIProfile]`. On startup, the accessor watches the
+   PKI informer, finds the entry matching the operator's desired version,
+   caches it, and closes the `InitialConfigObserved()` channel.
+4. The operator calls `CurrentPKIProfile()`:
+   - If the result is nil, the operator uses its hardcoded defaults (Unmanaged
+     mode).
+   - If non-nil, the operator calls `ResolveCertificateConfig` to resolve the
+     profile's category hierarchy (signer, serving, client overrides falling
+     back to defaults).
+5. If the management mode changes or the cluster upgrades, the change handler
+   fires and the operator restarts.
+
+#### Version Skew During Upgrade
+
+1. A cluster begins upgrading from 4.19 to 4.20. The PKI status contains
+   profile entries for both versions.
+2. An operator still running at version 4.19 finds its entry and uses
+   RSA-2048 as the key algorithm (the 4.19 default).
+3. A newly rolled-out operator at version 4.20 finds its entry and uses
+   ECDSA P-256 as the key algorithm (the 4.20 default).
+4. Both operators generate certificates with their version-appropriate key
+   algorithms. Existing certificates are not re-generated; only new
+   certificates use the new algorithm.
+5. After all operators converge on 4.20, the 4.19 entry is eventually pruned.
+
+### API Extensions
+
+This enhancement adds a status subresource to the existing PKI CRD. No new
+CRDs are added.
+
+#### PKI Status Addition
+
+The PKI CRD gains a status subresource with version-indexed resolved profiles:
+
+```go
+// in config/v1alpha1/types_pki.go
+
+type PKIStatus struct {
+    // conditions represent the observations of the current state.
+    // +listType=map
+    // +listMapKey=type
+    // +optional
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+    // profiles contains a list of resolved PKI profiles keyed by
+    // payloadVersion. Operators must locate the version they are managing
+    // and use the resolved profile for certificate generation.
+    // A nil PKIProfile entry for a version means PKI is Unmanaged for that
+    // version, and operators should use their hardcoded defaults.
+    // +listType=map
+    // +listMapKey=version
+    // +optional
+    Profiles []VersionedPKIProfile `json:"profiles,omitempty"`
+}
+
+type VersionedPKIProfile struct {
+    // version matches the version provided by ClusterVersion and in the
+    // ClusterOperator.Status.Versions field.
+    // +required
+    Version string `json:"version"`
+
+    // profile contains the resolved PKI profile for this version.
+    // When nil, PKI is Unmanaged for this version and operators should
+    // use their hardcoded defaults.
+    // +optional
+    Profile *PKIProfile `json:"profile,omitempty"`
+}
+```
+
+#### PKIProfile Lifetime Fields
+
+The `PKIProfile` type gains certificate lifetime fields, centralizing values
+that are currently hardcoded constants scattered across operators:
+
+```go
+// PKIProfile is extended with lifetime configuration.
+// These fields move hardcoded certificate lifetime constants into the
+// versioned table so that future versions can adjust lifetimes without
+// code changes in each operator.
+
+type PKIProfile struct {
+    // ... existing key algorithm and signature algorithm fields ...
+
+    // signerValidity defines the validity duration for signer (CA) certificates.
+    // +optional
+    SignerValidity *metav1.Duration `json:"signerValidity,omitempty"`
+
+    // leafValidity defines the validity duration for leaf certificates.
+    // +optional
+    LeafValidity *metav1.Duration `json:"leafValidity,omitempty"`
+
+    // refreshInterval defines how often certificates are refreshed
+    // before expiration.
+    // +optional
+    RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`
+}
+```
+
+#### Behavioral Changes to Existing Resources
+
+- **PKI**: Adds a status subresource. The PKI CRD is `v1alpha1` behind the
+  `ConfigurablePKI` feature gate, so there are no backward compatibility
+  concerns.
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+In Hypershift, control plane components run in the management cluster at a
+potentially different version than data plane components in the guest cluster.
+The version-indexed status model handles this naturally:
+
+- Each cluster materializes its own PKI status independently.
+- The accessor's `desiredVersion` parameter ensures each operator reads the
+  correct entry for its version.
+
+#### Standalone Clusters
+
+Fully applicable. Standalone clusters are the primary deployment model.
+
+#### Single-node Deployments or MicroShift
+
+**SNO**: No additional resource consumption. The materializer runs in
+cluster-config-operator which is already present. The accessor watches
+existing PKI informers.
+
+**MicroShift**: Out of scope. MicroShift does not use the library-go operator
+framework for PKI profile resolution.
+
+### Implementation Details/Notes/Constraints
+
+#### T = *PKIProfile (nil = Unmanaged)
+
+The use of a pointer type allows nil to represent "Unmanaged" mode, where
+operators use their hardcoded defaults. This avoids needing a sentinel value
+or a separate "is managed" boolean.
+
+#### Version-Indexed Declaration Table
+
+```go
+var VersionedPKIDefaults = []VersionedPKIDeclaration{
+    {MinVersion: "4.19", Profile: pkiProfile_RSA2048},
+    {MinVersion: "4.20", Profile: pkiProfile_ECDSA_P256},
+}
+```
+
+The materializer uses floor-based resolution: for a requested version `V`, it
+finds the highest `MinVersion` entry that is less than or equal to `V`. Only
+versions where PKI defaults change need entries.
+
+Custom mode bypasses the declaration table entirely; the administrator's
+explicit configuration is used as-is for all versions.
+
+#### Materializer Controller
+
+A controller (~100 lines) in cluster-config-operator:
+
+1. Watches the PKI spec for management mode changes.
+2. Reads all versions from `ClusterVersion.status.history` and
+   `ClusterVersion.status.desired.version`.
+3. Resolves each version:
+   - **Unmanaged**: writes nil profile.
+   - **Default**: performs floor-based lookup in declaration table.
+   - **Custom**: uses admin's configuration directly.
+4. Writes version-indexed entries into `pki.status.profiles[]`.
+
+#### PKIProfileAccess
+
+```go
+type PKIProfileAccess struct {
+    inner versionedconfig.VersionedConfigAccess[*PKIProfile]
+}
+
+func NewPKIProfileAccess(
+    desiredVersion, missingVersionMarker string,
+    clusterVersionInformer cache.SharedIndexInformer,
+    pkiInformer cache.SharedIndexInformer,
+    eventRecorder events.Recorder,
+) *PKIProfileAccess
+
+func (a *PKIProfileAccess) Run(ctx context.Context)
+func (a *PKIProfileAccess) InitialPKIProfileObserved() <-chan struct{}
+func (a *PKIProfileAccess) CurrentPKIProfile() (*PKIProfile, error)
+func (a *PKIProfileAccess) SetChangeHandler(fn func(old, new *PKIProfile))
+```
+
+These methods delegate to the inner `VersionedConfigAccess[*PKIProfile]`.
+The domain-specific naming (`InitialPKIProfileObserved` rather than
+`InitialConfigObserved`) follows the convention established by
+`FeatureGateAccess.InitialFeatureGatesObserved()`.
+
+When the returned profile is nil, the operator uses its hardcoded defaults
+(Unmanaged mode). When non-nil, the operator calls `ResolveCertificateConfig`
+to resolve the profile's category hierarchy (signer, serving, client overrides
+falling back to defaults).
+
+#### Override Hierarchy
+
+The accessor provides the version-selected PKI profile (what "Default" means
+for this cluster version). The `ResolveCertificateConfig` chain then resolves
+the category hierarchy within that profile:
+
+1. Check for a certificate-specific override in the profile.
+2. Fall back to the category default (signer, serving, or client).
+3. Fall back to the profile-level default.
+
+This two-tier separation keeps version selection (accessor) and category
+resolution (`ResolveCertificateConfig`) as independent concerns.
+
+### Risks and Mitigations
+
+**Risk: PKI status increases API object size.**
+Mitigation: During a normal upgrade, at most two version entries exist in
+status. Each `VersionedPKIProfile` entry is small (key algorithm, signature
+algorithm, lifetime fields). Two entries add negligible size to the PKI object.
+
+**Risk: Materializer controller failure leaves stale status.**
+Mitigation: Same as TLS (see
+[tls-versioned-config.md](tls-versioned-config.md)). The materializer runs in
+cluster-config-operator with established health monitoring. Operators block at
+startup until they have valid configuration.
+
+**Risk: Lifetime centralization changes existing operator behavior.**
+Mitigation: The initial versioned table entries use the same lifetime values
+currently hardcoded in operators. The centralization is a "move, not change"
+operation. Future lifetime adjustments are separate work with their own
+validation.
+
+**Risk: Nil profile semantics (Unmanaged) may confuse consumers.**
+Mitigation: The `CurrentPKIProfile()` return type is `*PKIProfile`, making nil
+checks natural in Go. Documentation and code comments make the nil = Unmanaged
+contract clear.
+
+### Drawbacks
+
+The PKI CRD is `v1alpha1` behind a feature gate, which limits the impact of
+this enhancement but also limits its validation surface. Until `ConfigurablePKI`
+graduates to a wider audience, the PKI accessor sees limited production use.
+However, building the accessor now (while the CRD is still alpha) is the right
+time to establish the pattern before the API stabilizes.
+
+## Design Details
+
+### Open Questions
+
+1. Should the PKI profile's lifetime fields be added to `PKIProfile` in the
+   same phase as the accessor, or deferred to a later phase? Adding them
+   increases scope but avoids a follow-up API change.
+
+2. What is the retention policy for old version entries in PKI status? The
+   materializer should prune entries for versions no longer present in
+   ClusterVersion status, but the exact cleanup timing needs definition.
+
+### Test Plan
+
+#### Unit Tests
+
+- **Declaration table**: Test floor-based version lookup. Verify that
+  requesting version 4.19 returns RSA-2048 and requesting 4.20 returns
+  ECDSA P-256.
+- **Mode resolution**: Test that Unmanaged returns nil, Default returns the
+  version-appropriate profile, and Custom passes through the admin's
+  configuration.
+- **StatusExtractor**: Test that `extractPKIProfilesFromPKI` correctly reads
+  `PKIStatus.Profiles` and converts to `[]VersionedEntry[*PKIProfile]`.
+- **EqualityFunc**: Test that `pkiProfileEqual` correctly handles nil vs
+  non-nil, identical profiles, and profiles differing in key algorithm or
+  lifetime fields.
+- **Lifetime fields**: Test that versioned table entries include the expected
+  lifetime values for each version.
+
+#### Integration Tests
+
+- **Materializer**: Test that cluster-config-operator correctly writes
+  version-indexed PKI profiles into PKI status for each management mode:
+  - Unmanaged produces nil profile entries
+  - Default produces version-appropriate profile entries
+  - Custom produces the admin's explicit configuration for all versions
+
+#### End-to-End Tests
+
+- **PKI profile resolution**: On a TechPreview cluster with `ConfigurablePKI`
+  enabled, set the PKI management mode to Default and verify that
+  `status.profiles[].profile` contains the expected key algorithm configuration
+  for the cluster's version.
+- **Unmanaged mode**: Verify that setting Unmanaged mode results in nil profile
+  entries and operators use their hardcoded defaults.
+
+### Graduation Criteria
+
+PKI profiles are gated by the `ConfigurablePKI` feature gate. The
+version-indexed status and accessor graduate alongside the PKI feature.
+
+#### Dev Preview -> Tech Preview
+
+- PKI CRD gains status subresource with version-indexed profiles
+- PKI accessor available in library-go
+- Materializer controller running in cluster-config-operator
+- At least one certificate-generating operator migrated to the accessor
+- Unit tests and integration tests passing
+
+#### Tech Preview -> GA
+
+- All certificate-generating operators migrated to the accessor
+- e2e tests for version resolution and lifetime centralization
+- Documentation in openshift-docs describing how admins can inspect resolved
+  PKI profiles
+- `ConfigurablePKI` feature gate moves to Default
+
+#### Removing a deprecated feature
+
+N/A. No features are deprecated by this enhancement.
+
+### Upgrade / Downgrade Strategy
+
+#### Upgrade
+
+**No admin action required.** On upgrade from N to N+1:
+
+1. The CRD schema update adds the status subresource (additive, no breaking
+   change). The PKI CRD is `v1alpha1`, so schema evolution is expected.
+2. The new cluster-config-operator version starts the PKI materializer
+   controller, which populates status entries.
+3. New operator versions use the accessor to read their version's entry from
+   status.
+4. Old operator versions continue functioning because they use their existing
+   pull-based configuration resolution (the spec is unchanged).
+
+#### Downgrade
+
+On downgrade from N+1 to N:
+
+1. The old cluster-config-operator does not have the PKI materializer, so
+   status entries become stale. Old operators do not read them.
+2. For v1alpha1 APIs, unknown fields in status are preserved but not validated.
+   The stale entries are harmless.
+3. Old operators resume using their existing configuration mechanisms.
+4. No manual cleanup is required.
+
+### Version Skew Strategy
+
+See the general version skew strategy in
+[versioned-config-access.md](versioned-config-access.md). For PKI specifically:
+
+- During an upgrade, operators at version N generate certificates using N's key
+  algorithm; operators at version N+1 generate certificates using N+1's key
+  algorithm. Existing certificates are not re-generated; only new certificates
+  use the new algorithm.
+- This is safe because PKI consumers (TLS clients and servers) support multiple
+  key algorithms simultaneously. A certificate signed with RSA-2048 and a
+  certificate signed with ECDSA P-256 can coexist in the same cluster without
+  conflicts.
+
+### Operational Aspects of API Extensions
+
+This enhancement adds a status subresource to the PKI CRD. It does not add
+webhooks, finalizers, or aggregated API servers.
+
+**Impact on existing SLIs:**
+
+- PKI object size increases minimally (two version entries during upgrade).
+  The PKI CRD has minimal watch traffic (only certificate-generating operators
+  watch it).
+- No impact on API latency.
+
+**Monitoring:**
+
+- The existing `cluster-config-operator` health metrics cover the materializer
+  controller.
+- The accessor emits events on initial config observation and config changes.
+
+**Escalation path:** Control Plane / Cert team.
+
+#### Failure Modes
+
+- **Materializer failure**: If the cluster-config-operator PKI materializer
+  controller fails, status entries are not written or updated. Operators using
+  the accessor block at startup (if no entry exists yet) or continue using
+  the last-observed configuration. Detection: `oc get co cluster-config-operator`
+  shows Degraded.
+- **Stale status entries**: If ClusterVersion changes but the materializer has
+  not yet updated status, operators at the new version may experience a startup
+  delay. Detection: operator logs show `missing desired version` errors.
+- **Version string mismatch**: If an operator reports a version string that
+  does not exactly match any status entry, the accessor returns an error and
+  the operator blocks at startup. Detection: operator pod in CrashLoopBackOff
+  with `timed out waiting for VersionedConfig detection` in logs.
+
+#### Support Procedures
+
+**Symptom: Certificate-generating operator fails to start with "timed out waiting for PKI config"**
+
+Detection: Operator logs show `timed out waiting for VersionedConfig detection`
+or similar messages. The operator pod is in CrashLoopBackOff.
+
+Root cause: The PKI materializer has not written a status entry for the
+operator's version.
+
+Remediation:
+1. Check `oc get co cluster-config-operator` for degraded conditions.
+2. Check `oc get pki cluster -o yaml` to see if version-indexed PKI status
+   entries exist.
+3. Compare the operator's reported desired version (from operator logs) with
+   the versions in CRD status.
+4. If cluster-config-operator is healthy, check its logs for PKI materializer
+   errors.
+
+**Symptom: Operator using wrong key algorithm after upgrade**
+
+Detection: Newly generated certificates use the old version's key algorithm
+instead of the new version's.
+
+Root cause: The operator is reading a stale status entry (old version) instead
+of the new version's entry.
+
+Remediation:
+1. Check `oc get pki cluster -o jsonpath='{.status.profiles}'` to see which
+   version entries exist.
+2. Verify the operator's reported version matches an entry in status.
+3. If the operator is at the new version but reading the old entry, restart
+   the operator and collect logs.
+
+## Implementation History
+
+N/A. This enhancement is newly proposed.
+
+## Alternatives
+
+### Pull-Based Configuration Without Accessor
+
+The current approach (operators read PKI spec directly) works for a single
+version but does not support version-indexed configuration. Each operator
+independently resolves the management mode, duplicating logic and providing
+no startup synchronization. The accessor pattern centralizes this logic and
+adds the three guarantees (version matching, startup sync, change detection)
+that the pull-based approach lacks.
+
+## Infrastructure Needed
+
+No new subprojects, repositories, or testing infrastructure needed. All changes
+are to existing repositories:
+
+- **openshift/api**: `PKIStatus` type with version-indexed profiles, lifetime
+  field additions to `PKIProfile`.
+- **openshift/library-go**: `PKIProfileAccess` wrapper type.
+- **openshift/cluster-config-operator**: PKI materializer controller.

--- a/enhancements/config/pki-versioned-config.md
+++ b/enhancements/config/pki-versioned-config.md
@@ -4,12 +4,12 @@ authors:
   - "@sanchezl"
 reviewers:
   - "@benluddy, for PKI profile resolution and certificate rotation domain expertise"
-  - "@deads2k, for library-go accessor pattern and VersionedConfigAccess design"
+  - "@JoelSpeed, for openshift/api conventions and PKI CRD status type additions"
   - "@everettraven, for openshift/api type changes and PKI CRD status additions"
 approvers:
-  - "@deads2k"
+  - "@JoelSpeed"
 api-approvers:
-  - "@deads2k"
+  - "@JoelSpeed"
 creation-date: 2026-08-04
 last-updated: 2026-08-04
 tracking-link:

--- a/enhancements/config/tls-versioned-config.md
+++ b/enhancements/config/tls-versioned-config.md
@@ -3,14 +3,13 @@ title: tls-versioned-config
 authors:
   - "@sanchezl"
 reviewers:
-  - "@deads2k, for library-go accessor pattern and VersionedConfigAccess design"
+  - "@JoelSpeed, for openshift/api conventions and APIServerStatus type additions"
   - "@damdo, for TLS profile domain expertise, please review version-indexed cipher evolution"
   - "@p0lyn0mial, for TLS config observer code being replaced by the accessor"
   - "@everettraven, for openshift/api type changes and APIServerStatus additions"
 approvers:
-  - "@deads2k"
+  - "@JoelSpeed"
 api-approvers:
-  - "@deads2k"
   - "@JoelSpeed"
 creation-date: 2026-08-04
 last-updated: 2026-08-04

--- a/enhancements/config/tls-versioned-config.md
+++ b/enhancements/config/tls-versioned-config.md
@@ -1,0 +1,600 @@
+---
+title: tls-versioned-config
+authors:
+  - "@sanchezl"
+reviewers:
+  - "@deads2k, for library-go accessor pattern and VersionedConfigAccess design"
+  - "@damdo, for TLS profile domain expertise, please review version-indexed cipher evolution"
+  - "@p0lyn0mial, for TLS config observer code being replaced by the accessor"
+  - "@everettraven, for openshift/api type changes and APIServerStatus additions"
+approvers:
+  - "@deads2k"
+api-approvers:
+  - "@deads2k"
+  - "@JoelSpeed"
+creation-date: 2026-08-04
+last-updated: 2026-08-04
+tracking-link:
+  - https://redhat.atlassian.net/browse/OCPSTRAT-2271
+see-also:
+  - "/enhancements/config/versioned-config-access.md"
+  - "/enhancements/kube-apiserver/tls-config.md"
+---
+
+# TLS Versioned Config
+
+## Summary
+
+OpenShift TLS security profiles (Old, Intermediate, Modern, Custom) are
+currently defined in a static Go map (`var TLSProfiles` in
+`config/v1/types_tlssecurityprofile.go`) that cannot vary by cluster version.
+When cipher suites need to evolve across OCP versions (for example, adding
+post-quantum groups like X25519MLKEM768 in newer versions), the only option is
+to modify the compiled-in map for all versions simultaneously.
+
+This enhancement introduces version-indexed TLS profile declarations in
+openshift/api, materializes resolved profiles into `APIServerStatus`, and
+provides a `TLSProfileAccess` wrapper in library-go built on the generic
+`VersionedConfigAccess[ResolvedTLSProfile]` interface from the
+[Versioned Config Access](versioned-config-access.md) framework. The result
+enables cipher suite evolution per version, gives administrators visibility
+into what their selected profile concretely resolves to, and provides operators
+with startup synchronization and change notification for TLS configuration.
+
+## Motivation
+
+The static `var TLSProfiles` map has several limitations:
+
+1. **No version indexing.** The map returns the same cipher list regardless of
+   cluster version. When OCP 4.22 needs to include post-quantum cipher groups
+   that OCP 4.18 does not support, there is no mechanism to serve different
+   cipher lists to different versions during an upgrade.
+
+2. **No CRD status visibility.** Administrators who select "Intermediate" have
+   no way to see what concrete cipher suites and minimum TLS version that
+   resolves to on their cluster without reading source code.
+
+3. **No startup synchronization.** Operators that use TLS profiles read the
+   static map at compile time. There is no informer-based observation, no
+   startup sync channel, and no change notification. If the platform ever needs
+   to evolve TLS configuration dynamically, the static map approach cannot
+   support it.
+
+4. **No accessor in library-go.** Each operator that needs the resolved TLS
+   profile must implement its own lookup and override logic.
+
+5. **Coordinated revendoring required for changes.** Because cipher lists are
+   compiled into every operator via the static map in openshift/api, any change
+   to TLS profiles requires revendoring openshift/api across every consuming
+   operator. With a materialized status approach, only cluster-config-operator
+   needs to revendor openshift/api; all other operators receive updated profiles
+   at runtime through their informer watch on CRD status.
+
+### User Stories
+
+* As a cluster administrator, I want to see what the "Intermediate" TLS profile
+  concretely resolves to on my cluster's version, so that I can verify the exact
+  cipher suites and minimum TLS version in use without reading source code:
+
+  ```bash
+  oc get apiserver cluster -o jsonpath='{.status.tlsProfiles}'
+  ```
+
+* As a platform developer evolving TLS cipher defaults across OCP versions, I
+  want to declare version-indexed TLS profiles in openshift/api, so that OCP
+  4.22 can include post-quantum cipher groups while OCP 4.18 continues using
+  its existing ciphers, without modifying the static map that all versions
+  share.
+
+* As a platform developer building an operator that serves TLS, I want a
+  standard `TLSProfileAccess` from library-go with startup sync and change
+  notification, so that I do not need to implement my own TLS configuration
+  lookup and observation logic.
+
+* As an SRE investigating a TLS issue during a version-skewed upgrade, I want
+  operators at both old and new versions to use their version-appropriate cipher
+  lists, so that a newly added cipher does not cause failures on operators
+  still running the old version.
+
+### Goals
+
+1. Replace the static `var TLSProfiles` map with a version-indexed declaration
+   table in openshift/api.
+2. Materialize resolved TLS profiles into `APIServerStatus` so administrators
+   can inspect them and operators can observe them.
+3. Provide a `TLSProfileAccess` wrapper in library-go that uses
+   `VersionedConfigAccess[ResolvedTLSProfile]`.
+4. Maintain backward compatibility for existing consumers of `var TLSProfiles`
+   through a compatibility alias.
+5. Enable per-version cipher suite evolution (including post-quantum readiness).
+
+### Non-Goals
+
+1. Adding specific new cipher suites or TLS configuration values. This
+   enhancement provides the infrastructure; actual cipher changes are separate
+   work.
+2. Changing the admin-facing API for selecting TLS profiles. The
+   `spec.tlsSecurityProfile` field on the APIServer CRD remains unchanged.
+3. Changing per-component TLS override mechanisms. Components that support
+   their own `tlsSecurityProfile` field (such as ingress controllers) continue
+   to use a stateless `ResolveTLSProfile` merge function.
+
+## Proposal
+
+This proposal applies the three-layer pattern from
+[versioned-config-access.md](versioned-config-access.md) to TLS profiles:
+
+1. **Declare**: A version-indexed TLS declaration table in openshift/api
+   replaces the static `var TLSProfiles` map.
+2. **Materialize**: A controller in cluster-config-operator reads the admin's
+   selected profile type from `apiserver.spec.tlsSecurityProfile.type`, looks
+   up the declaration table for each version present in ClusterVersion status,
+   and writes resolved entries into `apiserver.status.tlsProfiles[]`.
+3. **Access**: A `TLSProfileAccess` type in library-go wraps
+   `VersionedConfigAccess[ResolvedTLSProfile]`.
+
+### Workflow Description
+
+**cluster administrator** is a human user who selects a TLS profile type.
+
+**cluster-config-operator** is the controller responsible for materializing
+resolved TLS profiles into APIServer status.
+
+**consuming operator** is any OpenShift operator that needs the resolved TLS
+profile to configure its operand.
+
+#### TLS Profile Resolution
+
+1. The cluster administrator sets
+   `apiserver.config.openshift.io/cluster .spec.tlsSecurityProfile.type = Intermediate`.
+2. The cluster-config-operator materializer reads the spec, looks up the
+   version-indexed Intermediate profile for each version present in
+   ClusterVersion status, and writes resolved `TLSProfileSpec` entries into
+   `apiserver.status.tlsProfiles[]`.
+3. The kube-apiserver-operator instantiates `TLSProfileAccess`, which wraps
+   `VersionedConfigAccess[ResolvedTLSProfile]`. On startup, the accessor watches
+   the APIServer informer, finds the entry matching the operator's desired
+   version, caches it, and closes the `InitialConfigObserved()` channel.
+4. The operator calls `CurrentConfig()` to get the resolved `ResolvedTLSProfile`
+   containing the concrete cipher list and minimum TLS version for its version.
+5. If the administrator changes the profile type or the cluster upgrades (adding
+   a new version entry), the change handler fires and the operator restarts to
+   pick up the new configuration.
+6. The cluster administrator can inspect the resolved configuration:
+
+```bash
+oc get apiserver cluster -o jsonpath='{.status.tlsProfiles}'
+```
+
+#### Version Skew During Upgrade
+
+1. A cluster begins upgrading from 4.21 to 4.22. The APIServer status contains
+   TLS profile entries for both versions.
+2. An operator still running at version 4.21 finds the `version: "4.21.x"`
+   entry and uses its cipher list (which does not include new 4.22 ciphers).
+3. A newly rolled-out operator at version 4.22 finds the `version: "4.22.0"`
+   entry and uses its cipher list (which may include new ciphers).
+4. Both operators function correctly with their version-appropriate
+   configuration throughout the upgrade window.
+5. After all operators converge on 4.22, the 4.21 entry is eventually pruned
+   from status.
+
+#### Per-Component Override
+
+Components that support their own `tlsSecurityProfile` field (e.g., ingress
+controllers) apply a stateless `ResolveTLSProfile` function:
+
+1. If the component has its own `tlsSecurityProfile` set, resolve it directly
+   (this does not use the accessor).
+2. If the component does not have its own setting, use the cluster-wide resolved
+   profile from `TLSProfileAccess.CurrentConfig()`.
+
+This two-tier hierarchy separates concerns: the accessor provides the
+cluster-wide resolved profile; per-component overrides are stateless merges.
+
+### API Extensions
+
+This enhancement modifies the status of the existing APIServer CRD. No new
+CRDs are added.
+
+#### APIServer Status Addition
+
+The currently empty `APIServerStatus` struct gains a version-indexed list of
+resolved TLS profiles:
+
+```go
+// in config/v1/types_apiserver.go
+
+type APIServerStatus struct {
+    // tlsProfiles contains a list of resolved TLS security profiles keyed by
+    // payloadVersion. Operators must locate the version they are managing,
+    // find the resolved profile, and configure their operand accordingly.
+    // The resolved profile reflects the admin's selected profile type
+    // (Old, Intermediate, Modern, Custom) evaluated against the version-indexed
+    // declaration table for each version.
+    // +listType=map
+    // +listMapKey=version
+    // +optional
+    TLSProfiles []VersionedTLSProfile `json:"tlsProfiles,omitempty"`
+}
+
+type VersionedTLSProfile struct {
+    // version matches the version provided by ClusterVersion and in the
+    // ClusterOperator.Status.Versions field.
+    // +required
+    Version string `json:"version"`
+
+    // profileType indicates which profile type was resolved (Old, Intermediate,
+    // Modern, or Custom).
+    // +required
+    ProfileType TLSProfileType `json:"profileType"`
+
+    // spec contains the concrete cipher suites, groups, and minimum TLS version
+    // that the profile resolves to for this version.
+    // +required
+    Spec TLSProfileSpec `json:"spec"`
+}
+```
+
+This mirrors the pattern established by `FeatureGateStatus.FeatureGates`
+(`[]FeatureGateDetails` keyed by `version`) and uses existing `TLSProfileType`
+and `TLSProfileSpec` types.
+
+#### Behavioral Changes to Existing Resources
+
+- **APIServer**: The status subresource changes from empty to populated. No
+  existing consumers read `APIServerStatus` today, so this is purely additive.
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+In Hypershift, control plane components run in the management cluster at a
+potentially different version than data plane components in the guest cluster.
+The version-indexed status model handles this naturally:
+
+- Each cluster materializes its own APIServer status independently.
+- The accessor's `desiredVersion` parameter ensures each operator reads the
+  correct entry for its version.
+
+This is the same model used by FeatureGateAccess in Hypershift today.
+
+#### Standalone Clusters
+
+Fully applicable. Standalone clusters are the primary deployment model.
+
+#### Single-node Deployments or MicroShift
+
+**SNO**: No additional resource consumption. The materializer runs in
+cluster-config-operator which is already present. The accessor watches
+existing APIServer informers.
+
+**MicroShift**: Out of scope. MicroShift does not use the library-go operator
+framework for TLS profile resolution.
+
+### Implementation Details/Notes/Constraints
+
+#### T = ResolvedTLSProfile
+
+```go
+type ResolvedTLSProfile struct {
+    ProfileType TLSProfileType
+    Spec        TLSProfileSpec
+}
+```
+
+#### Version-Indexed Declaration Table
+
+The static `var TLSProfiles` map is replaced by a version-indexed declaration
+table. Only versions where profiles change need entries; the lookup uses
+floor-based resolution (the highest `MinVersion` entry at or below the
+requested version):
+
+```go
+// Pseudocode for the version-indexed TLS declaration table.
+// Actual implementation uses the features/util.go builder pattern.
+var VersionedTLSProfiles = map[TLSProfileType][]VersionedTLSDeclaration{
+    TLSProfileIntermediateType: {
+        {MinVersion: "4.18", Spec: intermediateSpec_4_18},
+        {MinVersion: "4.22", Spec: intermediateSpec_4_22}, // adds PQC groups
+    },
+    // Old, Modern follow the same pattern
+}
+```
+
+#### Backward-Compatible Alias
+
+The existing `var TLSProfiles` is retained as a backward-compatible alias that
+resolves to the latest version's values. Code that reads `TLSProfiles` today
+continues to compile and return reasonable defaults. This alias is deprecated
+once all consumers have migrated to the accessor.
+
+#### Materializer Controller
+
+A new controller (~100 lines) in cluster-config-operator:
+
+1. Watches the APIServer spec for `spec.tlsSecurityProfile.type` changes.
+2. Reads all versions from `ClusterVersion.status.history` and
+   `ClusterVersion.status.desired.version`.
+3. For each version, performs a floor-based lookup in the declaration table
+   to find the appropriate profile.
+4. Writes resolved entries into `apiserver.status.tlsProfiles[]`.
+
+#### TLSProfileAccess
+
+```go
+type TLSProfileAccess struct {
+    inner versionedconfig.VersionedConfigAccess[ResolvedTLSProfile]
+}
+
+func NewTLSProfileAccess(
+    desiredVersion, missingVersionMarker string,
+    clusterVersionInformer cache.SharedIndexInformer,
+    apiServerInformer cache.SharedIndexInformer,
+    eventRecorder events.Recorder,
+) *TLSProfileAccess
+
+func (a *TLSProfileAccess) Run(ctx context.Context)
+func (a *TLSProfileAccess) InitialTLSProfileObserved() <-chan struct{}
+func (a *TLSProfileAccess) CurrentTLSProfile() (ResolvedTLSProfile, error)
+func (a *TLSProfileAccess) SetChangeHandler(fn func(old, new ResolvedTLSProfile))
+```
+
+These methods delegate to the inner `VersionedConfigAccess[ResolvedTLSProfile]`.
+The domain-specific naming (`InitialTLSProfileObserved` rather than
+`InitialConfigObserved`) follows the convention established by
+`FeatureGateAccess.InitialFeatureGatesObserved()`.
+
+#### Override Hierarchy
+
+The accessor provides the cluster-wide resolved TLS profile. Components that
+support per-component TLS overrides (e.g., ingress controllers with their own
+`tlsSecurityProfile` field) apply a stateless `ResolveTLSProfile` function
+that merges the component-level override with the cluster-wide default. This
+function does not need the accessor; it operates on the already-resolved value.
+
+### Risks and Mitigations
+
+**Risk: Version-indexed TLS status increases API object size.**
+Mitigation: During a normal upgrade, at most two version entries exist in
+status. Each `VersionedTLSProfile` entry is approximately 500 bytes (cipher
+list + groups + min version). Two entries add ~1KB to the APIServer object,
+which is negligible.
+
+**Risk: Materializer controller failure leaves stale status.**
+Mitigation: The materializer controller runs in cluster-config-operator, which
+has high availability and established monitoring. If the materializer is
+temporarily unavailable, operators continue using the last-observed
+configuration (cached by the accessor). The accessor's `InitialConfigObserved`
+channel ensures operators block at startup until they have valid configuration,
+and a timeout (typically 1 minute) converts this into a clear startup failure
+rather than silent misconfiguration.
+
+**Risk: Backward compatibility breakage for `var TLSProfiles` consumers.**
+Mitigation: The static map is retained as a backward-compatible alias. Migration
+to the accessor is incremental, per-operator, with each migration being a small
+PR. Unmigrated consumers continue to compile and return reasonable defaults.
+
+### Drawbacks
+
+Migration burden is the primary concern. Existing TLS consumers use the static
+`var TLSProfiles` map directly. Migrating them to the accessor is incremental
+(per-operator, each one a small PR), and the backward-compatible alias ensures
+unmigrated consumers continue to work. However, until all consumers are
+migrated, the platform has two paths for TLS profile resolution, which adds
+cognitive overhead for developers.
+
+## Design Details
+
+### Open Questions
+
+1. Should the version-indexed TLS declaration table be defined in openshift/api
+   (alongside the existing `var TLSProfiles`) or in a separate package? Placing
+   it in openshift/api keeps the declaration close to the types but increases
+   the API module's surface area.
+
+2. What is the retention policy for old version entries in `APIServerStatus`?
+   The materializer should prune entries for versions no longer present in
+   `ClusterVersion.status`, but the exact cleanup timing needs definition.
+
+### Test Plan
+
+#### Unit Tests
+
+- **Declaration table**: Test floor-based version lookup for each profile type.
+  Verify that requesting version 4.20 with entries at 4.18 and 4.22 returns
+  the 4.18 entry. Verify that requesting 4.22 returns the 4.22 entry.
+- **Backward-compatible alias**: Verify that `var TLSProfiles` returns the same
+  values as the latest version entry in the declaration table.
+- **StatusExtractor**: Test that `extractTLSProfilesFromAPIServer` correctly
+  reads `APIServerStatus.TLSProfiles` and converts to
+  `[]VersionedEntry[ResolvedTLSProfile]`.
+- **EqualityFunc**: Test that `resolvedTLSProfileEqual` correctly compares
+  profiles with different cipher lists, different minimum TLS versions, and
+  different profile types.
+
+#### Integration Tests
+
+- **Materializer**: Test that cluster-config-operator correctly writes
+  version-indexed TLS profiles into APIServer status when:
+  - The admin changes `spec.tlsSecurityProfile.type`
+  - The cluster upgrades (new version appears in ClusterVersion status)
+  - Custom profile type passes through the admin's explicit cipher configuration
+
+#### End-to-End Tests
+
+- **TLS version resolution**: On a running cluster, set
+  `spec.tlsSecurityProfile.type = Intermediate`, verify that
+  `status.tlsProfiles[].spec` contains the expected ciphers for the cluster's
+  version. Compare against the declaration table entry for that version.
+- **Upgrade simulation**: Using a version-skewed test environment, verify that
+  operators at both old and new versions find their respective status entries
+  and use version-appropriate configuration.
+
+### Graduation Criteria
+
+#### Dev Preview -> Tech Preview
+
+- Version-indexed declaration table in openshift/api with backward-compatible
+  `var TLSProfiles` alias
+- APIServer status populated by cluster-config-operator materializer
+- TLS accessor available in library-go
+- At least one operator migrated to the accessor
+- Unit tests for version lookup and integration tests for materializer
+
+#### Tech Preview -> GA
+
+- All TLS-consuming operators migrated to the accessor
+- Static `var TLSProfiles` map deprecated
+- e2e tests for version resolution
+- Documentation in openshift-docs describing how admins can inspect resolved
+  TLS profiles
+
+#### Removing a deprecated feature
+
+The static `var TLSProfiles` map in openshift/api will be deprecated once all
+consumers have migrated to the accessor. Removal follows standard deprecation
+policy:
+
+1. Mark `var TLSProfiles` as deprecated with a comment pointing to the accessor
+2. Allow at least one minor release for downstream consumers to migrate
+3. Remove the deprecated map in a subsequent release
+
+### Upgrade / Downgrade Strategy
+
+#### Upgrade
+
+**No admin action required.** On upgrade from N to N+1:
+
+1. The CRD schema update adds the new status fields (additive, no breaking
+   change).
+2. The new cluster-config-operator version starts the TLS materializer
+   controller, which populates status entries for all versions present in
+   ClusterVersion status.
+3. New operator versions use the accessor to read their version's entry from
+   status.
+4. Old operator versions (not yet rolled out to the new version) continue
+   functioning because they use the static `var TLSProfiles` map (which is
+   preserved as a backward-compatible alias).
+
+#### Downgrade
+
+On downgrade from N+1 to N:
+
+1. The old cluster-config-operator does not have the TLS materializer
+   controller, so it stops updating the TLS status fields. The status entries
+   become stale but are ignored because old operators do not read them.
+2. The stale status fields remain in etcd but are pruned on read for v1 APIs
+   (unknown fields in status are pruned).
+3. Old operators resume using the static `var TLSProfiles` map and function
+   exactly as they did before the upgrade.
+4. No manual cleanup is required.
+
+### Version Skew Strategy
+
+See the general version skew strategy in
+[versioned-config-access.md](versioned-config-access.md). For TLS specifically:
+
+- During an upgrade, operators at version N use the N cipher list; operators at
+  version N+1 use the N+1 cipher list. A client connecting to an operator at
+  version N will negotiate using N's ciphers; a client connecting to an
+  operator at N+1 will negotiate using N+1's ciphers.
+- This is safe because TLS cipher negotiation is inherently
+  version-independent: the client and server negotiate the best mutually
+  supported cipher regardless of what the other party's "default" list contains.
+
+### Operational Aspects of API Extensions
+
+This enhancement adds version-indexed entries to the status subresource of the
+APIServer CRD. It does not add webhooks, finalizers, or aggregated API servers.
+
+**Impact on existing SLIs:**
+
+- APIServer object size increases by ~1KB during upgrades (two version entries).
+  This has negligible impact on API throughput and watch performance.
+- No impact on API latency. The status fields are populated asynchronously by
+  the materializer, not in the API server's request path.
+
+**Monitoring:**
+
+- The existing `cluster-config-operator` health metrics cover the materializer
+  controller.
+- The accessor emits events on initial config observation and config changes.
+
+**Escalation path:** Control Plane / Cert team (kube-apiserver component).
+
+#### Failure Modes
+
+- **Materializer failure**: If the cluster-config-operator TLS materializer
+  controller fails, status entries are not written or updated. Operators using
+  the accessor block at startup (if no entry exists yet) or continue using
+  the last-observed configuration (if an entry was previously written). The
+  `cluster-config-operator` already has established health monitoring and
+  alerting. Detection: `oc get co cluster-config-operator` shows Degraded.
+- **Stale status entries**: If ClusterVersion changes but the materializer has
+  not yet updated status, operators at the new version may experience a startup
+  delay. This is bounded by the materializer's reconciliation interval
+  (seconds, not minutes). Detection: operator logs show
+  `missing desired version` errors.
+
+#### Support Procedures
+
+**Symptom: Operator fails to start with "timed out waiting for TLS config"**
+
+Detection: Operator logs show `timed out waiting for VersionedConfig detection`
+or similar messages. The operator pod is in CrashLoopBackOff.
+
+Root cause: The TLS materializer has not written a status entry for the
+operator's version. This can happen if cluster-config-operator is unhealthy or
+if there is an unexpected version string mismatch.
+
+Remediation:
+1. Check `oc get co cluster-config-operator` for degraded conditions.
+2. Check `oc get apiserver cluster -o yaml` to see if version-indexed TLS
+   status entries exist.
+3. Compare the operator's reported desired version (from operator logs) with
+   the versions in CRD status.
+4. If cluster-config-operator is healthy, check its logs for TLS materializer
+   errors.
+
+**Symptom: Operator using wrong TLS ciphers after upgrade**
+
+Detection: The operator's TLS handshake fails with clients that expect the new
+version's cipher list, or security scans report unexpected ciphers.
+
+Root cause: The operator is reading a stale status entry (old version) instead
+of the new version's entry.
+
+Remediation:
+1. Check `oc get apiserver cluster -o jsonpath='{.status.tlsProfiles}'` to see
+   which version entries exist.
+2. Verify the operator's reported version matches an entry in status.
+3. If the operator is at the new version but reading the old entry, this
+   indicates a bug in version matching. Restart the operator and collect logs.
+
+## Implementation History
+
+N/A. This enhancement is newly proposed.
+
+## Alternatives
+
+### Keep Static Maps for TLS
+
+The status quo (static `var TLSProfiles` map) works when cipher lists change
+infrequently and do not need to differ by version. However, the addition of
+post-quantum ciphers (X25519MLKEM768) and the ongoing evolution of Mozilla's
+recommendations mean that cipher lists will change more frequently. Adding
+version-indexed entries to a static Go map would require consumers to pass
+their version and perform the lookup themselves, duplicating logic across
+operators. The accessor pattern centralizes this logic and adds startup sync
+that the static map approach lacks entirely.
+
+## Infrastructure Needed
+
+No new subprojects, repositories, or testing infrastructure needed. All changes
+are to existing repositories:
+
+- **openshift/api**: Version-indexed TLS declaration table, `APIServerStatus`
+  type additions.
+- **openshift/library-go**: `TLSProfileAccess` wrapper type.
+- **openshift/cluster-config-operator**: TLS materializer controller.

--- a/enhancements/config/versioned-config-access.md
+++ b/enhancements/config/versioned-config-access.md
@@ -1,0 +1,557 @@
+---
+title: versioned-config-access
+authors:
+  - "@sanchezl"
+reviewers:
+  - "@deads2k, for library-go operator patterns, please review the generic accessor interface design"
+  - "@everettraven, for openshift/api conventions and type design"
+approvers:
+  - "@deads2k"
+api-approvers:
+  - "None"
+creation-date: 2026-08-04
+last-updated: 2026-08-04
+tracking-link:
+  - https://redhat.atlassian.net/browse/OCPSTRAT-2271
+see-also:
+  - "/enhancements/config/featuregate-versioned-config.md"
+  - "/enhancements/config/tls-versioned-config.md"
+  - "/enhancements/config/pki-versioned-config.md"
+---
+
+# Versioned Config Access
+
+## Summary
+
+OpenShift has multiple configuration domains where the platform must resolve
+intent-based administrator choices into concrete values that differ by cluster
+version: feature gates, TLS security profiles, and PKI certificate profiles.
+Each domain needs the same three capabilities: version-indexed declaration,
+CRD-status materialization, and a library-go accessor with startup
+synchronization and change notification. Today only feature gates implement
+the full pattern; TLS profiles use a static Go map with no version indexing,
+and PKI profiles have a CRD but no status subresource or accessor.
+
+This enhancement extracts the common three-layer pattern into a generic
+`VersionedConfigAccess[T]` interface in library-go. The result is shared
+infrastructure (~150 lines) that gives every version-sensitive configuration
+domain consistent startup synchronization, version-match resolution, and
+change detection.
+
+## Motivation
+
+Three configuration domains in OpenShift share the same fundamental problem:
+an administrator selects an intent-based profile (a FeatureSet, a TLS profile
+type, or a PKI management mode), and the platform must resolve that intent into
+concrete configuration values appropriate for the cluster's current version.
+Each domain needs the same three capabilities:
+
+1. **Declare** version-indexed defaults compiled into openshift/api
+2. **Materialize** resolved configuration into CRD status so operators can observe it
+3. **Access** the resolved configuration in library-go with startup sync and change notification
+
+Feature gates already implement all three layers. The `FeatureGateAccess`
+interface in library-go provides startup synchronization via
+`InitialFeatureGatesObserved()`, current-value retrieval via
+`CurrentFeatureGates()`, and change handling (defaulting to `os.Exit(0)`) via
+`SetChangeHandler`. The FeatureGate CRD status contains version-indexed
+entries (`[]FeatureGateDetails` keyed by `version`), and the
+cluster-config-operator materializes these from the compiled-in declaration
+tables in `features/features.go`.
+
+TLS profiles lack all three layers. The `var TLSProfiles` map in
+`config/v1/types_tlssecurityprofile.go` is a static, unversioned lookup table.
+When cipher suites need to change across OCP versions (for example, adding
+post-quantum groups like X25519MLKEM768), the only option is to modify the
+compiled-in map for all versions simultaneously. There is no CRD status showing
+what "Intermediate" resolves to on a given cluster, no version-indexed table,
+and no accessor in library-go.
+
+PKI profiles are partway there. The `PKI` CRD in `config/v1alpha1/types_pki.go`
+has a spec with management modes (Unmanaged, Default, Custom), but no status
+subresource with version-indexed resolved profiles, no accessor in library-go,
+and operators must implement their own pull-based configuration resolution with
+no startup synchronization guarantees.
+
+Each domain independently reinvents or fails to implement the same three-layer
+pattern. This enhancement unifies the infrastructure so that existing and future
+domains get version resolution, startup sync, and change detection for free.
+
+Beyond consistency, the materialize/access pattern eliminates a coordination
+bottleneck: **operators no longer need to revendor openshift/api to pick up
+changed defaults.** Today, when the static `var TLSProfiles` map changes in
+openshift/api, every operator that vendors openshift/api must be bumped to
+compile in the new values. With this pattern, only cluster-config-operator
+revendors openshift/api (it runs the materializer); all other operators receive
+the updated values at runtime through their informer watch on CRD status. A
+cipher suite change that previously required coordinated bumps across dozens
+of repositories becomes a single PR to openshift/api plus a cluster-config-operator
+revendor.
+
+### User Stories
+
+* As a platform developer adding a new version-sensitive configuration domain,
+  I want to use a standard generic accessor from library-go, so that I get
+  startup synchronization, version-match resolution, and change notification
+  without reimplementing the pattern from scratch.
+
+* As a platform developer maintaining an operator that consumes version-sensitive
+  configuration, I want a consistent interface across all configuration domains,
+  so that I do not need to learn a different startup and change-notification
+  pattern for each domain.
+
+* As an SRE investigating an issue during a version-skewed upgrade, I want both
+  the old and new operator versions to find their respective configuration
+  entries in CRD status, so that operators at different versions do not conflict
+  or use incorrect configuration values during the upgrade window.
+
+### Goals
+
+1. Provide a generic `VersionedConfigAccess[T]` interface in library-go that
+   handles version-match resolution, startup synchronization, and change
+   notification for any type `T`.
+2. Define the three-layer pattern (declare/materialize/access) as a standard
+   recipe that any version-sensitive configuration domain can follow.
+3. Provide a `NewHardcodedConfigAccess[T]` constructor for unit tests and
+   components that do not run in a cluster.
+4. Document sparse version tables with floor-based lookup so that domain
+   implementers understand how the materializer resolves versions.
+
+### Non-Goals
+
+1. Implementing any specific domain mapping (feature gates, TLS, PKI) in this
+   enhancement. Each domain is covered by its own enhancement:
+   - [FeatureGate Versioned Config](featuregate-versioned-config.md)
+   - [TLS Versioned Config](tls-versioned-config.md)
+   - [PKI Versioned Config](pki-versioned-config.md)
+2. Introducing a new shared "ClusterDefaults" CRD. Each domain keeps its own
+   CRD boundary.
+3. Changing any admin-facing API for selecting profiles. This enhancement is
+   about the resolution and delivery mechanism, not the selection API.
+4. Modifying MicroShift. MicroShift does not use `FeatureGateAccess` or
+   library-go operator patterns and is out of scope.
+
+## Proposal
+
+This proposal introduces a three-layer pattern for version-sensitive
+configuration and extracts it into shared library-go infrastructure. The core
+insight is that **profile selection happens at materialization time, not access
+time.** The CRD status contains only the resolved configuration for the
+cluster's chosen profile, indexed by version. The accessor's job is narrow:
+find the entry matching the operator's version, cache it, and notify on changes.
+
+```mermaid
+flowchart LR
+    D["DECLARE\nopenshift/api\nversion-indexed tables\n(version, profile) -> config"]
+    M["MATERIALIZE\ncluster-config-operator\nintent + version -> resolved\nwrites CRD .status per version"]
+    A["ACCESS\nlibrary-go\nversion-match, startup sync\nos.Exit(0) on change"]
+    O(("Operator"))
+    D -- "compiled-in lookup" --> M
+    M -- "informer watch" --> A
+    A -- "CurrentConfig()" --> O
+```
+
+Planned consumers of this framework are documented in separate enhancements:
+
+- **Feature gates** (refactor onto the generic):
+  [FeatureGate Versioned Config](featuregate-versioned-config.md)
+- **TLS profiles** (new version-indexed profiles):
+  [TLS Versioned Config](tls-versioned-config.md)
+- **PKI profiles** (new version-indexed profiles):
+  [PKI Versioned Config](pki-versioned-config.md)
+
+### Workflow Description
+
+**platform developer** is an OpenShift engineer integrating a version-sensitive
+configuration domain.
+
+**cluster-config-operator** is the controller responsible for materializing
+resolved configuration into CRD status.
+
+**consuming operator** is any OpenShift operator that needs version-resolved
+configuration at startup.
+
+#### Adding a New Version-Sensitive Domain
+
+1. The platform developer defines a version-indexed declaration table in
+   openshift/api, mapping `(version, profile)` pairs to resolved configuration
+   values of type `T`.
+2. The platform developer adds a materializer controller (~100 lines) to
+   cluster-config-operator that reads the CRD spec (the admin's intent), looks
+   up the declaration table, and writes resolved entries into CRD status keyed
+   by version.
+3. The platform developer defines a domain-specific wrapper type (e.g.,
+   `TLSProfileAccess`) that instantiates `VersionedConfigAccess[T]` with the
+   appropriate `StatusExtractor[T]` and `EqualityFunc[T]`.
+4. Consuming operators instantiate the wrapper, call `Run(ctx)`, wait on
+   `InitialConfigObserved()`, then call `CurrentConfig()` to get the resolved
+   value. Changes trigger the change handler (default: `os.Exit(0)`).
+
+#### Version Skew During Upgrade
+
+1. A cluster begins upgrading from version N to N+1. The CRD status contains
+   entries for both versions.
+2. An operator still running at version N finds its entry and uses the
+   configuration appropriate for N.
+3. A newly rolled-out operator at version N+1 finds its entry and uses the
+   configuration appropriate for N+1.
+4. Both operators function correctly with their version-appropriate
+   configuration throughout the upgrade window.
+5. After all operators converge on N+1, the N entry is eventually pruned
+   from status.
+
+### API Extensions
+
+This enhancement adds no API extensions. It is purely a library-go
+infrastructure package. Domain-specific CRD status changes are documented in
+the respective domain enhancements
+([TLS](tls-versioned-config.md), [PKI](pki-versioned-config.md)).
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+
+In Hypershift, control plane components run in the management cluster at a
+potentially different version than data plane components in the guest cluster.
+The version-indexed status model handles this naturally:
+
+- **Management cluster operators** read entries matching the hosted control
+  plane version from the management cluster's CRD status.
+- **Guest cluster operators** read entries matching the guest cluster version
+  from the guest cluster's CRD status.
+- Each cluster materializes its own status independently, so version skew
+  between management and guest clusters does not cause conflicts.
+
+The accessor's `desiredVersion` parameter handles this: each operator provides
+its own version, and the accessor finds the matching entry. This is exactly how
+`FeatureGateAccess` works in Hypershift today.
+
+#### Standalone Clusters
+
+Fully applicable. Standalone clusters are the primary deployment model for this
+enhancement.
+
+#### Single-node Deployments or MicroShift
+
+**SNO**: No additional resource consumption beyond a standard cluster. The
+accessor watches existing CRD informers that are already running. No new
+controllers are deployed to the node; the materializer runs in
+cluster-config-operator which is already present.
+
+**MicroShift**: Out of scope. MicroShift does not use `FeatureGateAccess` or
+the library-go operator framework. MicroShift components that need
+version-specific configuration handle it through their own mechanisms.
+
+### Implementation Details/Notes/Constraints
+
+#### Generic Interface
+
+The core of this enhancement is a generic accessor interface in library-go,
+parameterized by the resolved configuration type `T`:
+
+```go
+package versionedconfig
+
+// VersionedConfigAccess provides version-matched, change-notifying access
+// to a configuration value of type T that is stored as version-indexed
+// entries in a CRD status.
+type VersionedConfigAccess[T any] interface {
+    // SetChangeHandler sets the function called when the resolved config
+    // changes. Must be called before Run. The default handler calls
+    // os.Exit(0), which causes the operator to restart and pick up the
+    // new configuration. On the first observation, the change handler is
+    // called with the zero value of T as the previous value.
+    SetChangeHandler(fn func(previous, current T))
+
+    // Run starts watching the CRD informer for changes. Blocks until ctx
+    // is cancelled.
+    Run(ctx context.Context)
+
+    // InitialConfigObserved returns a channel that is closed once the
+    // version-matched configuration has been observed for the first time.
+    InitialConfigObserved() <-chan struct{}
+
+    // AreInitialConfigObserved returns true if the initial config has been
+    // observed.
+    AreInitialConfigObserved() bool
+
+    // CurrentConfig returns the current version-matched configuration.
+    // Returns an error if the config has not yet been observed.
+    CurrentConfig() (T, error)
+}
+```
+
+Supporting types:
+
+```go
+// VersionedEntry pairs a version string with a configuration value.
+type VersionedEntry[T any] struct {
+    Version string
+    Config  T
+}
+
+// StatusExtractor extracts version-indexed entries from a CRD object.
+// Each domain provides its own extractor that knows how to read its
+// CRD status shape.
+type StatusExtractor[T any] func(obj runtime.Object) ([]VersionedEntry[T], error)
+
+// EqualityFunc compares two configuration values for equality.
+// Used to determine whether a change handler should fire.
+type EqualityFunc[T any] func(a, b T) bool
+```
+
+Constructor:
+
+```go
+// NewVersionedConfigAccess creates a new accessor. Parameters:
+//   - desiredVersion: the version this operator wants (from ClusterOperator status)
+//   - missingVersionMarker: stub version; if equal to desiredVersion, the
+//     accessor derives the best version from ClusterVersion status
+//   - clusterVersionInformer: used to derive version when desiredVersion equals
+//     missingVersionMarker
+//   - configInformer: the informer for the CRD containing version-indexed status
+//   - resourceName: the name of the CRD singleton (typically "cluster")
+//   - extract: domain-specific function to read version-indexed entries from status
+//   - equal: domain-specific equality comparison
+//   - recorder: event recorder for observability
+func NewVersionedConfigAccess[T any](
+    desiredVersion, missingVersionMarker string,
+    clusterVersionInformer, configInformer cache.SharedIndexInformer,
+    resourceName string,
+    extract StatusExtractor[T],
+    equal EqualityFunc[T],
+    recorder events.Recorder,
+) VersionedConfigAccess[T]
+
+// NewHardcodedConfigAccess returns a VersionedConfigAccess that always
+// returns the given config value. Useful for unit tests and components
+// that do not run in a cluster (e.g., the installer).
+func NewHardcodedConfigAccess[T any](config T) VersionedConfigAccess[T]
+```
+
+#### Why T Is Data, Not a Query Interface
+
+`T` is a plain data type, not a query interface. Each domain adds its own query
+semantics on top. For feature gates, the `FeatureGate` interface provides
+methods like `Enabled(name)` with panic-on-unknown semantics. For PKI, a
+`ResolveCertificateConfig` chain resolves category overrides. For TLS,
+consumers apply OpenSSL-to-IANA cipher name conversion after reading the
+resolved profile data.
+
+This separation keeps the generic accessor simple (it only needs to compare and
+cache `T` values) while allowing each domain to layer rich query semantics on
+top without polluting the shared interface.
+
+#### Version Resolution Details
+
+The accessor implements the same version-matching logic currently in
+`featuresFromFeatureGate`: iterate over status entries, find the one whose
+`Version` matches the operator's `desiredVersion`, return it. If no exact match
+exists, return an error (the operator will retry; the materializer has not yet
+written the entry for this version).
+
+When `desiredVersion == missingVersionMarker` (a common case during initial
+operator startup before the operator knows its version), the accessor derives
+the version from `ClusterVersion.status.desired.version` or the most recent
+history entry, exactly as the current `FeatureGateAccess` implementation does
+in `syncHandler`.
+
+#### Sparse Version Tables and Floor-Based Lookup
+
+Not every version needs an entry in the declaration table. The materializer
+uses floor-based resolution: for a requested version `V`, it finds the highest
+`MinVersion` entry that is less than or equal to `V`. This means that if a
+domain's configuration changes in 4.22, only a `MinVersion: "4.22"` entry is
+needed; all versions from 4.18 through 4.21 automatically resolve to the 4.18
+entry.
+
+This is a property of the **materializer**, not the accessor. The accessor
+always does exact version matching on the status entries. The materializer is
+responsible for writing an entry for every version that the cluster knows about,
+even if multiple versions resolve to the same configuration.
+
+### Risks and Mitigations
+
+**Risk: Go generics requirement increases minimum toolchain version.**
+Mitigation: library-go already requires Go 1.22+, which supports generics. No
+additional toolchain version bump is needed.
+
+**Risk: The generic abstraction is insufficiently flexible for future domains.**
+Mitigation: The interface is intentionally minimal (five methods). Domains that
+need richer semantics add them in their wrapper types, not in the generic.
+Feature gates, TLS, and PKI all fit this model cleanly, providing confidence
+that the abstraction level is correct.
+
+**Risk: Adoption friction if the pattern is perceived as over-engineered.**
+Mitigation: The FeatureGate refactor (see
+[featuregate-versioned-config.md](featuregate-versioned-config.md)) validates
+the generic in production using the most battle-tested domain. Demonstrating
+the pattern with a zero-behavioral-change refactor reduces skepticism.
+
+### Drawbacks
+
+The primary argument against this enhancement is that the three domains are
+dissimilar enough that a shared generic adds complexity without proportional
+benefit. Feature gates are a list of names, TLS profiles are cipher specs, and
+PKI profiles are key algorithm configs. The counter-argument is that the
+**infrastructure** (version matching, startup sync, change detection) is
+identical across all three; only the payload type `T` differs. The ~150 lines
+of shared generic code replace ~300 lines of domain-specific implementation
+per domain, and eliminates the risk of each domain making subtly different
+choices about startup synchronization and change handling.
+
+## Design Details
+
+### Open Questions
+
+1. What is the retention policy for old version entries in CRD status? The
+   materializer should prune entries for versions no longer present in
+   ClusterVersion status, but the exact cleanup timing needs definition.
+
+### Test Plan
+
+#### Unit Tests
+
+- **Version matching**: Test exact match, missing version error, multiple
+  entries with correct selection.
+- **Missing version marker fallback**: Test that when `desiredVersion` equals
+  `missingVersionMarker`, the accessor correctly derives the version from
+  ClusterVersion status.
+- **Change detection**: Test that the change handler fires when the
+  configuration value changes and does not fire when it remains equal.
+- **InitialConfigObserved channel**: Test that the channel is closed after first
+  successful observation and that `CurrentConfig()` returns an error before
+  observation.
+- **NewHardcodedConfigAccess**: Test that it immediately returns the given
+  value, that `InitialConfigObserved()` is already closed, and that
+  `CurrentConfig()` never errors.
+
+#### Integration Tests
+
+No integration tests are needed for the generic accessor itself, since it is
+purely a library. Domain-specific integration tests are covered by the
+respective domain enhancements.
+
+#### End-to-End Tests
+
+N/A for the generic accessor. End-to-end validation occurs through the domain
+enhancements.
+
+### Graduation Criteria
+
+The generic accessor is internal library-go infrastructure with no API surface.
+It ships as GA from the start, validated by its own unit tests and by the
+FeatureGate refactor (see
+[featuregate-versioned-config.md](featuregate-versioned-config.md)).
+
+#### Dev Preview -> Tech Preview
+
+N/A. The generic accessor is not a user-facing feature.
+
+#### Tech Preview -> GA
+
+N/A. The generic accessor ships as GA immediately.
+
+#### Removing a deprecated feature
+
+N/A. No features are deprecated by this enhancement.
+
+### Upgrade / Downgrade Strategy
+
+N/A. The generic accessor is a library-go package with no runtime state. It
+does not affect upgrade or downgrade behavior. Domain-specific upgrade and
+downgrade considerations are documented in their respective enhancements.
+
+### Version Skew Strategy
+
+The version-indexed status model is designed specifically for version skew
+during upgrades. The key invariants are:
+
+1. **Status contains entries for all active versions.** The materializer writes
+   an entry for every version present in `ClusterVersion.status.history` and
+   `ClusterVersion.status.desired.version`. During an upgrade, this includes
+   both the old and new versions.
+
+2. **Operators match on their own version.** Each operator provides its
+   `desiredVersion` to the accessor, which finds the matching entry. An
+   operator at version 4.21 reads the 4.21 entry; an operator at version 4.22
+   reads the 4.22 entry. They never interfere with each other.
+
+3. **The materializer runs ahead of operators.** Because cluster-config-operator
+   is updated early in the upgrade process (before most other operators), the
+   status entries for the new version are available before operators at the new
+   version start looking for them.
+
+4. **Missing version entries cause controlled startup delays, not crashes.** If
+   an operator starts before its version entry is available in status, the
+   accessor's `InitialConfigObserved` channel blocks. The operator's standard
+   timeout (typically 1 minute) converts this into a clear error. The
+   materializer will eventually write the entry, and the operator will proceed.
+
+### Operational Aspects of API Extensions
+
+N/A. This enhancement adds no API extensions. It is purely a library-go
+package. Domain-specific operational aspects are documented in their respective
+enhancements.
+
+#### Failure Modes
+
+N/A for the generic library. See domain-specific enhancements for failure modes
+related to materializers and CRD status.
+
+#### Support Procedures
+
+N/A for the generic library. See domain-specific enhancements for support
+procedures related to specific configuration domains.
+
+## Implementation History
+
+N/A. This enhancement is newly proposed.
+
+## Alternatives
+
+### Shared "ClusterDefaults" CRD
+
+Instead of adding status to each domain's existing CRD, a single
+`ClusterDefaults` CRD could hold all version-indexed configuration. This was
+rejected for three reasons:
+
+1. **Different RBAC audiences.** FeatureGates are cluster infrastructure;
+   TLS profiles involve the security team; PKI profiles are managed by
+   certificate administrators. A single CRD conflates these access control
+   boundaries.
+2. **Different lifecycle requirements.** FeatureGate status is managed by
+   cluster-config-operator. TLS status logically belongs to the APIServer
+   object. PKI is behind a feature gate. Their CRDs evolve on different
+   timelines.
+3. **Watch amplification.** Operators that only need TLS configuration would
+   receive spurious watch events from FeatureGate and PKI changes. Using
+   domain-specific CRDs lets operators watch only what they need.
+
+### Name: "Versioned Config Access" vs Alternatives
+
+Several alternative names were considered:
+
+- **"Versioned Configuration Profiles"** emphasizes the declaration layer but
+  obscures the accessor pattern that operators interact with.
+- **"Version-Indexed Cluster Defaults"** emphasizes the materialization layer
+  and is too implementation-focused.
+- **"Cluster Configuration Resolution"** is accurate but generic; it does not
+  convey the version-indexing or accessor aspects.
+- **"Profile-Based Configuration Resolution"** conflates "profile" (the
+  admin-facing concept) with the infrastructure pattern.
+
+"Versioned Config Access" was chosen because it names the artifact that
+operators interact with daily: the `VersionedConfigAccess[T]` interface in
+library-go. The full pattern (declare/materialize/access) is important for
+implementers but secondary for consumers. Platform developers will `import
+versionedconfig` and call `NewVersionedConfigAccess`; the name should match
+that import path and type name.
+
+## Infrastructure Needed
+
+No new subprojects, repositories, or testing infrastructure needed. All changes
+are to the existing repository:
+
+- **openshift/library-go**: New `pkg/operator/versionedconfig/` package for the
+  generic accessor.

--- a/enhancements/config/versioned-config-access.md
+++ b/enhancements/config/versioned-config-access.md
@@ -3,10 +3,10 @@ title: versioned-config-access
 authors:
   - "@sanchezl"
 reviewers:
-  - "@deads2k, for library-go operator patterns, please review the generic accessor interface design"
+  - "@JoelSpeed, for openshift/api conventions, please review the generic accessor interface design"
   - "@everettraven, for openshift/api conventions and type design"
 approvers:
-  - "@deads2k"
+  - "@JoelSpeed"
 api-approvers:
   - "None"
 creation-date: 2026-08-04


### PR DESCRIPTION
## Summary

Four related enhancement proposals for a generalized `VersionedConfigAccess[T]` pattern that unifies how OpenShift handles version-evolving configuration defaults.

**Note:** These are bundled in a single PR for early feedback on the overall approach. They would normally be separate PRs, one per enhancement.

### Enhancement Documents

| EP | Scope | API Changes |
|---|---|---|
| [versioned-config-access.md](enhancements/config/versioned-config-access.md) | Generic `VersionedConfigAccess[T]` interface in library-go | None |
| [featuregate-versioned-config.md](enhancements/config/featuregate-versioned-config.md) | Refactor `FeatureGateAccess` onto the generic as validation | None |
| [tls-versioned-config.md](enhancements/config/tls-versioned-config.md) | Version-indexed TLS profiles, `APIServerStatus` additions | `config/v1` |
| [pki-versioned-config.md](enhancements/config/pki-versioned-config.md) | Version-indexed PKI profiles, `PKIStatus` additions | `config/v1alpha1` |

### Problem

Three configuration domains share the same fundamental problem: an admin selects an intent-based profile (FeatureSet, TLS profile type, PKI management mode), and the platform must resolve that intent into concrete values appropriate for the cluster's version. Today:

- **Feature gates** have the full pattern (version-indexed status, library-go accessor with startup sync)
- **TLS profiles** use a static `var TLSProfiles` map with no version indexing, no status, and no accessor
- **PKI profiles** have a CRD but no status subresource, no version indexing, and a pull-based provider with no startup sync

Each domain independently reinvents (or fails to implement) the same three-layer pattern: declare, materialize, access.

### Key Benefits

- **Shared infrastructure** (~150 lines) for version resolution, startup sync, and change detection
- **No revendoring required** for profile changes: only cluster-config-operator revendors openshift/api; all other operators receive updated values at runtime via informer watch on CRD status
- **Observability**: admins can `oc get apiserver cluster -o yaml` and see exactly what "Intermediate" TLS resolves to for their version
- **Upgrade safety**: during rolling upgrades, status has entries for both old and new versions; each operator reads its own

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Added enhancement proposals for versioned configuration across feature gates, TLS profiles, and PKI profiles.
* Defined a shared, version-aware approach for resolving and reporting configuration.
* Documented backward compatibility, startup synchronization, version upgrades and downgrades, change notifications, failure handling, testing, rollout, and operations.
* Proposed versioned TLS and PKI status reporting, including profile validity and refresh settings.
* No immediate configuration, infrastructure, or custom resource changes are introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->