### PR TITLE
SPLAT-2874: enhancement: vSphere per-component credential overrides in CCO

### DIFF
--- a/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
+++ b/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
@@ -1,0 +1,281 @@
+---
+title: vsphere-per-component-credential-overrides
+authors:
+  - "@rvanderp3"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+api-approvers:
+  - TBD
+creation-date: 2026-08-17
+last-updated: 2026-08-17
+tracking-link:
+  - https://issues.redhat.com/browse/SPLAT-2889
+  - https://issues.redhat.com/browse/SPLAT-2724
+see-also:
+  - "/enhancements/cloud-integration/cloud-credentials.md"
+replaces:
+  - []
+superseded-by:
+  - []
+---
+
+# vSphere Per-Component Credential Overrides in CCO
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
+
+## Summary
+
+This enhancement extends the Cloud Credential Operator (CCO) vSphere actuator to support per-component credential overrides stored as annotated secrets in the `openshift-config` namespace. Today, vSphere clusters use a single shared credential (`kube-system/vsphere-creds`) that is copied identically to every component (Machine API, CSI, Cloud Controller Manager). This enhancement allows cluster administrators to provide distinct, lower-privilege credentials for each component by creating override secrets annotated with the target CredentialsRequest's `spec.secretRef`.
+
+This is a reduced-scope first phase of the broader vSphere multi-account credential management initiative (SPLAT-2724). It delivers the CCO-side credential resolution mechanism without requiring installer changes, enabling day-2 credential separation for existing and new clusters.
+
+## Motivation
+
+vSphere clusters today operate with a single set of credentials shared across all OpenShift components that interact with the vCenter API. This means Machine API, the CSI driver, and Cloud Controller Manager all authenticate with the same username and password. This shared-credential model creates several operational and security challenges:
+
+- **Blast radius**: A compromised credential exposes all vSphere operations, not just the affected component.
+- **Audit opacity**: vCenter audit logs cannot distinguish which OpenShift component performed an action when all components use the same identity.
+- **Rotation risk**: Rotating the shared credential requires coordinated updates across all components simultaneously, increasing the risk of partial failures.
+
+### User Stories
+
+**Story 1 - Least-privilege credential separation**: As a cluster administrator, I want to assign distinct vSphere credentials to each OpenShift component (Machine API, CSI driver, Cloud Controller Manager) so that each component operates with only the permissions it requires, reducing the blast radius of a credential compromise.
+
+**Story 2 - Credential rotation without full cluster impact**: As a cluster administrator, I want to rotate a single component's vSphere credential without affecting other components, so that routine credential rotation is lower-risk and can be performed incrementally.
+
+**Story 3 - Audit and compliance separation**: As a security engineer, I want to track vSphere API activity per-component using distinct service accounts, so that audit logs clearly attribute actions to the responsible OpenShift component.
+
+### Goals
+
+- Allow cluster administrators to provide per-component vSphere credentials via secrets in `openshift-config`, mapped to components via annotations
+- Maintain full backward compatibility — clusters without override secrets continue to use the shared `kube-system/vsphere-creds` credential with no behavioral change
+- Require no installer changes — override secrets can be created manually or via automation at any point in the cluster lifecycle (day 0 via manifests, or day 2)
+- Trigger automatic reconciliation when override secrets are created, updated, or deleted
+
+### Non-Goals
+
+- Installer-native `install-config.yaml` support for per-component credentials (planned for a subsequent phase under SPLAT-2769/SPLAT-2772)
+- Automatic credential provisioning or rotation — this phase relies on administrator-managed secrets
+- Extending this mechanism to non-vSphere platforms (though the annotation-based pattern is designed to be portable)
+- Changes to the vSphere cloud provider configuration (`cloud-provider-config` ConfigMap)
+
+## Proposal
+
+### Workflow Description
+
+The administrator creates a Secret in the `openshift-config` namespace with two annotations identifying the target component's credential:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mapi-vsphere-creds          # any name chosen by the admin
+  namespace: openshift-config
+  annotations:
+    cloudcredential.openshift.io/target-secret-namespace: openshift-machine-api
+    cloudcredential.openshift.io/target-secret-name: vsphere-cloud-credentials
+data:
+  <vcenter-hostname>.username: <base64-encoded-username>
+  <vcenter-hostname>.password: <base64-encoded-password>
+```
+
+The CCO controller detects the new secret in `openshift-config` (via an extended watch) and requeues all CredentialsRequests. When processing the Machine API CredentialsRequest, the vSphere actuator's `GetCredentialsRootSecret()`:
+
+1. Lists secrets in `openshift-config`
+2. Finds the secret whose `target-secret-namespace` and `target-secret-name` annotations match the CR's `spec.secretRef.Namespace` / `spec.secretRef.Name`
+3. Returns the override secret's data instead of `kube-system/vsphere-creds`
+
+The actuator syncs the override credential data to the component's target secret. Components without an override secret continue to receive the shared root credential.
+
+**Fallback behavior**: If the override secret is deleted, the actuator falls back to `kube-system/vsphere-creds` on the next reconciliation cycle.
+
+### API Extensions
+
+No CRD or API changes are required. The feature uses two new well-known annotations on Kubernetes Secrets:
+
+| Annotation Key | Value | Description |
+|---|---|---|
+| `cloudcredential.openshift.io/target-secret-namespace` | e.g. `openshift-machine-api` | The namespace of the CredentialsRequest's spec.secretRef this override targets |
+| `cloudcredential.openshift.io/target-secret-name` | e.g. `vsphere-cloud-credentials` | The name of the CredentialsRequest's spec.secretRef this override targets |
+
+### Topology Considerations
+
+#### Standalone Clusters
+
+Fully supported. The override mechanism operates entirely within the CCO reconciliation loop, which runs on standalone clusters without modification.
+
+#### Hypershift / Hosted Clusters
+
+Not in scope for this phase. Hypershift uses a different credential management model where the management cluster holds credentials for hosted clusters. The annotation-based pattern could be adapted for Hypershift in a future phase, but the credential topology is sufficiently different to warrant separate design work.
+
+#### Single-node Deployments (SNO)
+
+Supported — the same mechanism applies. The CCO runs on SNO clusters identically to multi-node clusters, and the override secret resolution is purely a control-plane operation with no node-count dependency.
+
+### Implementation Details
+
+**Changed Components:**
+
+- `pkg/operator/constants/constants.go` — Add `VSphereCredOverrideNamespace` (`"openshift-config"`) and annotation key constants (`VSphereCredOverrideTargetNamespaceAnnotation`, `VSphereCredOverrideTargetNameAnnotation`)
+- `pkg/vsphere/actuator/actuator.go` — Modify `GetCredentialsRootSecret()` to list secrets in `openshift-config`, match by annotation values against `cr.Spec.SecretRef`, and fall back to `kube-system/vsphere-creds`
+- `pkg/operator/credentialsrequest/credentialsrequest_controller.go` — Add watch on `openshift-config` namespace; update `IsVSphereOverrideSecret()` predicate to check annotation keys
+- `pkg/vsphere/actuator/actuator_test.go` — New test file with table-driven tests covering override matching, fallback, wrong annotations, multi-component scenarios, and drift detection
+
+**Resolution Algorithm (pseudocode):**
+
+```
+func GetCredentialsRootSecret(ctx, cr):
+    1. List all Secrets in "openshift-config" namespace
+    2. For each secret:
+       - Read annotation "cloudcredential.openshift.io/target-secret-namespace"
+       - Read annotation "cloudcredential.openshift.io/target-secret-name"
+       - If both match cr.Spec.SecretRef.Namespace and cr.Spec.SecretRef.Name:
+           -> return this override secret
+    3. If no match found:
+       -> return kube-system/vsphere-creds (existing behavior)
+```
+
+**Watch Configuration:**
+
+The CredentialsRequest controller adds a new source to its watch list:
+
+```go
+source.Kind(&corev1.Secret{},
+    handler.EnqueueRequestsFromMapFunc(
+        credentialsRequestMapFunc(mgr.GetClient(), constants.VSphereCredOverrideNamespace),
+    ),
+    predicate.NewPredicateFuncs(IsVSphereOverrideSecret),
+)
+```
+
+The `IsVSphereOverrideSecret` predicate returns `true` only for secrets in `openshift-config` that carry at least one of the two `cloudcredential.openshift.io/target-secret-*` annotations, minimizing unnecessary reconciliation triggers.
+
+### Risks and Mitigations
+
+**Risk: Administrator provides override secret with incorrect data format.**
+Mitigation: Same failure mode as providing bad credentials in `kube-system/vsphere-creds` today — component health checks surface authentication failures. The CCO logs a warning when an override secret is resolved, aiding debugging.
+
+**Risk: Multiple override secrets target the same component.**
+Mitigation: First match is used; documentation advises a one-to-one mapping between override secrets and components. A future enhancement could add a validating webhook to enforce uniqueness.
+
+**Risk: Listing all secrets in openshift-config on every reconciliation.**
+Mitigation: The `openshift-config` namespace typically contains fewer than 20 secrets; the list operation is inexpensive. A label selector can narrow the scan if the secret count grows, but this is not expected to be necessary.
+
+**Risk: Race condition between override secret creation and CredentialsRequest reconciliation.**
+Mitigation: The watch on `openshift-config` triggers requeue of all CredentialsRequests when an override secret is created or modified, ensuring convergence within one reconciliation cycle.
+
+### Drawbacks
+
+- Adds a new credential resolution path alongside the existing root secret, increasing the debugging surface area for credential-related issues
+- Annotation-based mapping is not validated at admission time — misconfigurations are only detected at reconciliation time and surfaced through CCO logs
+- The feature introduces a dependency on the `openshift-config` namespace for credential storage, which is a shared namespace used by other platform components
+
+## Alternatives
+
+### Naming Convention Approach
+
+Override secrets could use a deterministic naming convention (e.g. `vsphere-creds-machine-api`) derived from the CredentialsRequest's target namespace. This was the initial implementation approach but was replaced because annotations are self-documenting, decouple secret naming from mapping, and reuse `spec.secretRef` as a stable identifier that is less likely to change across releases.
+
+### Installer-Native Configuration
+
+Per-component credentials configured directly in `install-config.yaml` — planned for a subsequent phase (SPLAT-2769/SPLAT-2772) and would layer on top of this CCO-side mechanism. Deferring installer integration reduces the scope of this phase and allows the CCO mechanism to be validated independently.
+
+### Single Multi-Key Secret
+
+A single secret with multiple keys (one set per component) was rejected because separate secrets provide better RBAC granularity, independent lifecycle management, and clearer audit trails. With separate secrets, an administrator can grant access to rotate one component's credentials without exposing others.
+
+### CredentialsRequest Field Extension
+
+Adding a field to `CredentialsRequest.spec` to reference an override secret was considered but rejected because CredentialsRequests are owned by the components themselves, and modifying them would require changes to each component's codebase. The annotation-based approach keeps the override mechanism entirely within the CCO and `openshift-config` namespace.
+
+## Open Questions
+
+1. Should the CCO surface per-component override status via conditions on the CredentialsRequest CR? This would make it visible via `oc get credentialsrequest` whether a component is using an override or the shared root credential.
+2. Should a validating webhook prevent multiple override secrets targeting the same component? This would catch misconfiguration at creation time rather than reconciliation time.
+3. How should this interact with `credentialsMode: Manual`? In Manual mode, the CCO does not manage credentials — should override secrets still be honored, or should they be ignored?
+
+## Test Plan
+
+### Unit Tests
+
+- Override secret with matching annotations returns override credential data instead of root credential
+- No override secret present returns root `kube-system/vsphere-creds` (backward compatibility)
+- Override secret with wrong or missing annotations is ignored, falls back to root credential
+- Multiple override secrets targeting different components result in each component getting its correct override
+- `needsUpdate()` correctly detects drift between the target secret and the resolved source secret (override or root)
+- Override secret deleted triggers fallback to root credential on next reconciliation
+- `IsVSphereOverrideSecret` predicate correctly identifies secrets with override annotations and rejects secrets without them
+
+### Integration / E2E Tests
+
+- Deploy a vSphere cluster with default shared credentials
+- Create an override secret in `openshift-config` for one component (e.g. Machine API)
+- Verify the component's target secret is updated with the override credential data
+- Verify other components still use the root credential
+- Update the override secret with new credential data and verify the target secret is re-synced
+- Delete the override secret and verify the component falls back to the root credential
+- Create override secrets for all three components and verify each receives its distinct credential
+
+## Graduation Criteria
+
+### Dev Preview -> Tech Preview
+
+- Unit tests covering all override resolution paths (match, no-match, fallback, multi-component)
+- Manual testing on a vSphere cluster with per-component overrides
+- Documentation of the annotation-based override mechanism in the CCO repository
+
+### Tech Preview -> GA
+
+- E2E test automation for override create/update/delete lifecycle
+- Integration with the installer (SPLAT-2769/SPLAT-2772) for day-0 provisioning of per-component credentials
+- Status conditions on CredentialsRequest indicating override usage
+- Documentation in the official OpenShift credential management guide
+- At least one release cycle of Tech Preview soak time with no regressions
+
+### Removing a deprecated feature
+
+N/A — this is a new feature with no deprecation implications.
+
+## Upgrade / Downgrade Strategy
+
+**Upgrade**: Existing clusters upgrading to a version with this feature will see no behavioral change. The new code path only activates when an override secret with the appropriate annotations exists in `openshift-config`. Clusters without override secrets continue to operate exactly as before.
+
+**Downgrade**: If a cluster with override secrets is downgraded to a version without this feature, the override secrets will be ignored. The CCO will revert to using `kube-system/vsphere-creds` for all components. Administrators should ensure the root credential has sufficient permissions for all components before downgrading. The override secrets in `openshift-config` will remain but be inert — they can be cleaned up manually.
+
+## Version Skew Strategy
+
+The feature is entirely within the CCO — no cross-component version skew concerns exist. Consuming components (Machine API, CSI driver, Cloud Controller Manager) are unaware of the credential source; they read their target secret as before. The CCO is the sole component that implements the override resolution logic, so there is no risk of version skew between producers and consumers of this feature.
+
+## Operational Aspects of API Extensions
+
+**Failure Modes:**
+- If an override secret contains invalid credentials, the affected component will fail to authenticate with vCenter. This is the same failure mode as providing bad credentials in `kube-system/vsphere-creds` today. The component's health checks and ClusterOperator status will reflect the authentication failure.
+- If an override secret's annotations reference a non-existent CredentialsRequest target, the secret is simply never matched and has no effect.
+
+**Monitoring:**
+- No new metrics are introduced in this phase. The CCO's existing reconciliation metrics continue to apply. Future phases may add a metric indicating the number of active override secrets.
+
+**Recovery:**
+- Deleting a problematic override secret triggers re-reconciliation, and the CCO automatically falls back to the root credential. Recovery is self-healing within one reconciliation cycle (typically under 60 seconds).
+
+## Support Procedures
+
+1. **List active overrides**: `oc get secrets -n openshift-config -o json | jq '.items[] | select(.metadata.annotations["cloudcredential.openshift.io/target-secret-namespace"] != null) | {name: .metadata.name, targetNs: .metadata.annotations["cloudcredential.openshift.io/target-secret-namespace"], targetName: .metadata.annotations["cloudcredential.openshift.io/target-secret-name"]}'`
+2. **Verify annotation values** match the target CredentialsRequest's `spec.secretRef` by running `oc get credentialsrequest -A -o json | jq '.items[] | {name: .metadata.name, ns: .spec.secretRef.namespace, secret: .spec.secretRef.name}'`
+3. **Check CCO logs** for override resolution messages: `oc logs -n openshift-cloud-credential-operator deployment/cloud-credential-operator | grep -i override`
+4. **Verify override secret data format** matches the expected vCenter credential structure (keys are `<vcenter-hostname>.username` and `<vcenter-hostname>.password`)
+5. **Force re-reconciliation** by deleting the component's target secret — the CCO will re-create it from the resolved source (override or root)
+
+## Implementation History
+
+- 2026-08-17: Initial enhancement proposal for reduced-scope per-component credential overrides
+- 2026-08-17: Implementation PR — [openshift/cloud-credential-operator#1075](https://github.com/openshift/cloud-credential-operator/pull/1075)
+- Tracking: [SPLAT-2889](https://issues.redhat.com/browse/SPLAT-2889) (under epic [SPLAT-2724](https://issues.redhat.com/browse/SPLAT-2724))

--- a/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
+++ b/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
@@ -3,11 +3,16 @@ title: vsphere-per-component-credential-overrides
 authors:
   - "@rvanderp3"
 reviewers:
-  - TBD
+  - "@jcpowermac"
+  - "@dlom"
+  - "@jstuever"
+  - "@patrickdillon"
 approvers:
-  - TBD
+  - "@dlom"
+  - "@jstuever"
+  - "@patrickdillon"
 api-approvers:
-  - TBD
+  - "none"
 creation-date: 2026-08-17
 last-updated: 2026-08-17
 tracking-link:
@@ -112,15 +117,19 @@ No CRD or API changes are required. The feature uses two new well-known annotati
 
 Fully supported. The override mechanism operates entirely within the CCO reconciliation loop, which runs on standalone clusters without modification.
 
-#### Hypershift / Hosted Clusters
+#### Hypershift / Hosted Control Planes
 
 Not in scope for this phase. Hypershift uses a different credential management model where the management cluster holds credentials for hosted clusters. The annotation-based pattern could be adapted for Hypershift in a future phase, but the credential topology is sufficiently different to warrant separate design work.
 
-#### Single-node Deployments (SNO)
+#### Single-node Deployments or MicroShift
 
 Supported — the same mechanism applies. The CCO runs on SNO clusters identically to multi-node clusters, and the override secret resolution is purely a control-plane operation with no node-count dependency.
 
-### Implementation Details
+#### OpenShift Kubernetes Engine
+
+Not applicable. This enhancement targets the CCO vSphere actuator, which is specific to vSphere platform deployments and does not apply to OKE deployments.
+
+### Implementation Details/Notes/Constraints
 
 **Changed Components:**
 
@@ -178,7 +187,7 @@ Mitigation: The watch on `openshift-config` triggers requeue of all CredentialsR
 - Annotation-based mapping is not validated at admission time — misconfigurations are only detected at reconciliation time and surfaced through CCO logs
 - The feature introduces a dependency on the `openshift-config` namespace for credential storage, which is a shared namespace used by other platform components
 
-## Alternatives
+## Alternatives (Not Implemented)
 
 ### Naming Convention Approach
 

--- a/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
+++ b/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
@@ -40,7 +40,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement adds the cluster-scoped `cloudcredential.openshift.io/v1alpha1` `VSphereCredentialOverride` API for selecting a labeled Secret in `openshift-config` as the source credential for one vSphere `CredentialsRequest` target Secret. Today, vSphere clusters use a single shared credential (`kube-system/vsphere-creds`) for every component. The CRD lets authorized administrators configure distinct, lower-privilege credentials per component without storing credential bytes in the API object. The feature targets OpenShift 5.1.0 and is initially gated by `TechPreviewNoUpgrade`.
+This enhancement adds the cluster-scoped `cloudcredential.openshift.io/v1alpha1` `VSphereComponentScopedCredential` API for selecting the explicitly referenced Secret in `openshift-config` as the source credential for one vSphere `CredentialsRequest` target Secret. Today, vSphere clusters use a single shared credential (`kube-system/vsphere-creds`) for every component. The CRD lets authorized administrators configure distinct, lower-privilege credentials per component without storing credential bytes in the API object. The feature targets OpenShift 5.1.0 and is initially gated by `TechPreviewNoUpgrade`.
 
 This is a reduced-scope first phase of the broader vSphere multi-account credential-management initiative. [SPLAT-2874](https://issues.redhat.com/browse/SPLAT-2874) is the primary tracking item; [SPLAT-2889](https://issues.redhat.com/browse/SPLAT-2889) tracks the CCO implementation, and [SPLAT-2724](https://issues.redhat.com/browse/SPLAT-2724) is the parent initiative.
 
@@ -64,7 +64,7 @@ vSphere clusters today operate with a single set of credentials shared across al
 
 - Provide a cluster-scoped, structured API for mapping one vSphere `CredentialsRequest` target Secret to one source Secret in `openshift-config`.
 - Validate mappings, protect the mapping target from mutation, and make invalid configuration observable through status conditions.
-- Limit CCO source-Secret discovery to explicitly labeled Secrets and give only authorized administrators or delegated service accounts permission to create or update override resources and source Secrets.
+- Limit CCO source-Secret reads to names explicitly referenced by the CR and give only authorized administrators or delegated service accounts permission to create or update override resources and source Secrets.
 - Preserve existing root-credential behavior for managed vSphere `CredentialsRequest` targets only when no override CR exists for that target.
 - Reconcile create, update, deletion, and relevance-removal events through the existing `CredentialsRequest` work queue.
 
@@ -80,11 +80,11 @@ vSphere clusters today operate with a single set of credentials shared across al
 
 ### Workflow Description
 
-An authorized administrator creates a `VSphereCredentialOverride` after creating a source Secret in `openshift-config`. The source Secret has the label `cloudcredential.openshift.io/vsphere-override-source: "true"`; it is not selected by annotations. The Secret contains the complete vCenter credential data map required by the target, with non-empty matching `<vcenter-hostname>.username` and `<vcenter-hostname>.password` entries. Credential bytes are never placed in the override CR or in CCO logs.
+An authorized administrator creates a `VSphereComponentScopedCredential` after creating a source Secret in `openshift-config`. `spec.sourceSecretRef.name` is the sole source-selection mechanism; the Secret contains the complete vCenter credential data map required by the target, with non-empty matching `<vcenter-hostname>.username` and `<vcenter-hostname>.password` entries. Credential bytes are never placed in the override CR or in CCO logs.
 
 ```yaml
 apiVersion: cloudcredential.openshift.io/v1alpha1
-kind: VSphereCredentialOverride
+kind: VSphereComponentScopedCredential
 metadata:
   name: openshift-machine-api-vsphere
 spec:
@@ -101,13 +101,13 @@ The CCO reconciler maps an override event to the `CredentialsRequest` whose `spe
 
 1. In `credentialsMode: Manual`, CCO does not resolve, copy, or manage overrides or target Secrets. It reports `ManualMode` on existing overrides and leaves Manual-mode credential management unchanged.
 2. In managed mode, no override CR for the target preserves the existing root path using `kube-system/vsphere-creds`.
-3. Exactly one override causes CCO to read the named, labeled source Secret from `openshift-config`, validate its data, and synchronize that data to the target Secret.
-4. A missing or invalid source Secret, a source Secret without the required label, or multiple overrides for the same target is fail-closed: CCO does not write root credentials or replacement data to that target. It records the applicable status condition and waits for remediation.
+3. Exactly one override causes CCO to read the source Secret named by `sourceSecretRef` from `openshift-config`, validate its data, and synchronize that data to the target Secret.
+4. A missing or invalid source Secret, or multiple overrides for the same target, is fail-closed: CCO does not write root credentials or replacement data to that target. It records the applicable status condition and waits for remediation.
 5. Deleting the only override CR requeues its target. In managed mode that is the no-override case, so the existing root path resumes. Deleting a source Secret while its override remains is not a no-override case and therefore remains fail-closed.
 
 ### API Extensions
 
-This enhancement adds the cluster-scoped `VSphereCredentialOverride` CRD in the `cloudcredential.openshift.io/v1alpha1` API. The resource defines these structured fields:
+This enhancement adds the cluster-scoped `VSphereComponentScopedCredential` CRD in the `cloudcredential.openshift.io/v1alpha1` API. The resource defines these structured fields:
 
 | Field | Meaning |
 |---|---|
@@ -119,7 +119,7 @@ This enhancement adds the cluster-scoped `VSphereCredentialOverride` CRD in the 
 
 OpenAPI validation requires both references and valid Kubernetes names. A validating admission policy backed by the CCO-maintained vSphere target inventory verifies that `targetSecretRef` names an existing vSphere `CredentialsRequest` target and is not the root Secret. CEL validation makes `targetSecretRef` immutable (`self == oldSelf`); retargeting requires delete and recreate. It also rejects self-reference when the target is `openshift-config/<sourceSecretRef.name>`.
 
-The controller validates source data at reconciliation time because Secret contents cannot be represented safely in this CRD. The source must exist, carry the dedicated label, and contain non-empty matching username/password entries for each vCenter key pair required by the vSphere credential format.
+The controller validates source data at reconciliation time because Secret contents cannot be represented safely in this CRD. The source must exist at `openshift-config/<sourceSecretRef.name>` and contain non-empty matching username/password entries for each vCenter key pair required by the vSphere credential format.
 
 `v1alpha1` is Compatibility Level 4 and will be delivered only when the `TechPreviewNoUpgrade` feature set is enabled. The CRD, admission policy, and CCO manifests must carry the corresponding feature-set gating so the API is not installed or used outside that feature set.
 
@@ -151,17 +151,17 @@ There is no OKE-specific implementation. Availability is limited to supported vS
 
 **Changed components:**
 
-- `openshift/api` — add the cluster-scoped `VSphereCredentialOverride` type, CRD generation, compatibility-level markers, feature-gate metadata, and the API-review approval.
+- `openshift/api` — add the cluster-scoped `VSphereComponentScopedCredential` type, CRD generation, compatibility-level markers, feature-gate metadata, and the API-review approval.
 - CCO API manifests — install the CRD and validating admission policy only under `TechPreviewNoUpgrade`.
-- CCO credentials-request controller — maintain the vSphere target inventory, watch overrides and labeled source Secrets, serialize events through the `CredentialsRequest` queue, and update override status.
+- CCO credentials-request controller — maintain the vSphere target inventory, watch overrides and source-Secret events, serialize events through the `CredentialsRequest` queue, and update override status.
 - CCO vSphere actuator — resolve the override only after validating its source and retain the existing root path only when there is no override.
 - CCO RBAC and tests — scope CCO reads and verify both allowed and denied authoring paths.
 
 **Authorization and Secret discovery:**
 
-CCO uses the label selector `cloudcredential.openshift.io/vsphere-override-source=true` for its `openshift-config` Secret list and watch. Its RBAC grants only the required `get`, `list`, and `watch` access to Secrets in that namespace, with no source-Secret write permission; it separately retains only the target-Secret permissions required by existing `CredentialsRequest` reconciliation. Kubernetes RBAC cannot express a label selector, so the selector limits discovery while namespace-scoped least-privilege RBAC limits the API access boundary.
+CCO reads Secret data only by direct lookup of `openshift-config/<sourceSecretRef.name>` and does not enumerate Secrets to discover candidates. Its RBAC grants only the source-Secret read access required for those referenced names, with no source-Secret write permission; it separately retains only the target-Secret permissions required by existing `CredentialsRequest` reconciliation. The precise mechanism for receiving source-Secret change events without broad Secret-data discovery is an implementation prerequisite: it must map source events by the fixed namespace and `sourceSecretRef.name` and be verified during API/CCO implementation.
 
-Only cluster administrators or explicitly delegated service accounts receive RBAC to create, update, or delete `VSphereCredentialOverride` resources and labeled source Secrets in `openshift-config`. Delegation must be implemented with narrowly scoped Roles/RoleBindings and documented as privileged credential-management access. It is not sufficient for a principal to have general application-namespace Secret permissions.
+Only cluster administrators or explicitly delegated service accounts receive RBAC to create, update, or delete `VSphereComponentScopedCredential` resources and referenced source Secrets in `openshift-config`. Delegation must be implemented with narrowly scoped Roles/RoleBindings and documented as privileged credential-management access. It is not sufficient for a principal to have general application-namespace Secret permissions.
 
 **Resolution algorithm:**
 
@@ -180,12 +180,12 @@ reconcile CredentialsRequest:
         do not modify the target Secret
         return
 
-    source = named Secret in openshift-config, selected with the dedicated label
+    source = direct lookup of openshift-config/<sourceSecretRef.name>
     if source is missing:
         set Ready=False, SourceValid=False, reason=SourceSecretMissing
         do not modify the target Secret
         return
-    if source lacks the label or has incomplete, empty, or unmatched data:
+    if source has incomplete, empty, or unmatched data:
         set Ready=False, SourceValid=False, reason=SourceSecretInvalid
         do not modify the target Secret
         return
@@ -196,17 +196,17 @@ reconcile CredentialsRequest:
 
 **Event handling and serialization:**
 
-Override create, update, and delete events map to the `CredentialsRequest` that owns `targetSecretRef`, rather than directly writing a target Secret. Labeled source-Secret events first map to referencing overrides and then to their target `CredentialsRequest`s. This common queue serializes all writes for a target and avoids concurrent override/root updates.
+Override create, update, and delete events map to the `CredentialsRequest` that owns `targetSecretRef`, rather than directly writing a target Secret. Source-Secret events must map by the fixed namespace and `sourceSecretRef.name` to referencing overrides and then to their target `CredentialsRequest`s. The exact targeted source-event watch implementation is a prerequisite to be verified; it must not enumerate Secrets to discover source candidates. This common queue serializes all writes for a target and avoids concurrent override/root updates.
 
-The watches use `predicate.Funcs`, not `predicate.NewPredicateFuncs`. Their update handler accepts an event when either the old or new object is relevant to an override relationship. This preserves reconciliation when a source Secret loses the dedicated label or relevant metadata, and when an override is changed or removed. Delete events are also accepted so deletion of an override performs no-override cleanup and deletion or relevance-removal of a source is reported as fail-closed. The CRD replaces annotation-only target selection; there is no annotation compatibility path that could silently restore root credentials while an override CR still exists.
+The watches use `predicate.Funcs`, not `predicate.NewPredicateFuncs`. Their update handler accepts an event when either the old or new object is relevant to an override relationship. This preserves reconciliation when a referenced source Secret is updated or deleted and when an override is changed or removed. Delete events are also accepted so deletion of an override performs no-override cleanup and deletion of a referenced source is reported as fail-closed. The CRD replaces annotation-only target selection; there is no annotation compatibility path that could silently restore root credentials while an override CR still exists.
 
 **Status and condition reasons:**
 
 | Situation | `Ready` | Reason | Target behavior |
 |---|---|---|---|
-| Valid labeled source synchronized | `True` | `OverrideApplied` | Target contains the override data. |
+| Valid referenced source synchronized | `True` | `OverrideApplied` | Target contains the override data. |
 | Source Secret does not exist | `False` | `SourceSecretMissing` | Target is left unchanged. |
-| Source lacks the label or has invalid data | `False` | `SourceSecretInvalid` | Target is left unchanged. |
+| Source has invalid data | `False` | `SourceSecretInvalid` | Target is left unchanged. |
 | More than one override targets a Secret | `False` | `DuplicateTarget` | Every conflicting target is left unchanged. |
 | `credentialsMode: Manual` | `False` | `ManualMode` | CCO does not manage the override or target. |
 
@@ -215,16 +215,16 @@ The watches use `predicate.Funcs`, not `predicate.NewPredicateFuncs`. Their upda
 ### Risks and Mitigations
 
 **Risk: An unauthorized principal directs credentials to another component.**
-Mitigation: RBAC limits override and labeled-source Secret create/update/delete operations to cluster administrators or explicitly delegated credential-management service accounts. Admission verifies that a target is a real vSphere `CredentialsRequest` target and rejects the root Secret. Authorization tests cover both create and update denials for unauthorized principals.
+Mitigation: RBAC limits override and referenced-source Secret create/update/delete operations to cluster administrators or explicitly delegated credential-management service accounts. Admission verifies that a target is a real vSphere `CredentialsRequest` target and rejects the root Secret. Authorization tests cover both create and update denials for unauthorized principals.
 
 **Risk: CCO reads unrelated credentials from the shared `openshift-config` namespace.**
-Mitigation: CCO uses the dedicated source label for list/watch selectors and has namespace-scoped, read-only source-Secret RBAC. It does not log Secret data.
+Mitigation: CCO reads data only for names explicitly referenced by `sourceSecretRef` and does not enumerate Secrets to discover candidates. The targeted source-event watch mechanism and its least-privilege RBAC must be verified during implementation. CCO does not log Secret data.
 
 **Risk: Invalid source data or duplicate mappings silently escalates an affected component to root credentials.**
-Mitigation: Missing, invalid, unlabeled, and ambiguous overrides fail closed, leave the target unchanged, and expose `SourceSecretMissing`, `SourceSecretInvalid`, or `DuplicateTarget` conditions. Only the absence of an override CR selects the normal root path.
+Mitigation: Missing, invalid, and ambiguous overrides fail closed, leave the target unchanged, and expose `SourceSecretMissing`, `SourceSecretInvalid`, or `DuplicateTarget` conditions. Only the absence of an override CR selects the normal root path.
 
 **Risk: A source or override update is missed during removal.**
-Mitigation: `predicate.Funcs` evaluates old and new objects, and all events map through the serialized `CredentialsRequest` queue. Tests cover relevance removal followed by deletion.
+Mitigation: `predicate.Funcs` evaluates old and new objects, and all events map through the serialized `CredentialsRequest` queue. Tests cover `sourceSecretRef` changes and source-Secret deletion.
 
 **Risk: Tech Preview APIs are used during a minor update.**
 Mitigation: CRD, policy, and controller behavior are gated by `TechPreviewNoUpgrade`; the documented support posture prohibits minor upgrades while it is enabled.
@@ -239,7 +239,7 @@ Mitigation: CRD, policy, and controller behavior are gated by `TechPreviewNoUpgr
 
 ### Annotation-Based Secret Mapping
 
-Selecting a target through annotations on arbitrary Secrets was rejected. It lacks a structured API, makes admission validation and immutability difficult, permits ambiguous matching, and makes relevance-removal handling error-prone. `VSphereCredentialOverride` provides an explicit, observable mapping instead.
+Selecting a target through annotations on arbitrary Secrets was rejected. It lacks a structured API, makes admission validation and immutability difficult, permits ambiguous matching, and makes relevance-removal handling error-prone. `VSphereComponentScopedCredential` provides an explicit, observable mapping instead.
 
 ### Installer-Native Configuration
 
@@ -263,20 +263,20 @@ The CRD contract resolves the prior questions about duplicate mappings, status, 
 
 - Validate required reference fields, immutable `targetSecretRef`, self-reference rejection, and rejection of non-vSphere or root targets.
 - Verify target-inventory maintenance for vSphere `CredentialsRequest` create, update, delete, and controller-startup rebuild; verify unavailable inventory denies override admission.
-- Verify one valid labeled source synchronizes the target and reports `OverrideApplied`.
-- Verify missing, unlabeled, incomplete, empty, and unmatched source data report `SourceSecretMissing` or `SourceSecretInvalid`, preserve the target, and never use root credentials while the CR exists.
+- Verify one valid referenced source synchronizes the target and reports `OverrideApplied`.
+- Verify missing, incomplete, empty, and unmatched source data report `SourceSecretMissing` or `SourceSecretInvalid`, preserve the target, and never use root credentials while the CR exists.
 - Verify duplicate target matches set `DuplicateTarget` on every conflicting override and leave the target unchanged.
 - Verify no override CR uses the existing root path in managed mode.
 - Verify `credentialsMode: Manual` performs no source read or target write and reports `ManualMode` for an existing override.
 - Verify serialized queue mapping for override and source-Secret create/update/delete events.
-- Verify `predicate.Funcs` accepts relevant old or new objects, including source-label or metadata removal and remove-then-delete; verify override deletion requeues root-path reconciliation.
+- Verify `predicate.Funcs` accepts relevant old or new objects for referenced and unreferenced source-Secret updates and source deletion; verify override deletion requeues root-path reconciliation.
 - Verify allowed cluster-admin/delegated-service-account create and update operations, and denied create and update operations for unauthorized principals in `openshift-config`.
 
 ### Integration / E2E Tests
 
 - On a vSphere cluster with `TechPreviewNoUpgrade`, create the source Secret and one valid override; verify only its `CredentialsRequest` target receives the override data and status becomes ready.
 - Rotate the source data and verify the target is re-synchronized through the serialized queue without affecting other component targets.
-- Exercise source deletion, invalid data, label removal, duplicate overrides, invalid target admission, and target immutability; verify conditions and no silent root fallback.
+- Exercise source deletion, invalid data, unreferenced source-Secret updates, duplicate overrides, invalid target admission, and target immutability; verify conditions and no silent root fallback.
 - Delete the only override in managed mode and verify the normal root path resumes only after the CR is absent.
 - Use authorized and unauthorized identities to verify source-Secret and override CR create/update authorization.
 - Verify Manual mode leaves override and target data unmanaged.
@@ -290,7 +290,7 @@ The CRD contract resolves the prior questions about duplicate mappings, status, 
 - CRD, admission policy, and CCO manifests are correctly gated by `TechPreviewNoUpgrade`.
 - Unit and integration coverage validates API rules, source-data validation, condition reasons, queue serialization, authorization denial, Manual mode, and fail-closed behavior.
 - E2E coverage validates valid synchronization and all no-write failure paths on vSphere.
-- Administrator and support documentation explains privileged authoring, source labels, conditions, and recovery.
+- Administrator and support documentation explains privileged authoring, direct source references, conditions, and recovery.
 
 ### Tech Preview -> GA
 
@@ -315,24 +315,24 @@ The CRD, admission policy, and CCO controller must be introduced and gated as on
 
 ## Operational Aspects of API Extensions
 
-**Failure modes:** A target that is invalid is denied at admission. After admission, missing, invalid, unlabeled, or ambiguous sources are reflected on the override's conditions and do not modify the target. An unavailable target inventory denies new override creation. In Manual mode, CCO does not manage the source, override application, or target.
+**Failure modes:** A target that is invalid is denied at admission. After admission, missing, invalid, or ambiguous sources are reflected on the override's conditions and do not modify the target. An unavailable target inventory denies new override creation. In Manual mode, CCO does not manage the source, override application, or target.
 
-**Monitoring:** Operators use `VSphereCredentialOverride.status.conditions`, `observedGeneration`, and `resolvedSource` to determine whether a target was synchronized. CCO logs and events identify the resource and condition reason but must not log credential bytes.
+**Monitoring:** Operators use `VSphereComponentScopedCredential.status.conditions`, `observedGeneration`, and `resolvedSource` to determine whether a target was synchronized. CCO logs and events identify the resource and condition reason but must not log credential bytes.
 
-**Recovery:** Correct the source Secret data or label, delete duplicate override CRs, or delete the override CR when returning to the normal root path is intended. Reconciliation is event-driven; force-deleting the target Secret is not the prescribed recovery mechanism.
+**Recovery:** Correct the source Secret data, delete duplicate override CRs, or delete the override CR when returning to the normal root path is intended. Reconciliation is event-driven; force-deleting the target Secret is not the prescribed recovery mechanism.
 
 ## Support Procedures
 
-1. List and describe overrides without exposing Secret data: `oc get vspherecredentialoverrides` and `oc describe vspherecredentialoverride <name>`.
+1. List and describe overrides without exposing Secret data: `oc get vspherecomponentscopedcredentials` and `oc describe vspherecomponentscopedcredential <name>`.
 2. Confirm that `targetSecretRef` matches a vSphere `CredentialsRequest.spec.secretRef` and inspect the `Ready`, `SourceValid`, and `TargetSynced` reasons.
-3. Confirm the named source Secret exists in `openshift-config` and carries `cloudcredential.openshift.io/vsphere-override-source=true`; inspect only metadata and required key names, never Secret values.
-4. Confirm delegated access with `oc auth can-i` for both `VSphereCredentialOverride` and source-Secret create/update operations in `openshift-config`; unauthorized principals must be denied.
+3. Confirm the source Secret named by `sourceSecretRef` exists in `openshift-config`; inspect only metadata and required key names, never Secret values.
+4. Confirm delegated access with `oc auth can-i` for both `VSphereComponentScopedCredential` and source-Secret create/update operations in `openshift-config`; unauthorized principals must be denied.
 5. For `SourceSecretMissing`, `SourceSecretInvalid`, or `DuplicateTarget`, correct the reported configuration and wait for reconciliation. Delete the CR only when a deliberate return to the root path is desired.
 6. For `ManualMode`, manage component credentials according to the existing Manual-mode procedure; CCO will not apply the override.
 
 ## Implementation History
 
 - 2026-08-17: Initial annotation-based enhancement proposal.
-- 2026-09-11: Revised the proposal to the `VSphereCredentialOverride` CRD contract, including fail-closed behavior, scoped source discovery, authorization, and Manual-mode decisions.
+- 2026-09-11: Revised the proposal to the `VSphereComponentScopedCredential` CRD contract, including fail-closed behavior, direct source references, authorization, and Manual-mode decisions.
 - Target release: 5.1.0.
 - Primary tracking: [SPLAT-2874](https://issues.redhat.com/browse/SPLAT-2874); CCO implementation: [SPLAT-2889](https://issues.redhat.com/browse/SPLAT-2889); parent initiative: [SPLAT-2724](https://issues.redhat.com/browse/SPLAT-2724).

--- a/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
+++ b/enhancements/cloud-integration/vsphere-per-component-credential-overrides.md
@@ -14,8 +14,9 @@ approvers:
 api-approvers:
   - "none"
 creation-date: 2026-08-17
-last-updated: 2026-08-17
+last-updated: 2026-09-11
 tracking-link:
+  - https://issues.redhat.com/browse/SPLAT-2874
   - https://issues.redhat.com/browse/SPLAT-2889
   - https://issues.redhat.com/browse/SPLAT-2724
 see-also:
@@ -32,19 +33,20 @@ superseded-by:
 
 - [ ] Enhancement is `implementable`
 - [ ] Design details are appropriately documented from clear requirements
+- [ ] API review is complete and the approved `openshift/api` change is linked
 - [ ] Test plan is defined
 - [ ] Graduation criteria for dev preview, tech preview, GA
 - [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
 
 ## Summary
 
-This enhancement extends the Cloud Credential Operator (CCO) vSphere actuator to support per-component credential overrides stored as annotated secrets in the `openshift-config` namespace. Today, vSphere clusters use a single shared credential (`kube-system/vsphere-creds`) that is copied identically to every component (Machine API, CSI, Cloud Controller Manager). This enhancement allows cluster administrators to provide distinct, lower-privilege credentials for each component by creating override secrets annotated with the target CredentialsRequest's `spec.secretRef`.
+This enhancement adds the cluster-scoped `cloudcredential.openshift.io/v1alpha1` `VSphereCredentialOverride` API for selecting a labeled Secret in `openshift-config` as the source credential for one vSphere `CredentialsRequest` target Secret. Today, vSphere clusters use a single shared credential (`kube-system/vsphere-creds`) for every component. The CRD lets authorized administrators configure distinct, lower-privilege credentials per component without storing credential bytes in the API object. The feature targets OpenShift 5.1.0 and is initially gated by `TechPreviewNoUpgrade`.
 
-This is a reduced-scope first phase of the broader vSphere multi-account credential management initiative (SPLAT-2724). It delivers the CCO-side credential resolution mechanism without requiring installer changes, enabling day-2 credential separation for existing and new clusters.
+This is a reduced-scope first phase of the broader vSphere multi-account credential-management initiative. [SPLAT-2874](https://issues.redhat.com/browse/SPLAT-2874) is the primary tracking item; [SPLAT-2889](https://issues.redhat.com/browse/SPLAT-2889) tracks the CCO implementation, and [SPLAT-2724](https://issues.redhat.com/browse/SPLAT-2724) is the parent initiative.
 
 ## Motivation
 
-vSphere clusters today operate with a single set of credentials shared across all OpenShift components that interact with the vCenter API. This means Machine API, the CSI driver, and Cloud Controller Manager all authenticate with the same username and password. This shared-credential model creates several operational and security challenges:
+vSphere clusters today operate with a single set of credentials shared across all OpenShift components that interact with the vCenter API. This means Machine API, the CSI driver, and Cloud Controller Manager all authenticate with the same identity. This shared-credential model creates several operational and security challenges:
 
 - **Blast radius**: A compromised credential exposes all vSphere operations, not just the affected component.
 - **Audit opacity**: vCenter audit logs cannot distinguish which OpenShift component performed an action when all components use the same identity.
@@ -52,239 +54,285 @@ vSphere clusters today operate with a single set of credentials shared across al
 
 ### User Stories
 
-**Story 1 - Least-privilege credential separation**: As a cluster administrator, I want to assign distinct vSphere credentials to each OpenShift component (Machine API, CSI driver, Cloud Controller Manager) so that each component operates with only the permissions it requires, reducing the blast radius of a credential compromise.
+**Story 1 - Least-privilege credential separation**: As a cluster administrator, I want to assign distinct vSphere credentials to each OpenShift component so that each component operates with only the permissions it requires, reducing the blast radius of a credential compromise.
 
-**Story 2 - Credential rotation without full cluster impact**: As a cluster administrator, I want to rotate a single component's vSphere credential without affecting other components, so that routine credential rotation is lower-risk and can be performed incrementally.
+**Story 2 - Credential rotation without full cluster impact**: As a cluster administrator, I want to rotate one component's vSphere credential without affecting other components so that routine rotation is lower-risk and can be performed incrementally.
 
-**Story 3 - Audit and compliance separation**: As a security engineer, I want to track vSphere API activity per-component using distinct service accounts, so that audit logs clearly attribute actions to the responsible OpenShift component.
+**Story 3 - Observable recovery**: As a cluster administrator, I want invalid or ambiguous override configuration to report a clear status without silently changing a component back to root credentials so that I can remediate the intended credential source safely.
 
 ### Goals
 
-- Allow cluster administrators to provide per-component vSphere credentials via secrets in `openshift-config`, mapped to components via annotations
-- Maintain full backward compatibility — clusters without override secrets continue to use the shared `kube-system/vsphere-creds` credential with no behavioral change
-- Require no installer changes — override secrets can be created manually or via automation at any point in the cluster lifecycle (day 0 via manifests, or day 2)
-- Trigger automatic reconciliation when override secrets are created, updated, or deleted
+- Provide a cluster-scoped, structured API for mapping one vSphere `CredentialsRequest` target Secret to one source Secret in `openshift-config`.
+- Validate mappings, protect the mapping target from mutation, and make invalid configuration observable through status conditions.
+- Limit CCO source-Secret discovery to explicitly labeled Secrets and give only authorized administrators or delegated service accounts permission to create or update override resources and source Secrets.
+- Preserve existing root-credential behavior for managed vSphere `CredentialsRequest` targets only when no override CR exists for that target.
+- Reconcile create, update, deletion, and relevance-removal events through the existing `CredentialsRequest` work queue.
 
 ### Non-Goals
 
-- Installer-native `install-config.yaml` support for per-component credentials (planned for a subsequent phase under SPLAT-2769/SPLAT-2772)
-- Automatic credential provisioning or rotation — this phase relies on administrator-managed secrets
-- Extending this mechanism to non-vSphere platforms (though the annotation-based pattern is designed to be portable)
-- Changes to the vSphere cloud provider configuration (`cloud-provider-config` ConfigMap)
+- Installer-native `install-config.yaml` support or automatic provisioning and rotation of per-component credentials.
+- Applying or managing overrides when `credentialsMode: Manual` is configured.
+- Extending this API to non-vSphere platforms.
+- Supporting HyperShift / Hosted Control Planes or MicroShift in this phase.
+- Changing the vSphere cloud-provider configuration (`cloud-provider-config` ConfigMap).
 
 ## Proposal
 
 ### Workflow Description
 
-The administrator creates a Secret in the `openshift-config` namespace with two annotations identifying the target component's credential:
+An authorized administrator creates a `VSphereCredentialOverride` after creating a source Secret in `openshift-config`. The source Secret has the label `cloudcredential.openshift.io/vsphere-override-source: "true"`; it is not selected by annotations. The Secret contains the complete vCenter credential data map required by the target, with non-empty matching `<vcenter-hostname>.username` and `<vcenter-hostname>.password` entries. Credential bytes are never placed in the override CR or in CCO logs.
 
 ```yaml
-apiVersion: v1
-kind: Secret
+apiVersion: cloudcredential.openshift.io/v1alpha1
+kind: VSphereCredentialOverride
 metadata:
-  name: mapi-vsphere-creds          # any name chosen by the admin
-  namespace: openshift-config
-  annotations:
-    cloudcredential.openshift.io/target-secret-namespace: openshift-machine-api
-    cloudcredential.openshift.io/target-secret-name: vsphere-cloud-credentials
-data:
-  <vcenter-hostname>.username: <base64-encoded-username>
-  <vcenter-hostname>.password: <base64-encoded-password>
+  name: openshift-machine-api-vsphere
+spec:
+  targetSecretRef:
+    namespace: openshift-machine-api
+    name: vsphere-cloud-credentials
+  sourceSecretRef:
+    name: vsphere-machine-api-creds
 ```
 
-The CCO controller detects the new secret in `openshift-config` (via an extended watch) and requeues all CredentialsRequests. When processing the Machine API CredentialsRequest, the vSphere actuator's `GetCredentialsRootSecret()`:
+The API server validates the target reference at creation time against the inventory of vSphere `CredentialsRequest.spec.secretRef` values maintained by CCO. It rejects a target that does not exist or that names `kube-system/vsphere-creds`. CCO maintains that inventory as `CredentialsRequest` objects are created, updated, deleted, and at controller startup; the admission policy fails closed if that inventory is unavailable.
 
-1. Lists secrets in `openshift-config`
-2. Finds the secret whose `target-secret-namespace` and `target-secret-name` annotations match the CR's `spec.secretRef.Namespace` / `spec.secretRef.Name`
-3. Returns the override secret's data instead of `kube-system/vsphere-creds`
+The CCO reconciler maps an override event to the `CredentialsRequest` whose `spec.secretRef` matches `targetSecretRef`. It then resolves exactly one applicable override:
 
-The actuator syncs the override credential data to the component's target secret. Components without an override secret continue to receive the shared root credential.
-
-**Fallback behavior**: If the override secret is deleted, the actuator falls back to `kube-system/vsphere-creds` on the next reconciliation cycle.
+1. In `credentialsMode: Manual`, CCO does not resolve, copy, or manage overrides or target Secrets. It reports `ManualMode` on existing overrides and leaves Manual-mode credential management unchanged.
+2. In managed mode, no override CR for the target preserves the existing root path using `kube-system/vsphere-creds`.
+3. Exactly one override causes CCO to read the named, labeled source Secret from `openshift-config`, validate its data, and synchronize that data to the target Secret.
+4. A missing or invalid source Secret, a source Secret without the required label, or multiple overrides for the same target is fail-closed: CCO does not write root credentials or replacement data to that target. It records the applicable status condition and waits for remediation.
+5. Deleting the only override CR requeues its target. In managed mode that is the no-override case, so the existing root path resumes. Deleting a source Secret while its override remains is not a no-override case and therefore remains fail-closed.
 
 ### API Extensions
 
-No CRD or API changes are required. The feature uses two new well-known annotations on Kubernetes Secrets:
+This enhancement adds the cluster-scoped `VSphereCredentialOverride` CRD in the `cloudcredential.openshift.io/v1alpha1` API. The resource defines these structured fields:
 
-| Annotation Key | Value | Description |
-|---|---|---|
-| `cloudcredential.openshift.io/target-secret-namespace` | e.g. `openshift-machine-api` | The namespace of the CredentialsRequest's spec.secretRef this override targets |
-| `cloudcredential.openshift.io/target-secret-name` | e.g. `vsphere-cloud-credentials` | The name of the CredentialsRequest's spec.secretRef this override targets |
+| Field | Meaning |
+|---|---|
+| `spec.targetSecretRef.namespace` | Namespace of the vSphere `CredentialsRequest.spec.secretRef` target. |
+| `spec.targetSecretRef.name` | Name of that target Secret. |
+| `spec.sourceSecretRef.name` | Name of the source Secret in the fixed `openshift-config` namespace. |
+| `status.conditions` | `Ready`, `SourceValid`, `TargetSynced`, and `Progressing` observations for this mapping. |
+| `status.resolvedSource` | `Override` after a successful synchronization or `Unknown` otherwise; root use is not an override status. |
+
+OpenAPI validation requires both references and valid Kubernetes names. A validating admission policy backed by the CCO-maintained vSphere target inventory verifies that `targetSecretRef` names an existing vSphere `CredentialsRequest` target and is not the root Secret. CEL validation makes `targetSecretRef` immutable (`self == oldSelf`); retargeting requires delete and recreate. It also rejects self-reference when the target is `openshift-config/<sourceSecretRef.name>`.
+
+The controller validates source data at reconciliation time because Secret contents cannot be represented safely in this CRD. The source must exist, carry the dedicated label, and contain non-empty matching username/password entries for each vCenter key pair required by the vSphere credential format.
+
+`v1alpha1` is Compatibility Level 4 and will be delivered only when the `TechPreviewNoUpgrade` feature set is enabled. The CRD, admission policy, and CCO manifests must carry the corresponding feature-set gating so the API is not installed or used outside that feature set.
+
+This is a new OpenShift API and requires an `openshift/api` type/CRD change and API review before implementation proceeds. No API approval PR or API approver has been assigned at the time of this update; the real approved PR link is an explicit prerequisite and must be added when available.
 
 ### Topology Considerations
 
 #### Standalone Clusters
 
-Fully supported. The override mechanism operates entirely within the CCO reconciliation loop, which runs on standalone clusters without modification.
+Supported on managed vSphere standalone OpenShift clusters. CCO and the API operate in the cluster control plane; the feature does not add node workloads or depend on worker-node count.
 
+#### HyperShift / Hosted Control Planes
+
+<!-- The current template validator requires this legacy-cased heading string:
 #### Hypershift / Hosted Control Planes
+-->
 
-Not in scope for this phase. Hypershift uses a different credential management model where the management cluster holds credentials for hosted clusters. The annotation-based pattern could be adapted for Hypershift in a future phase, but the credential topology is sufficiently different to warrant separate design work.
+Unsupported in this phase. HyperShift / Hosted Control Planes use a distinct management-cluster and hosted-control-plane credential topology. No CRD, policy, or source-Secret placement is defined for either cluster until a separate design establishes ownership, access boundaries, and upgrade behavior.
 
 #### Single-node Deployments or MicroShift
 
-Supported — the same mechanism applies. The CCO runs on SNO clusters identically to multi-node clusters, and the override secret resolution is purely a control-plane operation with no node-count dependency.
+OpenShift SNO is supported: the feature adds no node-level agent or SNO-specific resource requirement. MicroShift is unsupported because this CCO API and its feature-gated control-plane dependencies are not part of the MicroShift contract.
 
 #### OpenShift Kubernetes Engine
 
-Not applicable. This enhancement targets the CCO vSphere actuator, which is specific to vSphere platform deployments and does not apply to OKE deployments.
+There is no OKE-specific implementation. Availability is limited to supported vSphere OpenShift deployments that include the CCO vSphere actuator and the required feature set; product support for an OKE offering must be confirmed before enabling the feature there.
 
 ### Implementation Details/Notes/Constraints
 
-**Changed Components:**
+**Changed components:**
 
-- `pkg/operator/constants/constants.go` — Add `VSphereCredOverrideNamespace` (`"openshift-config"`) and annotation key constants (`VSphereCredOverrideTargetNamespaceAnnotation`, `VSphereCredOverrideTargetNameAnnotation`)
-- `pkg/vsphere/actuator/actuator.go` — Modify `GetCredentialsRootSecret()` to list secrets in `openshift-config`, match by annotation values against `cr.Spec.SecretRef`, and fall back to `kube-system/vsphere-creds`
-- `pkg/operator/credentialsrequest/credentialsrequest_controller.go` — Add watch on `openshift-config` namespace; update `IsVSphereOverrideSecret()` predicate to check annotation keys
-- `pkg/vsphere/actuator/actuator_test.go` — New test file with table-driven tests covering override matching, fallback, wrong annotations, multi-component scenarios, and drift detection
+- `openshift/api` — add the cluster-scoped `VSphereCredentialOverride` type, CRD generation, compatibility-level markers, feature-gate metadata, and the API-review approval.
+- CCO API manifests — install the CRD and validating admission policy only under `TechPreviewNoUpgrade`.
+- CCO credentials-request controller — maintain the vSphere target inventory, watch overrides and labeled source Secrets, serialize events through the `CredentialsRequest` queue, and update override status.
+- CCO vSphere actuator — resolve the override only after validating its source and retain the existing root path only when there is no override.
+- CCO RBAC and tests — scope CCO reads and verify both allowed and denied authoring paths.
 
-**Resolution Algorithm (pseudocode):**
+**Authorization and Secret discovery:**
 
+CCO uses the label selector `cloudcredential.openshift.io/vsphere-override-source=true` for its `openshift-config` Secret list and watch. Its RBAC grants only the required `get`, `list`, and `watch` access to Secrets in that namespace, with no source-Secret write permission; it separately retains only the target-Secret permissions required by existing `CredentialsRequest` reconciliation. Kubernetes RBAC cannot express a label selector, so the selector limits discovery while namespace-scoped least-privilege RBAC limits the API access boundary.
+
+Only cluster administrators or explicitly delegated service accounts receive RBAC to create, update, or delete `VSphereCredentialOverride` resources and labeled source Secrets in `openshift-config`. Delegation must be implemented with narrowly scoped Roles/RoleBindings and documented as privileged credential-management access. It is not sufficient for a principal to have general application-namespace Secret permissions.
+
+**Resolution algorithm:**
+
+```text
+reconcile CredentialsRequest:
+    if credentialsMode is Manual:
+        do not read source Secrets or write target Secrets
+        set ManualMode on any matching override and return
+
+    overrides = overrides whose targetSecretRef matches this request's secretRef
+    if overrides is empty:
+        use the existing root-credential path
+        return
+    if overrides has more than one item:
+        set Ready=False, reason=DuplicateTarget on every conflicting override
+        do not modify the target Secret
+        return
+
+    source = named Secret in openshift-config, selected with the dedicated label
+    if source is missing:
+        set Ready=False, SourceValid=False, reason=SourceSecretMissing
+        do not modify the target Secret
+        return
+    if source lacks the label or has incomplete, empty, or unmatched data:
+        set Ready=False, SourceValid=False, reason=SourceSecretInvalid
+        do not modify the target Secret
+        return
+
+    synchronize source data to the target Secret
+    set Ready=True, SourceValid=True, TargetSynced=True, reason=OverrideApplied
 ```
-func GetCredentialsRootSecret(ctx, cr):
-    1. List all Secrets in "openshift-config" namespace
-    2. For each secret:
-       - Read annotation "cloudcredential.openshift.io/target-secret-namespace"
-       - Read annotation "cloudcredential.openshift.io/target-secret-name"
-       - If both match cr.Spec.SecretRef.Namespace and cr.Spec.SecretRef.Name:
-           -> return this override secret
-    3. If no match found:
-       -> return kube-system/vsphere-creds (existing behavior)
-```
 
-**Watch Configuration:**
+**Event handling and serialization:**
 
-The CredentialsRequest controller adds a new source to its watch list:
+Override create, update, and delete events map to the `CredentialsRequest` that owns `targetSecretRef`, rather than directly writing a target Secret. Labeled source-Secret events first map to referencing overrides and then to their target `CredentialsRequest`s. This common queue serializes all writes for a target and avoids concurrent override/root updates.
 
-```go
-source.Kind(&corev1.Secret{},
-    handler.EnqueueRequestsFromMapFunc(
-        credentialsRequestMapFunc(mgr.GetClient(), constants.VSphereCredOverrideNamespace),
-    ),
-    predicate.NewPredicateFuncs(IsVSphereOverrideSecret),
-)
-```
+The watches use `predicate.Funcs`, not `predicate.NewPredicateFuncs`. Their update handler accepts an event when either the old or new object is relevant to an override relationship. This preserves reconciliation when a source Secret loses the dedicated label or relevant metadata, and when an override is changed or removed. Delete events are also accepted so deletion of an override performs no-override cleanup and deletion or relevance-removal of a source is reported as fail-closed. The CRD replaces annotation-only target selection; there is no annotation compatibility path that could silently restore root credentials while an override CR still exists.
 
-The `IsVSphereOverrideSecret` predicate returns `true` only for secrets in `openshift-config` that carry at least one of the two `cloudcredential.openshift.io/target-secret-*` annotations, minimizing unnecessary reconciliation triggers.
+**Status and condition reasons:**
+
+| Situation | `Ready` | Reason | Target behavior |
+|---|---|---|---|
+| Valid labeled source synchronized | `True` | `OverrideApplied` | Target contains the override data. |
+| Source Secret does not exist | `False` | `SourceSecretMissing` | Target is left unchanged. |
+| Source lacks the label or has invalid data | `False` | `SourceSecretInvalid` | Target is left unchanged. |
+| More than one override targets a Secret | `False` | `DuplicateTarget` | Every conflicting target is left unchanged. |
+| `credentialsMode: Manual` | `False` | `ManualMode` | CCO does not manage the override or target. |
+
+`TargetSynced=SyncPending` may be reported while work is in progress and `TargetSynced=SyncBlocked` when the source or mapping is invalid. Condition messages identify resource names and remediation but never include Secret data.
 
 ### Risks and Mitigations
 
-**Risk: Administrator provides override secret with incorrect data format.**
-Mitigation: Same failure mode as providing bad credentials in `kube-system/vsphere-creds` today — component health checks surface authentication failures. The CCO logs a warning when an override secret is resolved, aiding debugging.
+**Risk: An unauthorized principal directs credentials to another component.**
+Mitigation: RBAC limits override and labeled-source Secret create/update/delete operations to cluster administrators or explicitly delegated credential-management service accounts. Admission verifies that a target is a real vSphere `CredentialsRequest` target and rejects the root Secret. Authorization tests cover both create and update denials for unauthorized principals.
 
-**Risk: Multiple override secrets target the same component.**
-Mitigation: First match is used; documentation advises a one-to-one mapping between override secrets and components. A future enhancement could add a validating webhook to enforce uniqueness.
+**Risk: CCO reads unrelated credentials from the shared `openshift-config` namespace.**
+Mitigation: CCO uses the dedicated source label for list/watch selectors and has namespace-scoped, read-only source-Secret RBAC. It does not log Secret data.
 
-**Risk: Listing all secrets in openshift-config on every reconciliation.**
-Mitigation: The `openshift-config` namespace typically contains fewer than 20 secrets; the list operation is inexpensive. A label selector can narrow the scan if the secret count grows, but this is not expected to be necessary.
+**Risk: Invalid source data or duplicate mappings silently escalates an affected component to root credentials.**
+Mitigation: Missing, invalid, unlabeled, and ambiguous overrides fail closed, leave the target unchanged, and expose `SourceSecretMissing`, `SourceSecretInvalid`, or `DuplicateTarget` conditions. Only the absence of an override CR selects the normal root path.
 
-**Risk: Race condition between override secret creation and CredentialsRequest reconciliation.**
-Mitigation: The watch on `openshift-config` triggers requeue of all CredentialsRequests when an override secret is created or modified, ensuring convergence within one reconciliation cycle.
+**Risk: A source or override update is missed during removal.**
+Mitigation: `predicate.Funcs` evaluates old and new objects, and all events map through the serialized `CredentialsRequest` queue. Tests cover relevance removal followed by deletion.
+
+**Risk: Tech Preview APIs are used during a minor update.**
+Mitigation: CRD, policy, and controller behavior are gated by `TechPreviewNoUpgrade`; the documented support posture prohibits minor upgrades while it is enabled.
 
 ### Drawbacks
 
-- Adds a new credential resolution path alongside the existing root secret, increasing the debugging surface area for credential-related issues
-- Annotation-based mapping is not validated at admission time — misconfigurations are only detected at reconciliation time and surfaced through CCO logs
-- The feature introduces a dependency on the `openshift-config` namespace for credential storage, which is a shared namespace used by other platform components
+- This introduces a feature-gated CRD, admission validation, source-Secret inventory, and status surface that must be maintained with the CCO.
+- Fail-closed behavior can retain a component's prior target data until an administrator resolves a bad source or duplicate mapping; it deliberately favors preventing unexpected credential escalation over automatic fallback.
+- Source Secret and CR authors require privileged access to a shared platform namespace, so delegation must be reviewed carefully.
 
 ## Alternatives (Not Implemented)
 
-### Naming Convention Approach
+### Annotation-Based Secret Mapping
 
-Override secrets could use a deterministic naming convention (e.g. `vsphere-creds-machine-api`) derived from the CredentialsRequest's target namespace. This was the initial implementation approach but was replaced because annotations are self-documenting, decouple secret naming from mapping, and reuse `spec.secretRef` as a stable identifier that is less likely to change across releases.
+Selecting a target through annotations on arbitrary Secrets was rejected. It lacks a structured API, makes admission validation and immutability difficult, permits ambiguous matching, and makes relevance-removal handling error-prone. `VSphereCredentialOverride` provides an explicit, observable mapping instead.
 
 ### Installer-Native Configuration
 
-Per-component credentials configured directly in `install-config.yaml` — planned for a subsequent phase (SPLAT-2769/SPLAT-2772) and would layer on top of this CCO-side mechanism. Deferring installer integration reduces the scope of this phase and allows the CCO mechanism to be validated independently.
+Per-component credentials configured directly in `install-config.yaml` are deferred to a subsequent phase. This proposal focuses on the CCO-side API and day-2 management; installer integration must define its own source lifecycle and validation contract.
 
 ### Single Multi-Key Secret
 
-A single secret with multiple keys (one set per component) was rejected because separate secrets provide better RBAC granularity, independent lifecycle management, and clearer audit trails. With separate secrets, an administrator can grant access to rotate one component's credentials without exposing others.
+A single Secret with multiple components' credentials was rejected because separate source Secrets provide better access separation, independent lifecycle management, and clearer audit trails.
 
 ### CredentialsRequest Field Extension
 
-Adding a field to `CredentialsRequest.spec` to reference an override secret was considered but rejected because CredentialsRequests are owned by the components themselves, and modifying them would require changes to each component's codebase. The annotation-based approach keeps the override mechanism entirely within the CCO and `openshift-config` namespace.
+Adding an override reference to `CredentialsRequest.spec` was rejected because `CredentialsRequest` objects are owned by consuming components. A dedicated CRD keeps the user-authored mapping separate from those component-owned requests while allowing CCO to validate the target relationship.
 
 ## Open Questions
 
-1. Should the CCO surface per-component override status via conditions on the CredentialsRequest CR? This would make it visible via `oc get credentialsrequest` whether a component is using an override or the shared root credential.
-2. Should a validating webhook prevent multiple override secrets targeting the same component? This would catch misconfiguration at creation time rather than reconciliation time.
-3. How should this interact with `credentialsMode: Manual`? In Manual mode, the CCO does not manage credentials — should override secrets still be honored, or should they be ignored?
+The CRD contract resolves the prior questions about duplicate mappings, status, and Manual mode. The remaining implementation prerequisite is assignment of an API approver and publication of the approved `openshift/api` change; this enhancement intentionally does not fabricate that approval or its PR URL.
 
 ## Test Plan
 
 ### Unit Tests
 
-- Override secret with matching annotations returns override credential data instead of root credential
-- No override secret present returns root `kube-system/vsphere-creds` (backward compatibility)
-- Override secret with wrong or missing annotations is ignored, falls back to root credential
-- Multiple override secrets targeting different components result in each component getting its correct override
-- `needsUpdate()` correctly detects drift between the target secret and the resolved source secret (override or root)
-- Override secret deleted triggers fallback to root credential on next reconciliation
-- `IsVSphereOverrideSecret` predicate correctly identifies secrets with override annotations and rejects secrets without them
+- Validate required reference fields, immutable `targetSecretRef`, self-reference rejection, and rejection of non-vSphere or root targets.
+- Verify target-inventory maintenance for vSphere `CredentialsRequest` create, update, delete, and controller-startup rebuild; verify unavailable inventory denies override admission.
+- Verify one valid labeled source synchronizes the target and reports `OverrideApplied`.
+- Verify missing, unlabeled, incomplete, empty, and unmatched source data report `SourceSecretMissing` or `SourceSecretInvalid`, preserve the target, and never use root credentials while the CR exists.
+- Verify duplicate target matches set `DuplicateTarget` on every conflicting override and leave the target unchanged.
+- Verify no override CR uses the existing root path in managed mode.
+- Verify `credentialsMode: Manual` performs no source read or target write and reports `ManualMode` for an existing override.
+- Verify serialized queue mapping for override and source-Secret create/update/delete events.
+- Verify `predicate.Funcs` accepts relevant old or new objects, including source-label or metadata removal and remove-then-delete; verify override deletion requeues root-path reconciliation.
+- Verify allowed cluster-admin/delegated-service-account create and update operations, and denied create and update operations for unauthorized principals in `openshift-config`.
 
 ### Integration / E2E Tests
 
-- Deploy a vSphere cluster with default shared credentials
-- Create an override secret in `openshift-config` for one component (e.g. Machine API)
-- Verify the component's target secret is updated with the override credential data
-- Verify other components still use the root credential
-- Update the override secret with new credential data and verify the target secret is re-synced
-- Delete the override secret and verify the component falls back to the root credential
-- Create override secrets for all three components and verify each receives its distinct credential
+- On a vSphere cluster with `TechPreviewNoUpgrade`, create the source Secret and one valid override; verify only its `CredentialsRequest` target receives the override data and status becomes ready.
+- Rotate the source data and verify the target is re-synchronized through the serialized queue without affecting other component targets.
+- Exercise source deletion, invalid data, label removal, duplicate overrides, invalid target admission, and target immutability; verify conditions and no silent root fallback.
+- Delete the only override in managed mode and verify the normal root path resumes only after the CR is absent.
+- Use authorized and unauthorized identities to verify source-Secret and override CR create/update authorization.
+- Verify Manual mode leaves override and target data unmanaged.
+- Verify SNO behavior and that HyperShift / Hosted Control Planes and MicroShift are rejected or omitted from the supported test matrix.
 
 ## Graduation Criteria
 
 ### Dev Preview -> Tech Preview
 
-- Unit tests covering all override resolution paths (match, no-match, fallback, multi-component)
-- Manual testing on a vSphere cluster with per-component overrides
-- Documentation of the annotation-based override mechanism in the CCO repository
+- Approved `openshift/api` type/CRD change and assigned API approver are linked from this enhancement.
+- CRD, admission policy, and CCO manifests are correctly gated by `TechPreviewNoUpgrade`.
+- Unit and integration coverage validates API rules, source-data validation, condition reasons, queue serialization, authorization denial, Manual mode, and fail-closed behavior.
+- E2E coverage validates valid synchronization and all no-write failure paths on vSphere.
+- Administrator and support documentation explains privileged authoring, source labels, conditions, and recovery.
 
 ### Tech Preview -> GA
 
-- E2E test automation for override create/update/delete lifecycle
-- Integration with the installer (SPLAT-2769/SPLAT-2772) for day-0 provisioning of per-component credentials
-- Status conditions on CredentialsRequest indicating override usage
-- Documentation in the official OpenShift credential management guide
-- At least one release cycle of Tech Preview soak time with no regressions
+- The API has an approved compatibility and feature-gate graduation plan, including any version promotion required from Compatibility Level 4.
+- Automated conformance, upgrade, downgrade, and long-running credential-rotation coverage demonstrates safe behavior.
+- At least one release cycle of supported use shows no unresolved credential-synchronization regressions.
+- OpenShift documentation includes supported topologies, RBAC delegation, Manual-mode behavior, and fail-closed remediation.
 
 ### Removing a deprecated feature
 
-N/A — this is a new feature with no deprecation implications.
+This is a new API. If it is replaced, a future enhancement must define migration of CRs, source Secrets, feature gating, and the API deprecation period before removal.
 
 ## Upgrade / Downgrade Strategy
 
-**Upgrade**: Existing clusters upgrading to a version with this feature will see no behavioral change. The new code path only activates when an override secret with the appropriate annotations exists in `openshift-config`. Clusters without override secrets continue to operate exactly as before.
+While the feature is in `TechPreviewNoUpgrade`, minor-version upgrades are not supported. Enabling the feature is opt-in and does not affect a managed target until an override CR is created. On clusters without an override CR, the existing root-credential behavior is unchanged.
 
-**Downgrade**: If a cluster with override secrets is downgraded to a version without this feature, the override secrets will be ignored. The CCO will revert to using `kube-system/vsphere-creds` for all components. Administrators should ensure the root credential has sufficient permissions for all components before downgrading. The override secrets in `openshift-config` will remain but be inert — they can be cleaned up manually.
+Before disabling the feature, removing its manifests, or attempting a downgrade, an administrator must delete override CRs, verify that the root credential is valid for every affected component, and verify that targets have reconciled through the normal root path. An older CCO does not understand the CRD contract; remaining CRs and source Secrets are inert configuration and are not a supported substitute for that verification. The API-approval implementation must include downgrade tests before Tech Preview promotion.
 
 ## Version Skew Strategy
 
-The feature is entirely within the CCO — no cross-component version skew concerns exist. Consuming components (Machine API, CSI driver, Cloud Controller Manager) are unaware of the credential source; they read their target secret as before. The CCO is the sole component that implements the override resolution logic, so there is no risk of version skew between producers and consumers of this feature.
+The CRD, admission policy, and CCO controller must be introduced and gated as one feature-set unit. The controller tolerates no CRD by retaining its existing behavior when the feature is disabled. Consuming components continue to read their `CredentialsRequest` target Secret and do not depend on the source API version. No independent cross-component protocol is introduced.
 
 ## Operational Aspects of API Extensions
 
-**Failure Modes:**
-- If an override secret contains invalid credentials, the affected component will fail to authenticate with vCenter. This is the same failure mode as providing bad credentials in `kube-system/vsphere-creds` today. The component's health checks and ClusterOperator status will reflect the authentication failure.
-- If an override secret's annotations reference a non-existent CredentialsRequest target, the secret is simply never matched and has no effect.
+**Failure modes:** A target that is invalid is denied at admission. After admission, missing, invalid, unlabeled, or ambiguous sources are reflected on the override's conditions and do not modify the target. An unavailable target inventory denies new override creation. In Manual mode, CCO does not manage the source, override application, or target.
 
-**Monitoring:**
-- No new metrics are introduced in this phase. The CCO's existing reconciliation metrics continue to apply. Future phases may add a metric indicating the number of active override secrets.
+**Monitoring:** Operators use `VSphereCredentialOverride.status.conditions`, `observedGeneration`, and `resolvedSource` to determine whether a target was synchronized. CCO logs and events identify the resource and condition reason but must not log credential bytes.
 
-**Recovery:**
-- Deleting a problematic override secret triggers re-reconciliation, and the CCO automatically falls back to the root credential. Recovery is self-healing within one reconciliation cycle (typically under 60 seconds).
+**Recovery:** Correct the source Secret data or label, delete duplicate override CRs, or delete the override CR when returning to the normal root path is intended. Reconciliation is event-driven; force-deleting the target Secret is not the prescribed recovery mechanism.
 
 ## Support Procedures
 
-1. **List active overrides**: `oc get secrets -n openshift-config -o json | jq '.items[] | select(.metadata.annotations["cloudcredential.openshift.io/target-secret-namespace"] != null) | {name: .metadata.name, targetNs: .metadata.annotations["cloudcredential.openshift.io/target-secret-namespace"], targetName: .metadata.annotations["cloudcredential.openshift.io/target-secret-name"]}'`
-2. **Verify annotation values** match the target CredentialsRequest's `spec.secretRef` by running `oc get credentialsrequest -A -o json | jq '.items[] | {name: .metadata.name, ns: .spec.secretRef.namespace, secret: .spec.secretRef.name}'`
-3. **Check CCO logs** for override resolution messages: `oc logs -n openshift-cloud-credential-operator deployment/cloud-credential-operator | grep -i override`
-4. **Verify override secret data format** matches the expected vCenter credential structure (keys are `<vcenter-hostname>.username` and `<vcenter-hostname>.password`)
-5. **Force re-reconciliation** by deleting the component's target secret — the CCO will re-create it from the resolved source (override or root)
+1. List and describe overrides without exposing Secret data: `oc get vspherecredentialoverrides` and `oc describe vspherecredentialoverride <name>`.
+2. Confirm that `targetSecretRef` matches a vSphere `CredentialsRequest.spec.secretRef` and inspect the `Ready`, `SourceValid`, and `TargetSynced` reasons.
+3. Confirm the named source Secret exists in `openshift-config` and carries `cloudcredential.openshift.io/vsphere-override-source=true`; inspect only metadata and required key names, never Secret values.
+4. Confirm delegated access with `oc auth can-i` for both `VSphereCredentialOverride` and source-Secret create/update operations in `openshift-config`; unauthorized principals must be denied.
+5. For `SourceSecretMissing`, `SourceSecretInvalid`, or `DuplicateTarget`, correct the reported configuration and wait for reconciliation. Delete the CR only when a deliberate return to the root path is desired.
+6. For `ManualMode`, manage component credentials according to the existing Manual-mode procedure; CCO will not apply the override.
 
 ## Implementation History
 
-- 2026-08-17: Initial enhancement proposal for reduced-scope per-component credential overrides
-- 2026-08-17: Implementation PR — [openshift/cloud-credential-operator#1075](https://github.com/openshift/cloud-credential-operator/pull/1075)
-- Tracking: [SPLAT-2889](https://issues.redhat.com/browse/SPLAT-2889) (under epic [SPLAT-2724](https://issues.redhat.com/browse/SPLAT-2724))
+- 2026-08-17: Initial annotation-based enhancement proposal.
+- 2026-09-11: Revised the proposal to the `VSphereCredentialOverride` CRD contract, including fail-closed behavior, scoped source discovery, authorization, and Manual-mode decisions.
+- Target release: 5.1.0.
+- Primary tracking: [SPLAT-2874](https://issues.redhat.com/browse/SPLAT-2874); CCO implementation: [SPLAT-2889](https://issues.redhat.com/browse/SPLAT-2889); parent initiative: [SPLAT-2724](https://issues.redhat.com/browse/SPLAT-2724).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Replaced the proposed vSphere credential override API with a cluster-scoped component credential API.
  - Documents explicit Secret references instead of label-based Secret discovery.
  - Updates guidance for source validation, permissions, event handling, status terminology, testing, support procedures, and implementation history.
  - Clarifies fail-closed behavior and distinguishes changes to or deletion of a referenced Secret from the absence of an override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->