### PR TITLE
Enhancement: MicroShift kubelet image credential provider configuration

### DIFF
--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -156,13 +156,15 @@ to `KubeletConfiguration` unchanged.
    resolves to a directory, and that both paths satisfy the trusted-path rule
    described under Config validation: after resolving symlinks, every path
    component, the final object, and every file inside a directory must be owned
-   by root and not writable by group or others.
+   by root and not writable by group or others. The canonical (symlink-resolved)
+   paths are stored in the typed fields.
 4. If validation fails, MicroShift exits with a descriptive error message naming
    the field and the path.
 5. If validation succeeds, the kubelet component sets
    `KubeletFlags.ImageCredentialProviderConfigPath` and
-   `KubeletFlags.ImageCredentialProviderBinDir` before starting the embedded
-   kubelet, and logs an informational message recording the configured values.
+   `KubeletFlags.ImageCredentialProviderBinDir` to the canonical paths before
+   starting the embedded kubelet, and logs an informational message recording
+   both the configured and the canonical values.
 6. The keys in the `kubelet:` section other than the two reserved keys are
    marshaled into the `KubeletConfiguration` file as today.
 7. Kubelet reads the provider configuration file and verifies that each
@@ -211,7 +213,8 @@ field, which the generator propagates into the sample configuration file and the
 configuration reference (see Sample configuration and documentation below).
 
 `microshift show-config --mode effective` displays the keys under `kubelet:` as
-set by the user, since the underlying map is not modified.
+set by the user, since the underlying map is not modified. Kubelet receives the
+canonical, symlink-resolved form of each path (see Config validation).
 
 The credential provider configuration file itself follows the upstream
 `kubelet.config.k8s.io/v1` `CredentialProviderConfig` format. For example, for
@@ -329,17 +332,26 @@ one rule to both paths, implemented once as a helper in the `config` package:
    parent directory from replacing the validated file or directory after
    startup.
 3. If the final object is a directory, every entry in it must satisfy the same
-   ownership and permission requirement, with symlinked entries checked at their
-   resolved target. For the bin directory this covers every provider binary; for
-   a configuration directory this covers every file kubelet will load.
+   ownership and permission requirement. A symlinked entry is resolved and the
+   full rule, including ancestors, is applied to its target, so an entry cannot
+   point into a location an unprivileged user controls.
+4. The canonical path, not the configured path, is what MicroShift passes to
+   kubelet. Validating the canonical path while handing kubelet the configured
+   path would leave a gap: a symlink under a user-writable directory could be
+   re-pointed after startup, and kubelet would follow it at invocation time.
+   Passing the canonical path removes the symlink from kubelet's view entirely;
+   every component kubelet then traverses has been verified. The components of
+   the configured path itself therefore do not need to be trusted. `validate()`
+   stores the canonical paths in the typed fields; `Config.Kubelet` retains the
+   user's values for `show-config`.
 
 Together these checks mean an unprivileged user can neither add, replace, nor
-modify anything on either path. Only root can change the ownership or
-permissions of root-owned objects, so the properties verified at startup hold
-until a privileged actor changes them, which is outside the threat model.
-Standard layouts (`/etc/microshift/...`, `/usr/libexec/...`, and their ostree
-and bootc equivalents) satisfy the rule as installed; paths under user home
-directories or `/tmp` do not.
+modify anything on either path, nor redirect kubelet to a different path. Only
+root can change the ownership or permissions of root-owned objects, so the
+properties verified at startup hold until a privileged actor changes them, which
+is outside the threat model. Standard layouts (`/etc/microshift/...`,
+`/usr/libexec/...`, and their ostree and bootc equivalents) satisfy the rule as
+installed; paths under user home directories or `/tmp` do not.
 
 Error messages name the field, the configured path, and the offending component,
 e.g. `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"):
@@ -376,10 +388,13 @@ no new plumbing is required:
     }
 ```
 
-The log line records that MicroShift applied the configuration to kubelet. It is
-emitted before kubelet registers providers, so it does not by itself indicate
-that the providers are usable; a missing or non-executable provider binary is
-reported by kubelet as a startup error after this line. Because MicroShift calls
+The typed fields hold the canonical paths produced by validation, so kubelet
+receives symlink-resolved paths. When a configured path differs from its
+canonical form, the log line additionally records the configured value. The log
+line records that MicroShift applied the configuration to kubelet. It is emitted
+before kubelet registers providers, so it does not by itself indicate that the
+providers are usable; a missing or non-executable provider binary is reported by
+kubelet as a startup error after this line. Because MicroShift calls
 `kubelet.Run()` directly rather than through kubelet's cobra command, kubelet's
 usual `FLAG: --image-credential-provider-config=...` startup lines are never
 emitted, and kubelet's own credential provider code logs nothing at default
@@ -447,7 +462,8 @@ OCPEDGE-2976):
    configuration file controls their arguments and environment; both paths,
    their parent directories, and their contents must be root-owned and not
    writable by group or others, and MicroShift refuses to start otherwise.
-   Recommended locations that satisfy this as installed.
+   Recommended locations that satisfy this as installed. Kubelet is given the
+   symlink-resolved path.
 4. Image-based deployments: the binary must be present in every OS image build;
    on rpm-ostree it must be delivered as an RPM; validation failures on a new
    image cause greenboot rollback.
@@ -493,11 +509,11 @@ users. Documentation states the trust boundary and recommends locations that
 satisfy it as installed.
 
 **Risk:** The trusted-path checks run at startup. Ownership or permissions could
-be changed afterwards.
+be changed afterwards, or a symlink in the configured path could be re-pointed.
 **Mitigation:** Only root can change the ownership or permissions of root-owned
-objects, and root is outside the threat model (see Non-Goals). The checks
-therefore remain valid until a privileged actor changes the filesystem, and they
-run again at every restart.
+objects, and root is outside the threat model (see Non-Goals). Kubelet receives
+the canonical path, so re-pointing a symlink in the configured path after
+startup has no effect. The checks run again at every restart.
 
 **Risk:** On image-based (ostree/bootc) systems, a validation failure at startup
 causes greenboot health checks to fail, triggering an automatic rollback to the
@@ -563,14 +579,15 @@ locations pass as installed.
   the bin directory fails; a writable or non-root-owned file inside a
   configuration directory fails; a directory whose entries all pass succeeds.
 - Validation, trusted path, symlinks: a symlink whose resolved target satisfies
-  the rule passes (ostree-style layout); a symlink to a writable or
-  non-root-owned target fails; a symlinked entry inside the bin directory is
-  checked at its target.
+  the rule passes (ostree-style layout) and the typed field holds the canonical
+  path; a symlink to a writable or non-root-owned target fails; a symlinked
+  entry inside the bin directory is checked at its target including the target's
+  ancestors.
 - Validation: neither key set passes (backward compatibility).
 - `generateConfig()`: the two keys never appear in the generated
   `KubeletConfiguration` YAML; other user-provided keys still do.
-- `configure()`: `KubeletFlags` carries both values when set, and empty values
-  when unset.
+- `configure()`: `KubeletFlags` carries both canonical values when set, and
+  empty values when unset.
 
 Unit tests that require non-root ownership use fake ownership through an
 injected `stat` function, since tests do not run as root and cannot `chown`.
@@ -609,6 +626,12 @@ injected `stat` function, since tests do not run as root and cannot `chown`.
   verify MicroShift starts.
 - Unsafe ancestor: bin directory placed under a world-writable parent, verify
   MicroShift fails to start with an error naming the parent.
+- Symlink re-pointing: configure the bin directory through a symlink located in
+  a user-writable directory whose target is a compliant root-owned directory;
+  verify MicroShift starts and the `configured` line shows the canonical path;
+  as the unprivileged user, re-point the symlink to a directory containing a
+  different mock provider; verify the next uncached pull still invokes the
+  original provider.
 - Only one key set: verify MicroShift fails to start with the both-or-neither
   error.
 - Missing provider binary: valid keys, provider configuration naming a binary
@@ -679,16 +702,19 @@ unset unless the user adds them, and existing behavior is preserved. The
 documented procedure is to add the keys after upgrading to a version that
 supports them. No migration is required; the feature holds no persisted state.
 
-If a user pre-stages the keys before upgrading, the older version passes them
-through to the `KubeletConfiguration` file, where kubelet's strict decoder
-rejects them and the lenient `v1beta1` fallback logs a warning and ignores them;
-the newer version then activates the keys on its first start. This holds for
-every MicroShift version that predates this feature, because all of them vendor
-a kubelet that includes the lenient fallback and those released binaries do not
-change. The upstream plan to remove the fallback affects only future kubelet
-versions, which will only ship in MicroShift versions that also include this
-feature and never pass the keys through. The upgrade test covers the Y-1 to
-feature-version transition with pre-staged keys.
+Pre-staging the keys before upgrading is tolerated but not the documented
+procedure. A pre-feature version passes the keys through to the
+`KubeletConfiguration` file, where kubelet's strict decoder rejects them and the
+lenient `v1beta1` fallback logs a warning and ignores them; the newer version
+then activates the keys on its first start. The lenient fallback is present in
+the kubelet codec of every Kubernetes version vendored by a GA MicroShift
+release (verified in the 1.25, 1.28, and 1.31 release branches; MicroShift 4.12
+vendors 1.25), and released binaries do not change. The upstream plan to remove
+the fallback affects only future kubelet versions, which ship in MicroShift
+versions that include this feature and never pass the keys through. This
+behavior is tested only for the supported Y-1 to feature-version upgrade; users
+should add the keys after upgrading unless they have verified pre-staging on
+their specific source version.
 
 MicroShift does not support downgrades. The supported scenario that boots an
 older MicroShift with a newer configuration is rollback to the previous
@@ -701,9 +727,9 @@ lenient decoder logs a warning and ignores them. MicroShift starts normally with
 the credential provider feature inactive, so the rollback itself succeeds.
 Private registry image pulls fail on the rolled-back deployment until the
 previous workaround is restored or the device is rolled forward again. The
-configuration file on disk is not modified. As above, this relies on the lenient
-fallback, which is present in every pre-feature version that a rollback can
-target.
+configuration file on disk is not modified. A rollback only ever targets the
+immediately previous deployment, which is the transition covered by the rollback
+test.
 
 ## Version Skew Strategy
 N/A
@@ -752,11 +778,10 @@ rpm-ostree.
   or
   `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"): "/opt/providers/ecr-credential-provider" must be owned by root and not writable by group or others`.
   Fix with `chown root:root` and `chmod go-w` on the named component.
-- Image pull failures with the feature active: inspect
-  `journalctl -u microshift` for provider execution errors, verify the provider
-  binary runs successfully when invoked manually with a
-  `CredentialProviderRequest` on stdin, and verify the device's cloud identity
-  has registry pull permissions.
+- Image pull failures with the feature active: inspect `journalctl -u
+  microshift` for provider execution errors, verify the provider binary runs
+  successfully when invoked manually with a `CredentialProviderRequest` on
+  stdin, and verify the device's cloud identity has registry pull permissions.
 - A lenient-decode warning in the kubelet logs referencing either key indicates
   a MicroShift version that does not support the feature, or a misspelled key.
 - On bootc or rpm-ostree systems, a greenboot rollback after an image update
@@ -801,6 +826,13 @@ prevent in-place modification of an existing writable binary, replacement of the
 directory through a writable ancestor, or modification of the configuration
 file, which controls the provider's arguments and environment. The trusted-path
 rule covers all three.
+
+**Validating the configured path's components instead of passing the canonical
+path.** Requiring every component of the configured (pre-resolution) path to be
+root-owned would also close the symlink re-pointing gap, but it would reject the
+standard ostree and bootc layouts where system directories are reached through
+symlinks under `/var`. Passing the canonical path to kubelet closes the gap
+without constraining where the user writes the configured path.
 
 **Rejecting symlinks outright.** Refusing any symlink in either path would be
 simpler than resolving and checking targets, but standard image-based layouts

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -446,36 +446,27 @@ images on edge devices.
 
 #### Documentation requirements
 
-The following items must be covered by the end-user documentation and are
-tracked in the documentation epic OSDOCS-20657 (MicroShift-side input in
-OCPEDGE-2976):
+The following must be covered by the end-user documentation, tracked in
+OSDOCS-20657 (MicroShift-side input in OCPEDGE-2976):
 
-1. The two configuration keys, their semantics (both-or-neither, absolute paths,
-   file-or-directory for the config path), and the `microshift show-config`
-   behavior.
-2. A configuration guide for Amazon ECR: obtaining the upstream
+1. Configuration guide for Amazon ECR: obtaining the upstream
    `ecr-credential-provider` binary, placement, the `CredentialProviderConfig`
    format with a `matchImages` example, the device's AWS identity requirement,
-   and verification steps. A note that the same mechanism applies to GCR and ACR
-   with their respective provider binaries.
-3. The trust boundary: provider binaries run with kubelet's privileges and the
-   configuration file controls their arguments and environment; both paths,
-   their parent directories, and their contents must be root-owned and not
-   writable by group or others, and MicroShift refuses to start otherwise.
-   Recommended locations that satisfy this as installed. Kubelet is given the
-   symlink-resolved path.
-4. Image-based deployments: the binary must be present in every OS image build;
-   on rpm-ostree it must be delivered as an RPM; validation failures on a new
-   image cause greenboot rollback.
-5. `defaultCacheDuration` guidance: keep it comfortably shorter than the
-   registry token lifetime (Amazon ECR: 12 hours).
-6. Restart requirements: changes to the two keys or to the provider
-   configuration file require a MicroShift restart; replacing an existing
-   provider binary takes effect on the next uncached invocation.
-7. Upgrade and rollback: add the keys after upgrading to a version with the
-   feature. On a deployment without the feature, the keys are ignored with a
-   kubelet warning and private registry pulls fail until the previous workaround
-   is restored or the device is upgraded again.
+   the two MicroShift keys and their semantics, verification steps, and a note
+   that GCR and ACR work the same way with their own provider binaries. Include
+   that changing the keys or the provider config file requires a MicroShift
+   restart, and that keys should be added after upgrading.
+2. Trust boundary: provider binaries run with kubelet's privileges and the
+   config file controls their arguments and environment; both paths, their
+   parent directories, and their contents must be root-owned and not writable
+   by group or others, or MicroShift refuses to start. List locations that
+   satisfy this as installed.
+3. Image-based deployments: the credential provider binary must be present in
+   every OS image build (on rpm-ostree, delivered as the user's own RPM);
+   a missing binary on a new image fails validation and triggers greenboot
+   rollback — check the failed boot's journal.
+4. `defaultCacheDuration`: keep it comfortably shorter than the registry
+   token lifetime (Amazon ECR: 12 hours).
 
 ### Risks and Mitigations
 

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -28,7 +28,14 @@ see-also:
 
 ## Summary
 
-MicroShift runs kubelet as an embedded, in-process component. Kubelet's [image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/) feature (GA since Kubernetes 1.26) allows kubelet to obtain container registry credentials dynamically at image pull time by executing an external provider binary. The feature is enabled through two kubelet command-line flags, `--image-credential-provider-config` and `--image-credential-provider-bin-dir`, which have no equivalent in `KubeletConfiguration`. Because MicroShift exposes no kubelet command line and only maps its `kubelet:` configuration section into `KubeletConfiguration`, users currently have no way to enable this feature.
+MicroShift runs kubelet as an embedded, in-process component. Kubelet's
+[image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)
+feature (GA since Kubernetes 1.26) allows kubelet to obtain container registry credentials
+dynamically at image pull time by executing an external provider binary. The feature is
+enabled through two kubelet command-line flags, `--image-credential-provider-config` and
+`--image-credential-provider-bin-dir`, which have no equivalent in `KubeletConfiguration`.
+Because MicroShift exposes no kubelet command line and only maps its `kubelet:` configuration
+section into `KubeletConfiguration`, users currently have no way to enable this feature.
 
 This enhancement introduces two new optional keys, `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir`, under the existing `kubelet:` section of the MicroShift configuration file. MicroShift extracts these keys, validates them at startup, and applies them to the embedded kubelet's startup flags.
 
@@ -74,7 +81,18 @@ kubelet:
   imageCredentialProviderBinDir: /usr/libexec/microshift/credential-providers
 ```
 
-The `kubelet:` section is currently a schemaless map (`map[string]any`) whose contents are marshaled verbatim into the generated `KubeletConfiguration` file. The two new keys are kubelet **flags**, not `KubeletConfiguration` fields, so they cannot follow that path: if left in the map, kubelet's strict decoder rejects them, falls back to a lenient decoder, logs a warning, and silently ignores them. MicroShift will therefore read these two keys from the map during configuration processing into typed internal fields, validate them, and set them on the `KubeletFlags` struct used to start the embedded kubelet. When the remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the two reserved keys are filtered out. The `Config.Kubelet` map itself is not modified, so `microshift show-config` continues to display the keys exactly where the user set them. All other keys in the `kubelet:` section continue to be passed through to `KubeletConfiguration` unchanged.
+The `kubelet:` section is currently a schemaless map (`map[string]any`) whose contents are
+marshaled verbatim into the generated `KubeletConfiguration` file. The two new keys are
+kubelet **flags**, not `KubeletConfiguration` fields, so they cannot follow that path: if
+left in the map, kubelet's strict decoder rejects them, falls back to a lenient decoder,
+logs a warning, and silently ignores them. MicroShift will therefore read these two keys
+from the map during configuration processing into typed internal fields, validate them,
+and set them on the `KubeletFlags` struct used to start the embedded kubelet. When the
+remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the two reserved
+keys are filtered out. The `Config.Kubelet` map itself is not modified, so
+`microshift show-config` continues to display the keys exactly where the user set them.
+All other keys in the `kubelet:` section continue to be passed through to
+`KubeletConfiguration` unchanged.
 
 ### Workflow Description
 
@@ -100,9 +118,19 @@ kubelet:
 - `imageCredentialProviderConfigPath`: path to a kubelet `CredentialProviderConfig` file (JSON or YAML), or a directory of such files which kubelet merges in lexicographical order.
 - `imageCredentialProviderBinDir`: path to the directory containing credential provider plugin binaries.
 
-Both keys must be set together; setting only one is a validation error. Values must be absolute paths. An empty string is equivalent to omitting the key. Because user configuration files and drop-ins under `/etc/microshift/config.d/` are combined with a JSON merge patch, which merges maps key by key, the two keys may be set in different files (for example, one in `config.yaml` and the other in a drop-in) and are merged before validation.
+Both keys must be set together; setting only one is a validation error. Values must be
+absolute paths. An empty string is equivalent to omitting the key. Because user
+configuration files and drop-ins under `/etc/microshift/config.d/` are combined with a
+JSON merge patch, which merges maps key by key, the two keys may be set in different
+files (for example, one in `config.yaml` and the other in a drop-in) and are merged
+before validation.
 
-The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no change to the generated configuration schema or a schema version bump is required. As a consequence, the configuration generator cannot emit the keys as schema entries; they are documented through the doc comment on the `Kubelet` field, which the generator propagates into the sample configuration file and the configuration reference (see Sample configuration and documentation below).
+The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no change to
+the generated configuration schema or a schema version bump is required. As a consequence,
+the configuration generator cannot emit the keys as schema entries; they are documented
+through the doc comment on the `Kubelet` field, which the generator propagates into the
+sample configuration file and the configuration reference (see Sample configuration and
+documentation below).
 
 `microshift show-config --mode effective` displays the keys under `kubelet:` as set by the user, since the underlying map is not modified.
 
@@ -297,7 +325,13 @@ The explicit log line is the intended verification point for tests and support. 
 
 #### Sample configuration and documentation
 
-`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are generated by `scripts/generate-config.sh` and kept in sync by `scripts/verify/verify-config.sh`; they must not be edited by hand. Because the `kubelet:` section is schemaless, the generator cannot emit the two keys as schema entries. They are documented by extending the doc comment on the `Kubelet` field in `pkg/config/config.go` (shown above), which the generator propagates into both files. After changing the comment, run `make generate-config` and commit the regenerated files.
+`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are generated by
+`scripts/generate-config.sh` and kept in sync by `scripts/verify/verify-config.sh`;
+they must not be edited by hand. Because the `kubelet:` section is schemaless, the
+generator cannot emit the two keys as schema entries. They are documented by extending
+the doc comment on the `Kubelet` field in `pkg/config/config.go` (shown above), which
+the generator propagates into both files. After changing the comment, run
+`make generate-config` and commit the regenerated files.
 
 ### Risks and Mitigations
 
@@ -318,7 +352,11 @@ The explicit log line is the intended verification point for tests and support. 
 
 ### Drawbacks
 
-Special-casing two keys inside an otherwise schemaless passthrough section introduces a small amount of hidden behavior: two keys under `kubelet:` are treated differently from all others, and the generated schema cannot express them. This is accepted because the OCPSTRAT acceptance criteria specify placement under `kubelet:`, and the alternative of a generic flag passthrough was explicitly ruled out of scope.
+Special-casing two keys inside an otherwise schemaless passthrough section introduces a
+small amount of hidden behavior: two keys under `kubelet:` are treated differently from
+all others, and the generated schema cannot express them. This is accepted because the
+OCPSTRAT acceptance criteria specify placement under `kubelet:`, and the alternative of a
+generic flag passthrough was explicitly ruled out of scope.
 
 ## Test Plan
 
@@ -378,7 +416,13 @@ N/A
 
 When upgrading from a version without support for these keys, the keys remain unset unless the user adds them, and existing behavior is preserved. If a user pre-stages the keys in the configuration file before upgrading, the older version ignores them and the newer version activates them on its first start. No migration is required; the feature holds no persisted state.
 
-When downgrading to a version without support for these keys, the older version passes them through to the `KubeletConfiguration` file, where kubelet's lenient decoder logs a warning and ignores them. MicroShift starts normally with the credential provider feature inactive. Private registry image pulls will fail on the downgraded version until the previous workaround is restored or the device is upgraded again. The configuration file on disk is not modified. This behavior depends on kubelet retaining lenient decoding for `v1beta1`, which holds for all currently supported downgrade targets.
+When downgrading to a version without support for these keys, the older version passes
+them through to the `KubeletConfiguration` file, where kubelet's lenient decoder logs a
+warning and ignores them. MicroShift starts normally with the credential provider feature
+inactive. Private registry image pulls will fail on the downgraded version until the
+previous workaround is restored or the device is upgraded again. The configuration file
+on disk is not modified. This behavior depends on kubelet retaining lenient decoding for
+`v1beta1`, which holds for all currently supported downgrade targets.
 
 ## Version Skew Strategy
 N/A
@@ -407,6 +451,11 @@ Changes to the two configuration keys require a MicroShift restart. Changes to t
 
 **Separate top-level configuration section.** Placing the keys outside `kubelet:` (e.g. `imageCredentialProvider:`) would avoid special-casing keys inside the passthrough and would be picked up by schema generation. It was rejected because the OCPSTRAT acceptance criteria and the originating RFE specify placement under `kubelet:`, where users familiar with the upstream flags will look for them.
 
-**Removing the reserved keys from the `Config.Kubelet` map.** An earlier draft extracted the two keys by deleting them from (a copy of) the map during configuration processing. This was rejected because `microshift show-config --mode effective` marshals the `Config` struct, so the keys would disappear from its output. Filtering at the point where the map is marshaled into `KubeletConfiguration` keeps the effective configuration faithful to user input.
+**Removing the reserved keys from the `Config.Kubelet` map.** An earlier draft extracted
+the two keys by deleting them from (a copy of) the map during configuration processing.
+This was rejected because `microshift show-config --mode effective` marshals the `Config`
+struct, so the keys would disappear from its output. Filtering at the point where the map
+is marshaled into `KubeletConfiguration` keeps the effective configuration faithful to
+user input.
 
 **Packaging credential provider binaries.** Shipping `ecr-credential-provider` or equivalents as MicroShift RPMs was rejected. The binaries are cloud-specific, upstream-maintained, and have their own release and CVE cadence. Bundling them would make their lifecycle a MicroShift concern.

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -16,7 +16,7 @@ approvers:
 api-approvers:
   - None
 creation-date: 2026-09-02
-last-updated: 2026-09-02
+last-updated: 2026-09-03
 tracking-link:
   - https://redhat.atlassian.net/browse/OCPSTRAT-3456
 see-also:
@@ -30,50 +30,87 @@ see-also:
 
 MicroShift runs kubelet as an embedded, in-process component. Kubelet's
 [image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)
-feature (GA since Kubernetes 1.26) allows kubelet to obtain container registry credentials
-dynamically at image pull time by executing an external provider binary. The feature is
-enabled through two kubelet command-line flags, `--image-credential-provider-config` and
-`--image-credential-provider-bin-dir`, which have no equivalent in `KubeletConfiguration`.
-Because MicroShift exposes no kubelet command line and only maps its `kubelet:` configuration
-section into `KubeletConfiguration`, users currently have no way to enable this feature.
+feature (GA since Kubernetes 1.26) allows kubelet to obtain container registry
+credentials dynamically at image pull time by executing an external provider
+binary. The feature is enabled through two kubelet command-line flags,
+`--image-credential-provider-config` and `--image-credential-provider-bin-dir`,
+which have no equivalent in `KubeletConfiguration`. Because MicroShift exposes
+no kubelet command line and only maps its `kubelet:` configuration section into
+`KubeletConfiguration`, users currently have no way to enable this feature.
 
-This enhancement introduces two new optional keys, `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir`, under the existing `kubelet:` section of the MicroShift configuration file. MicroShift extracts these keys, validates them at startup, and applies them to the embedded kubelet's startup flags.
+This enhancement introduces two new optional keys,
+`imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir`, under
+the existing `kubelet:` section of the MicroShift configuration file. MicroShift
+reads these keys, validates them at startup, and applies them to the embedded
+kubelet's startup flags.
 
 ## Motivation
 
-Edge devices frequently pull application images from private, token-based registries such as Amazon ECR, Google Artifact Registry, or Azure Container Registry. These registries do not issue long-lived passwords; Amazon ECR, for example, issues authorization tokens that expire after 12 hours.
+Edge devices frequently pull application images from private, token-based
+registries such as Amazon ECR, Google Artifact Registry, or Azure Container
+Registry. These registries do not issue long-lived passwords; Amazon ECR, for
+example, issues authorization tokens that expire after 12 hours.
 
-Today, MicroShift users work around this with a systemd timer that periodically obtains a fresh token (e.g. `aws ecr get-login-password`) and rewrites it into CRI-O's static auth file. This workaround has known drawbacks:
+Today, MicroShift users work around this with a systemd timer that periodically
+obtains a fresh token (e.g. `aws ecr get-login-password`) and rewrites it into
+CRI-O's static auth file. This workaround has known drawbacks:
 
-- **Token gap:** if the timer fires late, or the token expires early, image pulls fail until the next refresh.
-- **Operational overhead:** an additional systemd unit and script must be maintained on every device.
-- **Not portable:** each registry type (ECR, GCR, ACR) requires its own bespoke script.
+- **Token gap:** if the timer fires late, or the token expires early, image
+  pulls fail until the next refresh.
+- **Operational overhead:** an additional systemd unit and script must be
+  maintained on every device.
+- **Not portable:** each registry type (ECR, GCR, ACR) requires its own
+  bespoke script.
 
-The kubelet image credential provider is the upstream-standard, cloud-vendor-recommended solution to this problem. A customer (see the linked RFE) requires it to pull private images from Amazon ECR on MicroShift edge devices.
+The kubelet image credential provider is the upstream-standard,
+cloud-vendor-recommended solution to this problem. A customer (see the linked
+RFE) requires it to pull private images from Amazon ECR on MicroShift edge
+devices.
 
 ### User Stories
 
-1. As a MicroShift administrator, I want to enable the kubelet image credential provider through the MicroShift configuration file so that my edge devices can authenticate to private registries at pull time without direct access to kubelet command-line flags.
-2. As a MicroShift administrator with devices pulling from Amazon ECR, I want kubelet to obtain short-lived registry credentials automatically so that I no longer maintain a per-device token rotation script.
-3. As a MicroShift administrator, I want MicroShift to fail to start with a clear error if the credential provider configuration points to paths that do not exist, so that misconfigurations are caught at startup rather than surfacing as opaque image pull failures.
+1. As a MicroShift administrator, I want to enable the kubelet image credential
+   provider through the MicroShift configuration file so that my edge devices
+   can authenticate to private registries at pull time without direct access to
+   kubelet command-line flags.
+2. As a MicroShift administrator with devices pulling from Amazon ECR, I want
+   kubelet to obtain short-lived registry credentials automatically so that I
+   no longer maintain a per-device token rotation script.
+3. As a MicroShift administrator, I want MicroShift to fail to start with a
+   clear error if the credential provider configuration points to paths that do
+   not exist or are unsafe, so that misconfigurations are caught at startup
+   rather than surfacing as opaque image pull failures.
 
 ### Goals
 
-1. Allow users to set `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir` under the `kubelet:` section of the MicroShift configuration file.
+1. Allow users to set `imageCredentialProviderConfigPath` and
+   `imageCredentialProviderBinDir` under the `kubelet:` section of the
+   MicroShift configuration file.
 2. Apply these settings to the embedded kubelet as startup flags when present.
-3. Preserve current behavior when the keys are not set, ensuring full backward compatibility.
-4. Validate the provided paths at startup and fail with a clear error message if they are invalid.
+3. Preserve current behavior when the keys are not set, ensuring full backward
+   compatibility.
+4. Validate the provided paths at startup and fail with a clear error message
+   if they are invalid or unsafe.
 
 ### Non-Goals
 
-1. A generic mechanism for passing arbitrary kubelet command-line flags through the MicroShift configuration file. This enhancement special-cases exactly two keys.
-2. Packaging or distributing credential provider binaries (e.g. `ecr-credential-provider`). These are standalone upstream binaries that users install separately.
-3. Validating the contents of the credential provider configuration file or the presence and executability of binaries in the bin directory. Kubelet performs this validation itself.
-4. Runtime reconfiguration without restarting MicroShift.
+1. A generic mechanism for passing arbitrary kubelet command-line flags through
+   the MicroShift configuration file. This enhancement special-cases exactly
+   two keys.
+2. Packaging or distributing credential provider binaries (e.g.
+   `ecr-credential-provider`). These are standalone upstream binaries that
+   users install separately, and which binary is needed depends on the registry
+   in use.
+3. Validating the contents of the credential provider configuration file, or
+   the presence, executability, or permissions of individual binaries inside
+   the bin directory. Kubelet validates the configuration file and the presence
+   of each configured binary when it registers providers.
+4. Runtime reconfiguration of the two keys without restarting MicroShift.
 
 ## Proposal
 
-Introduce two new optional keys under the existing `kubelet:` section of the MicroShift configuration file:
+Introduce two new optional keys under the existing `kubelet:` section of the
+MicroShift configuration file:
 
 ```yaml
 kubelet:
@@ -81,29 +118,58 @@ kubelet:
   imageCredentialProviderBinDir: /usr/libexec/microshift/credential-providers
 ```
 
-The `kubelet:` section is currently a schemaless map (`map[string]any`) whose contents are
-marshaled verbatim into the generated `KubeletConfiguration` file. The two new keys are
-kubelet **flags**, not `KubeletConfiguration` fields, so they cannot follow that path: if
-left in the map, kubelet's strict decoder rejects them, falls back to a lenient decoder,
-logs a warning, and silently ignores them. MicroShift will therefore read these two keys
-from the map during configuration processing into typed internal fields, validate them,
-and set them on the `KubeletFlags` struct used to start the embedded kubelet. When the
-remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the two reserved
-keys are filtered out. The `Config.Kubelet` map itself is not modified, so
-`microshift show-config` continues to display the keys exactly where the user set them.
-All other keys in the `kubelet:` section continue to be passed through to
-`KubeletConfiguration` unchanged.
+This follows the same pattern as user-provided certificates, the hosts file,
+and kustomize manifests: MicroShift consumes user-supplied content at configured
+paths and does not provide the content itself. The provider binary and its
+configuration file are supplied by the user because they depend on which
+registry is in use.
+
+The `kubelet:` section is currently a schemaless map (`map[string]any`) whose
+contents are marshaled verbatim into the generated `KubeletConfiguration` file.
+The two new keys are kubelet **flags**, not `KubeletConfiguration` fields, so
+they cannot follow that path: if left in the map, kubelet's strict decoder
+rejects them, falls back to a lenient decoder, logs a warning, and silently
+ignores them. MicroShift will therefore read these two keys from the map during
+configuration processing into typed internal fields, validate them, and set
+them on the `KubeletFlags` struct used to start the embedded kubelet. When the
+remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the
+two reserved keys are filtered out. The `Config.Kubelet` map itself is not
+modified, so `microshift show-config` continues to display the keys exactly
+where the user set them. All other keys in the `kubelet:` section continue to
+be passed through to `KubeletConfiguration` unchanged.
 
 ### Workflow Description
 
-1. MicroShift starts up and loads its configuration file. The `kubelet:` section is read into `Config.Kubelet` as a schemaless map.
-2. During computed-value processing, MicroShift reads `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir` from the map into typed internal fields. The map is not modified. An empty string is treated as unset.
-3. During validation, MicroShift checks that either both keys are set or neither is, that both paths are absolute, that `imageCredentialProviderConfigPath` exists as a file or directory, and that `imageCredentialProviderBinDir` exists and is a directory.
-4. If validation fails, MicroShift exits with a descriptive error message naming the field and the path.
-5. If validation succeeds, the kubelet component sets `KubeletFlags.ImageCredentialProviderConfigPath` and `KubeletFlags.ImageCredentialProviderBinDir` before starting the embedded kubelet, and logs an informational message recording the configured values.
-6. The keys in the `kubelet:` section other than the two reserved keys are marshaled into the `KubeletConfiguration` file as today.
-7. At image pull time, kubelet consults the credential provider configuration; for images matching a configured provider, kubelet executes the provider binary, caches the returned credentials in memory for the returned or default cache duration, and passes them to CRI-O with the pull request.
-8. If the keys are not set, kubelet starts without credential provider configuration, identical to current behavior.
+1. MicroShift starts up and loads its configuration file and drop-ins. The
+   `kubelet:` section is read into `Config.Kubelet` as a schemaless map.
+2. During computed-value processing, MicroShift reads
+   `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir` from
+   the map into typed internal fields. The map is not modified. An empty string
+   or explicit `null` is treated as unset.
+3. During validation, MicroShift checks that either both keys are set or
+   neither is, that both paths are absolute, that
+   `imageCredentialProviderConfigPath` exists as a regular file or directory,
+   and that `imageCredentialProviderBinDir` exists, is a directory, is owned by
+   root, and is not writable by group or others.
+4. If validation fails, MicroShift exits with a descriptive error message
+   naming the field and the path.
+5. If validation succeeds, the kubelet component sets
+   `KubeletFlags.ImageCredentialProviderConfigPath` and
+   `KubeletFlags.ImageCredentialProviderBinDir` before starting the embedded
+   kubelet, and logs an informational message recording the configured values.
+6. The keys in the `kubelet:` section other than the two reserved keys are
+   marshaled into the `KubeletConfiguration` file as today.
+7. Kubelet reads the provider configuration file and verifies that each
+   configured provider binary exists in the bin directory. Failures here are
+   kubelet startup errors, reported in the MicroShift journal.
+8. At image pull time, kubelet consults the credential provider configuration;
+   for images matching a configured provider, kubelet executes the provider
+   binary, caches the returned credentials in memory for the returned or
+   default cache duration, and passes them to CRI-O with the pull request.
+   CRI-O uses credentials supplied by kubelet in preference to its own auth
+   files; images that match no provider use CRI-O's auth files as today.
+9. If the keys are not set, kubelet starts without credential provider
+   configuration, identical to current behavior.
 
 ### API Extensions
 
@@ -115,26 +181,34 @@ kubelet:
   imageCredentialProviderBinDir: <string>      # optional, default: not set
 ```
 
-- `imageCredentialProviderConfigPath`: path to a kubelet `CredentialProviderConfig` file (JSON or YAML), or a directory of such files which kubelet merges in lexicographical order.
-- `imageCredentialProviderBinDir`: path to the directory containing credential provider plugin binaries.
+- `imageCredentialProviderConfigPath`: absolute path to a kubelet
+  `CredentialProviderConfig` file (JSON or YAML), or a directory of such files
+  which kubelet merges in lexicographical order.
+- `imageCredentialProviderBinDir`: absolute path to the directory containing
+  credential provider plugin binaries. Must be owned by root and not writable
+  by group or others.
 
-Both keys must be set together; setting only one is a validation error. Values must be
-absolute paths. An empty string is equivalent to omitting the key. Because user
-configuration files and drop-ins under `/etc/microshift/config.d/` are combined with a
-JSON merge patch, which merges maps key by key, the two keys may be set in different
-files (for example, one in `config.yaml` and the other in a drop-in) and are merged
-before validation.
+Both keys must be set together; setting only one is a validation error. An
+empty string or explicit `null` is equivalent to omitting the key. Because user
+configuration files and drop-ins under `/etc/microshift/config.d/` are combined
+with a JSON merge patch, which merges maps key by key, the two keys may be set
+in different files (for example, one in `config.yaml` and the other in a
+drop-in) and are merged before validation. Treating `null` as unset is
+consistent with merge-patch semantics, where `null` removes a key.
 
-The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no change to
-the generated configuration schema or a schema version bump is required. As a consequence,
-the configuration generator cannot emit the keys as schema entries; they are documented
-through the doc comment on the `Kubelet` field, which the generator propagates into the
-sample configuration file and the configuration reference (see Sample configuration and
-documentation below).
+The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no
+change to the generated configuration schema or a schema version bump is
+required. As a consequence, the configuration generator cannot emit the keys as
+schema entries; they are documented through the doc comment on the `Kubelet`
+field, which the generator propagates into the sample configuration file and
+the configuration reference (see Sample configuration and documentation below).
 
-`microshift show-config --mode effective` displays the keys under `kubelet:` as set by the user, since the underlying map is not modified.
+`microshift show-config --mode effective` displays the keys under `kubelet:` as
+set by the user, since the underlying map is not modified.
 
-The credential provider configuration file itself follows the upstream `kubelet.config.k8s.io/v1` `CredentialProviderConfig` format. For example, for Amazon ECR:
+The credential provider configuration file itself follows the upstream
+`kubelet.config.k8s.io/v1` `CredentialProviderConfig` format. For example, for
+Amazon ECR:
 
 ```yaml
 apiVersion: kubelet.config.k8s.io/v1
@@ -165,18 +239,23 @@ N/A
 
 #### Config struct changes
 
-Add two internal, non-serialized fields to the `Config` struct in `pkg/config/config.go`. These follow the existing convention for internal fields (e.g. `userSettings`) and are populated by reading the schemaless map rather than by direct decoding. The `Kubelet` field's doc comment is extended because the configuration generator propagates it into the sample configuration and reference documentation:
+Add two internal, non-serialized fields to the `Config` struct in
+`pkg/config/config.go`, following the existing convention for internal fields
+(e.g. `userSettings`). The `Kubelet` field's doc comment is extended to
+describe the two keys, because the configuration generator propagates it into
+the sample configuration and reference documentation:
 
 ```go
-type Config struct {
-    // ... existing fields ...
-
-    // Settings specified in this section are transferred as-is into the Kubelet config,
-    // with two exceptions that are applied as kubelet startup flags instead:
-    //   imageCredentialProviderConfigPath: absolute path to a kubelet CredentialProviderConfig
-    //     file, or a directory of such files. Enables the kubelet image credential provider.
-    //   imageCredentialProviderBinDir: absolute path to the directory containing credential
-    //     provider plugin binaries. Must be set together with imageCredentialProviderConfigPath.
+    // Settings specified in this section are transferred as-is into the
+    // Kubelet config, with two exceptions that are applied as kubelet startup
+    // flags instead:
+    //   imageCredentialProviderConfigPath: absolute path to a kubelet
+    //     CredentialProviderConfig file, or a directory of such files. Enables
+    //     the kubelet image credential provider.
+    //   imageCredentialProviderBinDir: absolute path to the directory
+    //     containing credential provider plugin binaries. Must be owned by
+    //     root and not writable by group or others. Must be set together with
+    //     imageCredentialProviderConfigPath.
     // +kubebuilder:validation:Schemaless
     Kubelet map[string]any `json:"kubelet"`
 
@@ -184,217 +263,322 @@ type Config struct {
     // These are kubelet flags, not KubeletConfiguration fields.
     KubeletImageCredentialProviderConfigPath string `json:"-"`
     KubeletImageCredentialProviderBinDir     string `json:"-"`
-}
 ```
 
-Populating internal fields from the schemaless `Kubelet` map is a new pattern in the MicroShift configuration code. The map has always been passed through untouched, and this enhancement preserves that: the map is read, not modified.
+Populating internal fields from the schemaless `Kubelet` map is a new pattern
+in the MicroShift configuration code. The map has always been passed through
+untouched, and this enhancement preserves that: the map is read, not modified.
 
 #### Config extraction
 
-Extend `updateComputedValues()` in `pkg/config/config.go` to read the two keys. The map is not modified, so `incorporateUserSettings()` (which assigns `c.Kubelet = u.Kubelet`) and `microshift show-config` are unaffected:
+`updateComputedValues()` in `pkg/config/config.go` reads the two reserved keys
+into the typed fields. A present key whose value is a non-string (other than
+`null`) is an error. A helper returns the passthrough view of the map for
+kubelet:
 
 ```go
-const (
-    kubeletImageCredentialProviderConfigPathKey = "imageCredentialProviderConfigPath"
-    kubeletImageCredentialProviderBinDirKey     = "imageCredentialProviderBinDir"
-)
-
-// kubeletReservedKeys are keys under `kubelet:` that are applied as kubelet
-// startup flags rather than passed through to KubeletConfiguration.
-var kubeletReservedKeys = []string{
-    kubeletImageCredentialProviderConfigPathKey,
-    kubeletImageCredentialProviderBinDirKey,
-}
-
-func (c *Config) readKubeletCredentialProviderSettings() error {
-    for key, dst := range map[string]*string{
-        kubeletImageCredentialProviderConfigPathKey: &c.KubeletImageCredentialProviderConfigPath,
-        kubeletImageCredentialProviderBinDirKey:     &c.KubeletImageCredentialProviderBinDir,
-    } {
-        raw, ok := c.Kubelet[key]
-        if !ok || raw == nil {
-            continue
-        }
-        s, ok := raw.(string)
-        if !ok {
-            return fmt.Errorf("kubelet.%s must be a string, got %T", key, raw)
-        }
-        *dst = s
-    }
-    return nil
-}
-
 // KubeletPassthrough returns the user-provided kubelet settings that are
-// transferred into KubeletConfiguration, excluding reserved keys.
-func (c *Config) KubeletPassthrough() map[string]any {
-    if c.Kubelet == nil {
-        return nil
-    }
-    out := make(map[string]any, len(c.Kubelet))
-    for k, v := range c.Kubelet {
-        out[k] = v
-    }
-    for _, k := range kubeletReservedKeys {
-        delete(out, k)
-    }
-    return out
-}
+// transferred into KubeletConfiguration, excluding the reserved keys.
+func (c *Config) KubeletPassthrough() map[string]any
 ```
 
-`updateComputedValues()` calls `readKubeletCredentialProviderSettings()` before returning. `generateConfig()` in `pkg/node/kubelet.go` is changed to marshal `cfg.KubeletPassthrough()` instead of `cfg.Kubelet`, so the reserved keys never reach the `KubeletConfiguration` file. The list of reserved keys lives only in the `config` package.
+`generateConfig()` in `pkg/node/kubelet.go` marshals
+`cfg.KubeletPassthrough()` instead of `cfg.Kubelet`, so the reserved keys
+never reach the `KubeletConfiguration` file. The list of reserved keys lives
+only in the `config` package.
 
 #### Config validation
 
-Extend `validate()` in `pkg/config/config.go`:
+`validate()` in `pkg/config/config.go` is extended with the following rules,
+in order:
 
-```go
-func (c *Config) validateKubeletCredentialProvider() error {
-    configPath := c.KubeletImageCredentialProviderConfigPath
-    binDir := c.KubeletImageCredentialProviderBinDir
-
-    if configPath == "" && binDir == "" {
-        return nil
-    }
-    if configPath == "" || binDir == "" {
-        return fmt.Errorf("kubelet.%s and kubelet.%s must be set together",
-            kubeletImageCredentialProviderConfigPathKey, kubeletImageCredentialProviderBinDirKey)
-    }
-    if !filepath.IsAbs(configPath) {
-        return fmt.Errorf("kubelet.%s (%q) must be an absolute path",
-            kubeletImageCredentialProviderConfigPathKey, configPath)
-    }
-    if !filepath.IsAbs(binDir) {
-        return fmt.Errorf("kubelet.%s (%q) must be an absolute path",
-            kubeletImageCredentialProviderBinDirKey, binDir)
-    }
-
-    if _, err := os.Stat(configPath); err != nil {
-        return fmt.Errorf("error validating kubelet.%s (%q): file or directory does not exist: %w",
-            kubeletImageCredentialProviderConfigPathKey, configPath, err)
-    }
-
-    info, err := os.Stat(binDir)
-    if err != nil {
-        return fmt.Errorf("error validating kubelet.%s (%q): directory does not exist: %w",
-            kubeletImageCredentialProviderBinDirKey, binDir, err)
-    }
-    if !info.IsDir() {
-        return fmt.Errorf("error validating kubelet.%s (%q): not a directory",
-            kubeletImageCredentialProviderBinDirKey, binDir)
-    }
-
-    return nil
-}
-```
-
-Validation rules:
-
-- Both-or-neither: setting only one of the two keys is an error. Kubelet requires both to activate the feature; failing early in MicroShift produces a clearer message than kubelet's own error. An empty string is treated as unset.
-- Both paths must be absolute. A relative path would be resolved against the MicroShift process working directory, which is not a stable location.
-- `imageCredentialProviderConfigPath` must exist. A file or a directory is accepted, matching upstream kubelet semantics.
+- Neither key set: valid, feature inactive.
+- Exactly one key set: error. Kubelet requires both to activate the feature;
+  failing early in MicroShift produces a clearer message than kubelet's own
+  error.
+- Either path not absolute: error. A relative path would be resolved against
+  the MicroShift process working directory, which is not a stable location.
+- `imageCredentialProviderConfigPath` must exist and be a regular file or a
+  directory. Other file types (devices, sockets, FIFOs) are rejected. A
+  directory is accepted to match upstream kubelet semantics.
 - `imageCredentialProviderBinDir` must exist and be a directory.
-- Error messages name the field and the path.
+- `imageCredentialProviderBinDir` must be owned by root (uid 0) and must not
+  have group or other write permission. Credential provider binaries execute
+  with kubelet's privileges, so a directory that other users can write to is a
+  local privilege escalation vector. The check is applied to the directory
+  because directory permissions govern who can add or replace binaries; kubelet
+  resolves each binary at invocation time, so per-binary checks at startup
+  would not provide durable protection.
 
-MicroShift deliberately does **not** validate the contents of the credential provider configuration file, nor the presence or executability of binaries inside the bin directory. Kubelet validates these at startup and its errors surface in the journal. Duplicating that validation would require keeping MicroShift in sync with upstream kubelet behavior.
+Error messages name the field and the path, e.g.
+`error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"): must be owned by root and not writable by group or others`.
 
-Optionally, MicroShift may emit a warning via `AddWarning()` if the bin directory is writable by users other than root, since credential provider binaries execute with kubelet's privileges. This is a warning, not a startup failure.
+MicroShift deliberately does **not** validate the contents of the credential
+provider configuration file, nor the presence or executability of individual
+binaries. Kubelet validates the configuration file and checks that each
+configured provider binary exists (`exec.LookPath`) when it registers
+providers; failures surface as kubelet startup errors in the journal.
+Duplicating that validation would require keeping MicroShift in sync with
+upstream kubelet behavior.
 
 #### Kubelet flag injection
 
-Extend `configure()` in `pkg/node/kubelet.go`. The `KubeletFlags` struct from the vendored `k8s.io/kubernetes/cmd/kubelet/app/options` package already exposes the required fields, and they are passed through to `NewMainKubelet()` by the existing in-process startup path. No new plumbing is required:
+`configure()` in `pkg/node/kubelet.go` sets the two fields on `KubeletFlags`.
+The `KubeletFlags` struct from the vendored
+`k8s.io/kubernetes/cmd/kubelet/app/options` package already exposes them, and
+the existing in-process startup path passes them through to
+`NewMainKubelet()`; no new plumbing is required:
 
 ```go
-func (s *KubeletServer) configure(cfg *config.Config) {
-    // ... existing code ...
-    kubeletFlags := kubeletoptions.NewKubeletFlags()
-    // ... existing flag assignments ...
-
     if cfg.KubeletImageCredentialProviderConfigPath != "" {
-        kubeletFlags.ImageCredentialProviderConfigPath = cfg.KubeletImageCredentialProviderConfigPath
-        kubeletFlags.ImageCredentialProviderBinDir = cfg.KubeletImageCredentialProviderBinDir
-        klog.InfoS("Kubelet image credential provider enabled",
+        kubeletFlags.ImageCredentialProviderConfigPath =
+            cfg.KubeletImageCredentialProviderConfigPath
+        kubeletFlags.ImageCredentialProviderBinDir =
+            cfg.KubeletImageCredentialProviderBinDir
+        klog.InfoS("Kubelet image credential provider configured",
             "configPath", cfg.KubeletImageCredentialProviderConfigPath,
             "binDir", cfg.KubeletImageCredentialProviderBinDir)
     }
-
-    // ... existing code ...
-}
 ```
 
-The explicit log line is the intended verification point for tests and support. Because MicroShift calls `kubelet.Run()` directly rather than through kubelet's cobra command, kubelet's usual `FLAG: --image-credential-provider-config=...` startup lines are never emitted, and kubelet's own credential provider code logs nothing at default verbosity when plugins are registered.
+The log line records that MicroShift applied the configuration to kubelet. It
+is emitted before kubelet registers providers, so it does not by itself
+indicate that the providers are usable; a missing or non-executable provider
+binary is reported by kubelet as a startup error after this line. Because
+MicroShift calls `kubelet.Run()` directly rather than through kubelet's cobra
+command, kubelet's usual `FLAG: --image-credential-provider-config=...` startup
+lines are never emitted, and kubelet's own credential provider code logs
+nothing at default verbosity on successful registration. The MicroShift log
+line is therefore the authoritative signal that the keys were applied.
 
 #### Sample configuration and documentation
 
-`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are generated by
-`scripts/generate-config.sh` and kept in sync by `scripts/verify/verify-config.sh`;
-they must not be edited by hand. Because the `kubelet:` section is schemaless, the
-generator cannot emit the two keys as schema entries. They are documented by extending
-the doc comment on the `Kubelet` field in `pkg/config/config.go` (shown above), which
-the generator propagates into both files. After changing the comment, run
+`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are
+generated by `scripts/generate-config.sh` and kept in sync by
+`scripts/verify/verify-config.sh`; they must not be edited by hand. Because
+the `kubelet:` section is schemaless, the generator cannot emit the two keys as
+schema entries. They are documented by extending the doc comment on the
+`Kubelet` field in `pkg/config/config.go` (shown above), which the generator
+propagates into both files. After changing the comment, run
 `make generate-config` and commit the regenerated files.
+
+#### Image-based deployments (bootc and rpm-ostree)
+
+The feature behaves identically across RPM, rpm-ostree, and bootc
+installations; the configuration and kubelet startup code paths do not branch
+on install type. What differs is how the user-supplied files reach the device.
+On image-based systems `/usr` is read-only at runtime, so the credential
+provider binary must be included in the OS image, while `/etc` content (the
+MicroShift configuration or a `/etc/microshift/config.d/` drop-in, and the
+provider configuration file) may be included in the image or written after
+deployment.
+
+- On bootc, the user adds the binary in their Containerfile, e.g.
+  `COPY --chmod=755 ecr-credential-provider /usr/libexec/microshift/credential-providers/`.
+  Because `/usr` is replaced on every image update while `/etc` persists, every
+  subsequent image must also contain the binary; otherwise startup validation
+  fails on the new image and greenboot rolls the device back to the previous
+  one.
+- On rpm-ostree systems built with Image Builder (RHEL 9 only; rpm-ostree is
+  not available on RHEL 10), blueprint file customizations cannot place content
+  under `/usr` and cannot carry binary content, so the binary must be delivered
+  as an RPM added to the blueprint. Packaging the provider binary is out of
+  scope for MicroShift (see Non-Goals); users of rpm-ostree deployments must
+  build or obtain such an RPM themselves.
+
+MicroShift component images that are embedded in an OS image are never pulled
+from a registry and do not involve the credential provider. The feature applies
+to images that are pulled at runtime, which is the normal case for application
+images on edge devices.
+
+#### Documentation requirements
+
+The following items must be covered by the end-user documentation and are
+tracked in the documentation epic OSDOCS-20657 (MicroShift-side input in
+OCPEDGE-2976):
+
+1. The two configuration keys, their semantics (both-or-neither, absolute
+   paths, file-or-directory for the config path), and the
+   `microshift show-config` behavior.
+2. A configuration guide for Amazon ECR: obtaining the upstream
+   `ecr-credential-provider` binary, placement, the
+   `CredentialProviderConfig` format with a `matchImages` example, the
+   device's AWS identity requirement, and verification steps. A note that the
+   same mechanism applies to GCR and ACR with their respective provider
+   binaries.
+3. The trust boundary: provider binaries run with kubelet's privileges; the bin
+   directory must be root-owned and not writable by group or others, and
+   MicroShift refuses to start otherwise.
+4. Image-based deployments: the binary must be present in every OS image
+   build; on rpm-ostree it must be delivered as an RPM; validation failures on
+   a new image cause greenboot rollback.
+5. `defaultCacheDuration` guidance: keep it comfortably shorter than the
+   registry token lifetime (Amazon ECR: 12 hours).
+6. Restart requirements: changes to the two keys or to the provider
+   configuration file require a MicroShift restart; replacing an existing
+   provider binary takes effect on the next uncached invocation.
+7. Rollback behavior: on a deployment without this feature, the keys are
+   ignored with a kubelet warning and private registry pulls fail until the
+   previous workaround is restored or the device is upgraded again.
 
 ### Risks and Mitigations
 
-**Risk:** A user places the keys under `kubelet:` in a MicroShift version that supports the feature, but a typo in the key name (e.g. `imageCredentialProviderConfig`) causes the key to fall through to the `KubeletConfiguration` passthrough, where kubelet's lenient decoder silently ignores it. The feature appears enabled but is inert.
-**Mitigation:** Kubelet logs a lenient-decode warning in the journal. A future improvement could warn on near-miss keys. This risk is not specific to this enhancement; it applies to any misspelled key in the passthrough.
+**Risk:** A user places the keys under `kubelet:` in a MicroShift version that
+supports the feature, but a typo in the key name (e.g.
+`imageCredentialProviderConfig`) causes the key to fall through to the
+`KubeletConfiguration` passthrough, where kubelet's lenient decoder silently
+ignores it. The feature appears enabled but is inert.
+**Mitigation:** Kubelet logs a lenient-decode warning in the journal. A future
+improvement could warn on near-miss keys. This risk is not specific to this
+enhancement; it applies to any misspelled key in the passthrough.
 
-**Risk:** Kubelet's lenient decoding of unknown `KubeletConfiguration` fields is marked upstream as temporary, to be removed when `v1beta1` support is dropped. When that happens, any unknown key left in the passthrough becomes a hard kubelet startup failure.
-**Mitigation:** This enhancement extracts its two keys in the MicroShift configuration layer before the map is marshaled, so it never depends on lenient decoding. The general passthrough exposure predates this enhancement.
+**Risk:** Kubelet's lenient decoding of unknown `KubeletConfiguration` fields
+is marked upstream as temporary, to be removed when `v1beta1` support is
+dropped. When that happens, any unknown key left in the passthrough becomes a
+hard kubelet startup failure.
+**Mitigation:** This enhancement filters its two keys out of the passthrough
+before the map is marshaled, so it never depends on lenient decoding. The
+general passthrough exposure predates this enhancement.
 
-**Risk:** Credential provider binaries execute with kubelet's (root) privileges. A bin directory writable by unprivileged users is a local privilege escalation vector.
-**Mitigation:** User documentation must state this trust boundary and recommend a root-owned bin directory that is not writable by other users. MicroShift may additionally emit a startup warning for world-writable bin directories.
+**Risk:** Credential provider binaries execute with kubelet's (root)
+privileges. A bin directory writable by unprivileged users would allow a local
+user to replace a provider binary and gain root execution during a matching
+image pull.
+**Mitigation:** MicroShift refuses to start if the bin directory is not owned
+by root or is writable by group or others (see Config validation).
+Documentation states the trust boundary. Individual binaries are not checked
+because kubelet resolves them at invocation time; the directory check is what
+durably controls who can place binaries.
 
-**Risk:** On image-based (ostree/bootc) systems, a validation failure at startup causes greenboot health checks to fail, triggering an automatic rollback to the previous deployment.
-**Mitigation:** This is the intended composition of fail-fast validation with greenboot: the device returns to a known-good state rather than remaining unhealthy. Documentation must note that the provider config file and bin directory must exist in the image before the configuration keys are enabled.
+**Risk:** On image-based (ostree/bootc) systems, a validation failure at
+startup causes greenboot health checks to fail, triggering an automatic
+rollback to the previous deployment.
+**Mitigation:** This is the intended composition of fail-fast validation with
+greenboot: the device returns to a known-good state rather than remaining
+unhealthy. Documentation notes that the provider config file and bin directory
+must exist in the image before the configuration keys are enabled.
 
-**Risk:** Users may set `defaultCacheDuration` in the provider configuration longer than the registry token lifetime, causing kubelet to serve expired credentials.
-**Mitigation:** Documentation for Amazon ECR (12-hour tokens) must recommend a cache duration comfortably shorter than the token lifetime.
+**Risk:** On image-based systems, a user rebuilds the OS image without the
+provider binary while the configuration keys persist in `/etc`. The new image
+fails startup validation and is rolled back by greenboot, which may not be
+immediately attributed to the missing binary.
+**Mitigation:** Documentation for image-based deployments states that the
+binary must be present in every image build. The validation error names the bin
+directory path, and the failure is visible in the journal of the failed boot.
+
+**Risk:** Users may set `defaultCacheDuration` in the provider configuration
+longer than the registry token lifetime, causing kubelet to serve expired
+credentials.
+**Mitigation:** Documentation for Amazon ECR (12-hour tokens) recommends a
+cache duration comfortably shorter than the token lifetime.
 
 ### Drawbacks
 
-Special-casing two keys inside an otherwise schemaless passthrough section introduces a
-small amount of hidden behavior: two keys under `kubelet:` are treated differently from
-all others, and the generated schema cannot express them. This is accepted because the
-OCPSTRAT acceptance criteria specify placement under `kubelet:`, and the alternative of a
-generic flag passthrough was explicitly ruled out of scope.
+Special-casing two keys inside an otherwise schemaless passthrough section
+introduces a small amount of hidden behavior: two keys under `kubelet:` are
+treated differently from all others, and the generated schema cannot express
+them. This is accepted because the OCPSTRAT acceptance criteria specify
+placement under `kubelet:`, and the alternative of a generic flag passthrough
+was explicitly ruled out of scope.
+
+Enforcing ownership and permissions on the bin directory goes beyond what
+upstream kubelet enforces. It may reject a small number of unusual but
+deliberate layouts. This is accepted because no legitimate layout for
+root-executed plugins should be writable by other users.
 
 ## Test Plan
 
 ### Unit Tests
 
 - Extraction: both keys present, both absent, only one present.
-- Extraction: non-string values rejected with an error.
-- Extraction: `c.Kubelet` is not modified; `KubeletPassthrough()` returns the map without the two reserved keys and with all other keys intact.
+- Extraction: non-string values rejected with an error; explicit `null`
+  treated as unset.
+- Extraction: `c.Kubelet` is not modified; `KubeletPassthrough()` returns the
+  map without the two reserved keys and with all other keys intact.
 - Extraction: empty string values are treated as unset.
 - Validation: only one key set fails with the both-or-neither error.
 - Validation: relative paths are rejected.
-- Validation: `imageCredentialProviderConfigPath` missing fails; existing file passes; existing directory passes.
-- Validation: `imageCredentialProviderBinDir` missing fails; path is a file fails; existing directory passes.
+- Validation: `imageCredentialProviderConfigPath` missing fails; existing
+  regular file passes; existing directory passes; a non-regular path (e.g. a
+  FIFO) fails.
+- Validation: `imageCredentialProviderBinDir` missing fails; path is a file
+  fails; existing directory passes.
+- Validation: `imageCredentialProviderBinDir` not owned by root fails;
+  group-writable fails; world-writable fails; root-owned `0755` passes.
 - Validation: neither key set passes (backward compatibility).
-- `generateConfig()`: the two keys never appear in the generated `KubeletConfiguration` YAML; other user-provided keys still do.
-- `configure()`: `KubeletFlags` carries both values when set, and empty values when unset.
+- `generateConfig()`: the two keys never appear in the generated
+  `KubeletConfiguration` YAML; other user-provided keys still do.
+- `configure()`: `KubeletFlags` carries both values when set, and empty values
+  when unset.
 
 ### Integration Tests (Robot Framework)
 
-- Default behavior: no keys set, MicroShift starts, the "Kubelet image credential provider enabled" log line is absent.
-- Valid configuration: both keys set to an existing file and directory via drop-in, restart, verify MicroShift starts and the journal contains the "Kubelet image credential provider enabled" log line with the configured paths.
-- `show-config`: verify `microshift show-config --mode effective` displays both keys under `kubelet:`.
-- Split configuration: one key in `config.yaml` and the other in a `/etc/microshift/config.d/` drop-in, verify the merged configuration is valid and MicroShift starts.
-- Empty strings: both keys set to `""`, verify behavior is identical to omitting them.
-- Relative path: verify MicroShift fails to start with an error naming the field.
-- Directory config path: `imageCredentialProviderConfigPath` set to a directory, verify MicroShift starts.
-- Missing config path: verify MicroShift fails to start with an error naming the field and path in the journal.
-- Missing bin directory: verify MicroShift fails to start with an error naming the field and path in the journal.
-- Only one key set: verify MicroShift fails to start with the both-or-neither error.
+- Default behavior: no keys set, MicroShift starts, the "Kubelet image
+  credential provider configured" log line is absent.
+- Valid configuration: both keys set to an existing file and directory via
+  drop-in, restart, verify MicroShift starts and the journal contains the
+  "Kubelet image credential provider configured" log line with the configured
+  paths.
+- `show-config`: verify `microshift show-config --mode effective` displays
+  both keys under `kubelet:`.
+- Split configuration: one key in `config.yaml` and the other in a
+  `/etc/microshift/config.d/` drop-in, verify the merged configuration is
+  valid and MicroShift starts.
+- Empty strings: both keys set to `""`, verify behavior is identical to
+  omitting them.
+- Relative path: verify MicroShift fails to start with an error naming the
+  field.
+- Directory config path: `imageCredentialProviderConfigPath` set to a
+  directory, verify MicroShift starts.
+- Missing config path: verify MicroShift fails to start with an error naming
+  the field and path in the journal.
+- Missing bin directory: verify MicroShift fails to start with an error naming
+  the field and path in the journal.
+- Unsafe bin directory: bin directory world-writable, verify MicroShift fails
+  to start with an error naming the field and path; restore `0755`, verify
+  MicroShift starts.
+- Only one key set: verify MicroShift fails to start with the both-or-neither
+  error.
+- Missing provider binary: valid keys, provider configuration naming a binary
+  that is not present in the bin directory, verify the "configured" log line
+  is present and kubelet reports a startup error for the missing plugin binary
+  in the journal.
 - Recovery: restore valid configuration, restart, verify MicroShift starts.
-- Downgrade: configuration with the new keys on a MicroShift version without the feature, verify MicroShift starts with a kubelet lenient-decode warning and the feature inert.
-- End-to-end pull: deploy a mock credential provider (an executable implementing the `credentialprovider.kubelet.k8s.io/v1` exec contract returning static credentials) and a local password-protected registry, deploy a pod referencing a private image with no CRI-O auth pre-populated, verify the pod reaches Running.
-- End-to-end negative: mock provider returns incorrect credentials, verify the pod reaches ImagePullBackOff.
-- Coexistence with CRI-O auth: with the credential provider configured and CRI-O auth also pre-populated for the same registry, verify the pull succeeds.
-- Mixed registries: pods referencing an image from a credential-provider registry and an image from a registry using CRI-O static auth, verify both pulls succeed independently.
-- Caching: with a short `defaultCacheDuration`, verify a second pull within the cache window does not re-invoke the provider and a pull after expiry does.
+- Rollback: on an image-based system, configuration with the new keys present
+  in `/etc`, roll back to a deployment without the feature, verify MicroShift
+  starts with a kubelet lenient-decode warning and the feature inert; roll
+  forward, verify the feature is active.
+- End-to-end pull: deploy a mock credential provider (an executable
+  implementing the `credentialprovider.kubelet.k8s.io/v1` exec contract
+  returning static credentials) and a local password-protected registry,
+  deploy a pod referencing a private image with no CRI-O auth pre-populated,
+  verify the pod reaches Running.
+- End-to-end negative: mock provider returns incorrect credentials, verify the
+  pod reaches ImagePullBackOff.
+- Coexistence with CRI-O auth: with the credential provider configured and
+  CRI-O auth also pre-populated for the same registry, verify the pull
+  succeeds.
+- Mixed registries: pods referencing an image from a credential-provider
+  registry and an image from a registry using CRI-O static auth, verify both
+  pulls succeed independently.
+- Caching: with a short `defaultCacheDuration`, verify a second pull within
+  the cache window does not re-invoke the provider and a pull after expiry
+  does.
+- Binary replacement without restart: replace the mock provider binary in
+  place, verify the next uncached invocation runs the new binary without
+  restarting MicroShift.
+- bootc: a bootc test image layer that copies the mock provider into
+  `/usr/libexec/microshift/credential-providers/` and the configuration
+  drop-in and provider configuration into `/etc/microshift/` at image build
+  time, following the existing `test/image-blueprints-bootc` layering; boot
+  the image and run the end-to-end pull scenarios above. This exercises the
+  read-only `/usr` placement that distinguishes image-based deployments from
+  RPM installs.
 
-A one-time manual validation against Amazon ECR with the upstream `ecr-credential-provider` binary is performed before release to confirm the customer's exact path and to source the configuration guide. Automated CI coverage uses the mock provider and local registry only.
+A one-time manual validation against Amazon ECR with the upstream
+`ecr-credential-provider` binary is performed before release to confirm the
+customer's exact path and to source the configuration guide. Automated CI
+coverage uses the mock provider and local registry only.
 
 ## Graduation Criteria
 
@@ -404,7 +588,8 @@ N/A
 ### Tech Preview -> GA
 
 - Ability to utilize the enhancement end to end
-- End user documentation completed and published, including a configuration guide for Amazon ECR
+- End user documentation completed and published, covering all items in
+  Documentation requirements
 - Available by default
 - End-to-end tests
 - Unit tests covering config extraction and validation
@@ -414,48 +599,119 @@ N/A
 
 ## Upgrade / Downgrade Strategy
 
-When upgrading from a version without support for these keys, the keys remain unset unless the user adds them, and existing behavior is preserved. If a user pre-stages the keys in the configuration file before upgrading, the older version ignores them and the newer version activates them on its first start. No migration is required; the feature holds no persisted state.
+When upgrading from a version without support for these keys, the keys remain
+unset unless the user adds them, and existing behavior is preserved. If a user
+pre-stages the keys in the configuration file before upgrading, the older
+version ignores them and the newer version activates them on its first start.
+No migration is required; the feature holds no persisted state.
 
-When downgrading to a version without support for these keys, the older version passes
-them through to the `KubeletConfiguration` file, where kubelet's lenient decoder logs a
-warning and ignores them. MicroShift starts normally with the credential provider feature
-inactive. Private registry image pulls will fail on the downgraded version until the
-previous workaround is restored or the device is upgraded again. The configuration file
-on disk is not modified. This behavior depends on kubelet retaining lenient decoding for
-`v1beta1`, which holds for all currently supported downgrade targets.
+MicroShift does not support downgrades. The supported scenario that boots an
+older MicroShift with a newer configuration is rollback to the previous
+deployment on image-based systems (rpm-ostree and bootc), either manually or
+automatically through greenboot. Because `/etc` persists across deployments
+while `/usr` does not, the rolled-back deployment sees the configuration keys
+but not necessarily the provider binary. In that scenario the older MicroShift
+passes the keys through to the `KubeletConfiguration` file, where kubelet's
+lenient decoder logs a warning and ignores them. MicroShift starts normally
+with the credential provider feature inactive, so the rollback itself succeeds.
+Private registry image pulls fail on the rolled-back deployment until the
+previous workaround is restored or the device is rolled forward again. The
+configuration file on disk is not modified. This behavior relies on kubelet's
+lenient decoding of `v1beta1` `KubeletConfiguration`, which is present in the
+previous deployment that a rollback targets.
 
 ## Version Skew Strategy
 N/A
 
 ## Operational Aspects of API Extensions
 
-The credential provider is invoked by kubelet only for images matching a configured `matchImages` pattern; pulls from other registries are unaffected. Credentials are held in kubelet's memory only, never written to disk, and are discarded when MicroShift restarts; the first matching pull after a restart re-invokes the provider.
+The credential provider is invoked by kubelet only for images matching a
+configured `matchImages` pattern; pulls from other registries are unaffected.
+Credentials are held in kubelet's memory only, never written to disk, and are
+discarded when MicroShift restarts; the first matching pull after a restart
+re-invokes the provider.
 
-The provider binary must be able to authenticate to the cloud provider itself (for Amazon ECR: an EC2 instance role, IAM Roles Anywhere, or static credentials in `/root/.aws/credentials`). Failures in the provider surface as image pull failures (`ImagePullBackOff`) with the provider's error in the kubelet journal.
+The provider binary must be able to authenticate to the cloud provider itself
+(for Amazon ECR: an EC2 instance role, IAM Roles Anywhere, or static
+credentials in `/root/.aws/credentials`). Failures in the provider surface as
+image pull failures (`ImagePullBackOff`) with the provider's error in the
+kubelet journal.
 
-Changes to the two configuration keys require a MicroShift restart. Changes to the provider configuration file or binaries require a MicroShift restart for kubelet to reload them.
+Changes to the two configuration keys or to the provider configuration file
+require a MicroShift restart: kubelet reads the provider configuration once
+during initialization. Replacing an existing provider binary in place does not
+require a restart, because kubelet resolves the binary path at each invocation;
+the replacement takes effect on the next invocation that is not served from the
+credential cache. Adding a new provider entry to the configuration file
+requires a restart.
+
+See Image-based deployments for the placement requirements on bootc and
+rpm-ostree.
 
 ## Support Procedures
 
-- Confirm the keys were applied: `journalctl -u microshift` at startup contains `Kubelet image credential provider enabled` with the configured `configPath` and `binDir`. Kubelet does not log `FLAG:` lines in MicroShift and logs nothing at default verbosity when providers are registered, so this MicroShift log line is the authoritative signal.
-- Confirm the effective configuration: `microshift show-config --mode effective` displays both keys under `kubelet:`.
-- Startup validation failures are logged with the field name and path, e.g. `error validating kubelet.imageCredentialProviderConfigPath ("/etc/microshift/credential-providers.yaml"): file or directory does not exist`.
-- Image pull failures with the feature active: inspect `journalctl -u microshift` for provider execution errors, verify the provider binary runs successfully when invoked manually with a `CredentialProviderRequest` on stdin, and verify the device's cloud identity has registry pull permissions.
-- A lenient-decode warning in the kubelet logs referencing either key indicates a MicroShift version that does not support the feature, or a misspelled key.
+- Confirm the keys were applied: `journalctl -u microshift` at startup
+  contains `Kubelet image credential provider configured` with the configured
+  `configPath` and `binDir`. Kubelet does not log `FLAG:` lines in MicroShift
+  and logs nothing at default verbosity on successful provider registration,
+  so this MicroShift log line is the authoritative signal that the keys
+  reached kubelet. It does not confirm that the provider binaries are usable.
+- Confirm the providers registered: the absence of a kubelet startup error
+  following the "configured" line. A missing or non-executable provider binary
+  is reported by kubelet as a startup error naming the plugin binary path.
+- Confirm the effective configuration:
+  `microshift show-config --mode effective` displays both keys under
+  `kubelet:`.
+- Startup validation failures are logged with the field name and path, e.g.
+  `error validating kubelet.imageCredentialProviderConfigPath ("/etc/microshift/credential-providers.yaml"): file or directory does not exist`
+  or
+  `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"): must be owned by root and not writable by group or others`.
+- Image pull failures with the feature active: inspect
+  `journalctl -u microshift` for provider execution errors, verify the
+  provider binary runs successfully when invoked manually with a
+  `CredentialProviderRequest` on stdin, and verify the device's cloud identity
+  has registry pull permissions.
+- A lenient-decode warning in the kubelet logs referencing either key indicates
+  a MicroShift version that does not support the feature, or a misspelled key.
+- On bootc or rpm-ostree systems, a greenboot rollback after an image update
+  with a validation error naming `imageCredentialProviderBinDir` indicates the
+  new image was built without the provider binary.
 
 ## Alternatives (Not Implemented)
 
-**Generic kubelet flag passthrough.** A `kubelet.args` or similar mechanism for arbitrary flags was rejected. It exposes the full kubelet flag surface, most of which MicroShift manages deliberately, and increases the risk of misconfiguration. The OCPSTRAT explicitly rules this out of scope; it should be tracked as a separate RFE if needed.
+**Generic kubelet flag passthrough.** A `kubelet.args` or similar mechanism for
+arbitrary flags was rejected. It exposes the full kubelet flag surface, most of
+which MicroShift manages deliberately, and increases the risk of
+misconfiguration. The OCPSTRAT explicitly rules this out of scope; it should be
+tracked as a separate RFE if needed.
 
-**Typed `kubelet:` section.** Replacing the schemaless map with a typed struct was rejected because it would break the existing passthrough of arbitrary `KubeletConfiguration` fields, which users depend on.
+**Typed `kubelet:` section.** Replacing the schemaless map with a typed struct
+was rejected because it would break the existing passthrough of arbitrary
+`KubeletConfiguration` fields, which users depend on.
 
-**Separate top-level configuration section.** Placing the keys outside `kubelet:` (e.g. `imageCredentialProvider:`) would avoid special-casing keys inside the passthrough and would be picked up by schema generation. It was rejected because the OCPSTRAT acceptance criteria and the originating RFE specify placement under `kubelet:`, where users familiar with the upstream flags will look for them.
+**Separate top-level configuration section.** Placing the keys outside
+`kubelet:` (e.g. `imageCredentialProvider:`) would avoid special-casing keys
+inside the passthrough and would be picked up by schema generation. It was
+rejected because the OCPSTRAT acceptance criteria and the originating RFE
+specify placement under `kubelet:`, where users familiar with the upstream
+flags will look for them.
 
-**Removing the reserved keys from the `Config.Kubelet` map.** An earlier draft extracted
-the two keys by deleting them from (a copy of) the map during configuration processing.
-This was rejected because `microshift show-config --mode effective` marshals the `Config`
-struct, so the keys would disappear from its output. Filtering at the point where the map
-is marshaled into `KubeletConfiguration` keeps the effective configuration faithful to
-user input.
+**Removing the reserved keys from the `Config.Kubelet` map.** An earlier draft
+extracted the two keys by deleting them from (a copy of) the map during
+configuration processing. This was rejected because
+`microshift show-config --mode effective` marshals the `Config` struct, so the
+keys would disappear from its output. Filtering at the point where the map is
+marshaled into `KubeletConfiguration` keeps the effective configuration
+faithful to user input.
 
-**Packaging credential provider binaries.** Shipping `ecr-credential-provider` or equivalents as MicroShift RPMs was rejected. The binaries are cloud-specific, upstream-maintained, and have their own release and CVE cadence. Bundling them would make their lifecycle a MicroShift concern.
+**Warning instead of failing on unsafe bin directory permissions.** An earlier
+draft only warned. A warning does not prevent a local user from replacing a
+provider binary that kubelet executes as root, so the check is a startup
+failure.
+
+**Packaging credential provider binaries.** Shipping `ecr-credential-provider`
+or equivalents as MicroShift RPMs was rejected. The binaries are
+cloud-specific, upstream-maintained, and have their own release and CVE
+cadence; there is one per registry type, so shipping any subset would favor
+particular clouds. Bundling them would make their lifecycle a MicroShift
+concern.

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -1,0 +1,412 @@
+---
+title: microshift-kubelet-image-credential-provider
+authors:
+  - "@Neilhamza"
+reviewers:
+  - "@pacevedom"
+  - "@eslutsky"
+  - "@copejon"
+  - "@ggiguash"
+  - "@pmtk"
+  - "@kasturinarra"
+  - "@qJkee"
+  - "@dfroehli"
+approvers:
+  - "@jerpeter1"
+api-approvers:
+  - None
+creation-date: 2026-09-02
+last-updated: 2026-09-02
+tracking-link:
+  - https://redhat.atlassian.net/browse/OCPSTRAT-3456
+see-also:
+  - enhancements/microshift/enabling-user-specified-featuregates.md
+  - enhancements/microshift/microshift-dns-resource-configuration.md
+---
+
+# MicroShift Kubelet Image Credential Provider Configuration
+
+## Summary
+
+MicroShift runs kubelet as an embedded, in-process component. Kubelet's [image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/) feature (GA since Kubernetes 1.26) allows kubelet to obtain container registry credentials dynamically at image pull time by executing an external provider binary. The feature is enabled through two kubelet command-line flags, `--image-credential-provider-config` and `--image-credential-provider-bin-dir`, which have no equivalent in `KubeletConfiguration`. Because MicroShift exposes no kubelet command line and only maps its `kubelet:` configuration section into `KubeletConfiguration`, users currently have no way to enable this feature.
+
+This enhancement introduces two new optional keys, `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir`, under the existing `kubelet:` section of the MicroShift configuration file. MicroShift extracts these keys, validates them at startup, and applies them to the embedded kubelet's startup flags.
+
+## Motivation
+
+Edge devices frequently pull application images from private, token-based registries such as Amazon ECR, Google Artifact Registry, or Azure Container Registry. These registries do not issue long-lived passwords; Amazon ECR, for example, issues authorization tokens that expire after 12 hours.
+
+Today, MicroShift users work around this with a systemd timer that periodically obtains a fresh token (e.g. `aws ecr get-login-password`) and rewrites it into CRI-O's static auth file. This workaround has known drawbacks:
+
+- **Token gap:** if the timer fires late, or the token expires early, image pulls fail until the next refresh.
+- **Operational overhead:** an additional systemd unit and script must be maintained on every device.
+- **Not portable:** each registry type (ECR, GCR, ACR) requires its own bespoke script.
+
+The kubelet image credential provider is the upstream-standard, cloud-vendor-recommended solution to this problem. A customer (see the linked RFE) requires it to pull private images from Amazon ECR on MicroShift edge devices.
+
+### User Stories
+
+1. As a MicroShift administrator, I want to enable the kubelet image credential provider through the MicroShift configuration file so that my edge devices can authenticate to private registries at pull time without direct access to kubelet command-line flags.
+2. As a MicroShift administrator with devices pulling from Amazon ECR, I want kubelet to obtain short-lived registry credentials automatically so that I no longer maintain a per-device token rotation script.
+3. As a MicroShift administrator, I want MicroShift to fail to start with a clear error if the credential provider configuration points to paths that do not exist, so that misconfigurations are caught at startup rather than surfacing as opaque image pull failures.
+
+### Goals
+
+1. Allow users to set `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir` under the `kubelet:` section of the MicroShift configuration file.
+2. Apply these settings to the embedded kubelet as startup flags when present.
+3. Preserve current behavior when the keys are not set, ensuring full backward compatibility.
+4. Validate the provided paths at startup and fail with a clear error message if they are invalid.
+
+### Non-Goals
+
+1. A generic mechanism for passing arbitrary kubelet command-line flags through the MicroShift configuration file. This enhancement special-cases exactly two keys.
+2. Packaging or distributing credential provider binaries (e.g. `ecr-credential-provider`). These are standalone upstream binaries that users install separately.
+3. Validating the contents of the credential provider configuration file or the presence and executability of binaries in the bin directory. Kubelet performs this validation itself.
+4. Runtime reconfiguration without restarting MicroShift.
+
+## Proposal
+
+Introduce two new optional keys under the existing `kubelet:` section of the MicroShift configuration file:
+
+```yaml
+kubelet:
+  imageCredentialProviderConfigPath: /etc/microshift/credential-providers.yaml
+  imageCredentialProviderBinDir: /usr/libexec/microshift/credential-providers
+```
+
+The `kubelet:` section is currently a schemaless map (`map[string]any`) whose contents are marshaled verbatim into the generated `KubeletConfiguration` file. The two new keys are kubelet **flags**, not `KubeletConfiguration` fields, so they cannot follow that path: if left in the map, kubelet's strict decoder rejects them, falls back to a lenient decoder, logs a warning, and silently ignores them. MicroShift will therefore read these two keys from the map during configuration processing into typed internal fields, validate them, and set them on the `KubeletFlags` struct used to start the embedded kubelet. When the remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the two reserved keys are filtered out. The `Config.Kubelet` map itself is not modified, so `microshift show-config` continues to display the keys exactly where the user set them. All other keys in the `kubelet:` section continue to be passed through to `KubeletConfiguration` unchanged.
+
+### Workflow Description
+
+1. MicroShift starts up and loads its configuration file. The `kubelet:` section is read into `Config.Kubelet` as a schemaless map.
+2. During computed-value processing, MicroShift reads `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir` from the map into typed internal fields. The map is not modified. An empty string is treated as unset.
+3. During validation, MicroShift checks that either both keys are set or neither is, that both paths are absolute, that `imageCredentialProviderConfigPath` exists as a file or directory, and that `imageCredentialProviderBinDir` exists and is a directory.
+4. If validation fails, MicroShift exits with a descriptive error message naming the field and the path.
+5. If validation succeeds, the kubelet component sets `KubeletFlags.ImageCredentialProviderConfigPath` and `KubeletFlags.ImageCredentialProviderBinDir` before starting the embedded kubelet, and logs an informational message recording the configured values.
+6. The keys in the `kubelet:` section other than the two reserved keys are marshaled into the `KubeletConfiguration` file as today.
+7. At image pull time, kubelet consults the credential provider configuration; for images matching a configured provider, kubelet executes the provider binary, caches the returned credentials in memory for the returned or default cache duration, and passes them to CRI-O with the pull request.
+8. If the keys are not set, kubelet starts without credential provider configuration, identical to current behavior.
+
+### API Extensions
+
+The following changes to the MicroShift configuration file are proposed:
+
+```yaml
+kubelet:
+  imageCredentialProviderConfigPath: <string>  # optional, default: not set
+  imageCredentialProviderBinDir: <string>      # optional, default: not set
+```
+
+- `imageCredentialProviderConfigPath`: path to a kubelet `CredentialProviderConfig` file (JSON or YAML), or a directory of such files which kubelet merges in lexicographical order.
+- `imageCredentialProviderBinDir`: path to the directory containing credential provider plugin binaries.
+
+Both keys must be set together; setting only one is a validation error. Values must be absolute paths. An empty string is equivalent to omitting the key. Because user configuration files and drop-ins under `/etc/microshift/config.d/` are combined with a JSON merge patch, which merges maps key by key, the two keys may be set in different files (for example, one in `config.yaml` and the other in a drop-in) and are merged before validation.
+
+The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no change to the generated configuration schema or a schema version bump is required. As a consequence, the configuration generator cannot emit the keys as schema entries; they are documented through the doc comment on the `Kubelet` field, which the generator propagates into the sample configuration file and the configuration reference (see Sample configuration and documentation below).
+
+`microshift show-config --mode effective` displays the keys under `kubelet:` as set by the user, since the underlying map is not modified.
+
+The credential provider configuration file itself follows the upstream `kubelet.config.k8s.io/v1` `CredentialProviderConfig` format. For example, for Amazon ECR:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+  - name: ecr-credential-provider
+    matchImages:
+      - "*.dkr.ecr.*.amazonaws.com"
+    defaultCacheDuration: "6h"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
+```
+
+### Topology Considerations
+
+#### Hypershift / Hosted Control Planes
+N/A
+
+#### Standalone Clusters
+N/A
+
+#### Single-node Deployments or MicroShift
+Enhancement is intended for MicroShift only.
+
+#### OpenShift Kubernetes Engine
+N/A
+
+### Implementation Details/Notes/Constraints
+
+#### Config struct changes
+
+Add two internal, non-serialized fields to the `Config` struct in `pkg/config/config.go`. These follow the existing convention for internal fields (e.g. `userSettings`) and are populated by reading the schemaless map rather than by direct decoding. The `Kubelet` field's doc comment is extended because the configuration generator propagates it into the sample configuration and reference documentation:
+
+```go
+type Config struct {
+    // ... existing fields ...
+
+    // Settings specified in this section are transferred as-is into the Kubelet config,
+    // with two exceptions that are applied as kubelet startup flags instead:
+    //   imageCredentialProviderConfigPath: absolute path to a kubelet CredentialProviderConfig
+    //     file, or a directory of such files. Enables the kubelet image credential provider.
+    //   imageCredentialProviderBinDir: absolute path to the directory containing credential
+    //     provider plugin binaries. Must be set together with imageCredentialProviderConfigPath.
+    // +kubebuilder:validation:Schemaless
+    Kubelet map[string]any `json:"kubelet"`
+
+    // Read from the Kubelet map during updateComputedValues().
+    // These are kubelet flags, not KubeletConfiguration fields.
+    KubeletImageCredentialProviderConfigPath string `json:"-"`
+    KubeletImageCredentialProviderBinDir     string `json:"-"`
+}
+```
+
+Populating internal fields from the schemaless `Kubelet` map is a new pattern in the MicroShift configuration code. The map has always been passed through untouched, and this enhancement preserves that: the map is read, not modified.
+
+#### Config extraction
+
+Extend `updateComputedValues()` in `pkg/config/config.go` to read the two keys. The map is not modified, so `incorporateUserSettings()` (which assigns `c.Kubelet = u.Kubelet`) and `microshift show-config` are unaffected:
+
+```go
+const (
+    kubeletImageCredentialProviderConfigPathKey = "imageCredentialProviderConfigPath"
+    kubeletImageCredentialProviderBinDirKey     = "imageCredentialProviderBinDir"
+)
+
+// kubeletReservedKeys are keys under `kubelet:` that are applied as kubelet
+// startup flags rather than passed through to KubeletConfiguration.
+var kubeletReservedKeys = []string{
+    kubeletImageCredentialProviderConfigPathKey,
+    kubeletImageCredentialProviderBinDirKey,
+}
+
+func (c *Config) readKubeletCredentialProviderSettings() error {
+    for key, dst := range map[string]*string{
+        kubeletImageCredentialProviderConfigPathKey: &c.KubeletImageCredentialProviderConfigPath,
+        kubeletImageCredentialProviderBinDirKey:     &c.KubeletImageCredentialProviderBinDir,
+    } {
+        raw, ok := c.Kubelet[key]
+        if !ok || raw == nil {
+            continue
+        }
+        s, ok := raw.(string)
+        if !ok {
+            return fmt.Errorf("kubelet.%s must be a string, got %T", key, raw)
+        }
+        *dst = s
+    }
+    return nil
+}
+
+// KubeletPassthrough returns the user-provided kubelet settings that are
+// transferred into KubeletConfiguration, excluding reserved keys.
+func (c *Config) KubeletPassthrough() map[string]any {
+    if c.Kubelet == nil {
+        return nil
+    }
+    out := make(map[string]any, len(c.Kubelet))
+    for k, v := range c.Kubelet {
+        out[k] = v
+    }
+    for _, k := range kubeletReservedKeys {
+        delete(out, k)
+    }
+    return out
+}
+```
+
+`updateComputedValues()` calls `readKubeletCredentialProviderSettings()` before returning. `generateConfig()` in `pkg/node/kubelet.go` is changed to marshal `cfg.KubeletPassthrough()` instead of `cfg.Kubelet`, so the reserved keys never reach the `KubeletConfiguration` file. The list of reserved keys lives only in the `config` package.
+
+#### Config validation
+
+Extend `validate()` in `pkg/config/config.go`:
+
+```go
+func (c *Config) validateKubeletCredentialProvider() error {
+    configPath := c.KubeletImageCredentialProviderConfigPath
+    binDir := c.KubeletImageCredentialProviderBinDir
+
+    if configPath == "" && binDir == "" {
+        return nil
+    }
+    if configPath == "" || binDir == "" {
+        return fmt.Errorf("kubelet.%s and kubelet.%s must be set together",
+            kubeletImageCredentialProviderConfigPathKey, kubeletImageCredentialProviderBinDirKey)
+    }
+    if !filepath.IsAbs(configPath) {
+        return fmt.Errorf("kubelet.%s (%q) must be an absolute path",
+            kubeletImageCredentialProviderConfigPathKey, configPath)
+    }
+    if !filepath.IsAbs(binDir) {
+        return fmt.Errorf("kubelet.%s (%q) must be an absolute path",
+            kubeletImageCredentialProviderBinDirKey, binDir)
+    }
+
+    if _, err := os.Stat(configPath); err != nil {
+        return fmt.Errorf("error validating kubelet.%s (%q): file or directory does not exist: %w",
+            kubeletImageCredentialProviderConfigPathKey, configPath, err)
+    }
+
+    info, err := os.Stat(binDir)
+    if err != nil {
+        return fmt.Errorf("error validating kubelet.%s (%q): directory does not exist: %w",
+            kubeletImageCredentialProviderBinDirKey, binDir, err)
+    }
+    if !info.IsDir() {
+        return fmt.Errorf("error validating kubelet.%s (%q): not a directory",
+            kubeletImageCredentialProviderBinDirKey, binDir)
+    }
+
+    return nil
+}
+```
+
+Validation rules:
+
+- Both-or-neither: setting only one of the two keys is an error. Kubelet requires both to activate the feature; failing early in MicroShift produces a clearer message than kubelet's own error. An empty string is treated as unset.
+- Both paths must be absolute. A relative path would be resolved against the MicroShift process working directory, which is not a stable location.
+- `imageCredentialProviderConfigPath` must exist. A file or a directory is accepted, matching upstream kubelet semantics.
+- `imageCredentialProviderBinDir` must exist and be a directory.
+- Error messages name the field and the path.
+
+MicroShift deliberately does **not** validate the contents of the credential provider configuration file, nor the presence or executability of binaries inside the bin directory. Kubelet validates these at startup and its errors surface in the journal. Duplicating that validation would require keeping MicroShift in sync with upstream kubelet behavior.
+
+Optionally, MicroShift may emit a warning via `AddWarning()` if the bin directory is writable by users other than root, since credential provider binaries execute with kubelet's privileges. This is a warning, not a startup failure.
+
+#### Kubelet flag injection
+
+Extend `configure()` in `pkg/node/kubelet.go`. The `KubeletFlags` struct from the vendored `k8s.io/kubernetes/cmd/kubelet/app/options` package already exposes the required fields, and they are passed through to `NewMainKubelet()` by the existing in-process startup path. No new plumbing is required:
+
+```go
+func (s *KubeletServer) configure(cfg *config.Config) {
+    // ... existing code ...
+    kubeletFlags := kubeletoptions.NewKubeletFlags()
+    // ... existing flag assignments ...
+
+    if cfg.KubeletImageCredentialProviderConfigPath != "" {
+        kubeletFlags.ImageCredentialProviderConfigPath = cfg.KubeletImageCredentialProviderConfigPath
+        kubeletFlags.ImageCredentialProviderBinDir = cfg.KubeletImageCredentialProviderBinDir
+        klog.InfoS("Kubelet image credential provider enabled",
+            "configPath", cfg.KubeletImageCredentialProviderConfigPath,
+            "binDir", cfg.KubeletImageCredentialProviderBinDir)
+    }
+
+    // ... existing code ...
+}
+```
+
+The explicit log line is the intended verification point for tests and support. Because MicroShift calls `kubelet.Run()` directly rather than through kubelet's cobra command, kubelet's usual `FLAG: --image-credential-provider-config=...` startup lines are never emitted, and kubelet's own credential provider code logs nothing at default verbosity when plugins are registered.
+
+#### Sample configuration and documentation
+
+`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are generated by `scripts/generate-config.sh` and kept in sync by `scripts/verify/verify-config.sh`; they must not be edited by hand. Because the `kubelet:` section is schemaless, the generator cannot emit the two keys as schema entries. They are documented by extending the doc comment on the `Kubelet` field in `pkg/config/config.go` (shown above), which the generator propagates into both files. After changing the comment, run `make generate-config` and commit the regenerated files.
+
+### Risks and Mitigations
+
+**Risk:** A user places the keys under `kubelet:` in a MicroShift version that supports the feature, but a typo in the key name (e.g. `imageCredentialProviderConfig`) causes the key to fall through to the `KubeletConfiguration` passthrough, where kubelet's lenient decoder silently ignores it. The feature appears enabled but is inert.
+**Mitigation:** Kubelet logs a lenient-decode warning in the journal. A future improvement could warn on near-miss keys. This risk is not specific to this enhancement; it applies to any misspelled key in the passthrough.
+
+**Risk:** Kubelet's lenient decoding of unknown `KubeletConfiguration` fields is marked upstream as temporary, to be removed when `v1beta1` support is dropped. When that happens, any unknown key left in the passthrough becomes a hard kubelet startup failure.
+**Mitigation:** This enhancement extracts its two keys in the MicroShift configuration layer before the map is marshaled, so it never depends on lenient decoding. The general passthrough exposure predates this enhancement.
+
+**Risk:** Credential provider binaries execute with kubelet's (root) privileges. A bin directory writable by unprivileged users is a local privilege escalation vector.
+**Mitigation:** User documentation must state this trust boundary and recommend a root-owned bin directory that is not writable by other users. MicroShift may additionally emit a startup warning for world-writable bin directories.
+
+**Risk:** On image-based (ostree/bootc) systems, a validation failure at startup causes greenboot health checks to fail, triggering an automatic rollback to the previous deployment.
+**Mitigation:** This is the intended composition of fail-fast validation with greenboot: the device returns to a known-good state rather than remaining unhealthy. Documentation must note that the provider config file and bin directory must exist in the image before the configuration keys are enabled.
+
+**Risk:** Users may set `defaultCacheDuration` in the provider configuration longer than the registry token lifetime, causing kubelet to serve expired credentials.
+**Mitigation:** Documentation for Amazon ECR (12-hour tokens) must recommend a cache duration comfortably shorter than the token lifetime.
+
+### Drawbacks
+
+Special-casing two keys inside an otherwise schemaless passthrough section introduces a small amount of hidden behavior: two keys under `kubelet:` are treated differently from all others, and the generated schema cannot express them. This is accepted because the OCPSTRAT acceptance criteria specify placement under `kubelet:`, and the alternative of a generic flag passthrough was explicitly ruled out of scope.
+
+## Test Plan
+
+### Unit Tests
+
+- Extraction: both keys present, both absent, only one present.
+- Extraction: non-string values rejected with an error.
+- Extraction: `c.Kubelet` is not modified; `KubeletPassthrough()` returns the map without the two reserved keys and with all other keys intact.
+- Extraction: empty string values are treated as unset.
+- Validation: only one key set fails with the both-or-neither error.
+- Validation: relative paths are rejected.
+- Validation: `imageCredentialProviderConfigPath` missing fails; existing file passes; existing directory passes.
+- Validation: `imageCredentialProviderBinDir` missing fails; path is a file fails; existing directory passes.
+- Validation: neither key set passes (backward compatibility).
+- `generateConfig()`: the two keys never appear in the generated `KubeletConfiguration` YAML; other user-provided keys still do.
+- `configure()`: `KubeletFlags` carries both values when set, and empty values when unset.
+
+### Integration Tests (Robot Framework)
+
+- Default behavior: no keys set, MicroShift starts, the "Kubelet image credential provider enabled" log line is absent.
+- Valid configuration: both keys set to an existing file and directory via drop-in, restart, verify MicroShift starts and the journal contains the "Kubelet image credential provider enabled" log line with the configured paths.
+- `show-config`: verify `microshift show-config --mode effective` displays both keys under `kubelet:`.
+- Split configuration: one key in `config.yaml` and the other in a `/etc/microshift/config.d/` drop-in, verify the merged configuration is valid and MicroShift starts.
+- Empty strings: both keys set to `""`, verify behavior is identical to omitting them.
+- Relative path: verify MicroShift fails to start with an error naming the field.
+- Directory config path: `imageCredentialProviderConfigPath` set to a directory, verify MicroShift starts.
+- Missing config path: verify MicroShift fails to start with an error naming the field and path in the journal.
+- Missing bin directory: verify MicroShift fails to start with an error naming the field and path in the journal.
+- Only one key set: verify MicroShift fails to start with the both-or-neither error.
+- Recovery: restore valid configuration, restart, verify MicroShift starts.
+- Downgrade: configuration with the new keys on a MicroShift version without the feature, verify MicroShift starts with a kubelet lenient-decode warning and the feature inert.
+- End-to-end pull: deploy a mock credential provider (an executable implementing the `credentialprovider.kubelet.k8s.io/v1` exec contract returning static credentials) and a local password-protected registry, deploy a pod referencing a private image with no CRI-O auth pre-populated, verify the pod reaches Running.
+- End-to-end negative: mock provider returns incorrect credentials, verify the pod reaches ImagePullBackOff.
+- Coexistence with CRI-O auth: with the credential provider configured and CRI-O auth also pre-populated for the same registry, verify the pull succeeds.
+- Mixed registries: pods referencing an image from a credential-provider registry and an image from a registry using CRI-O static auth, verify both pulls succeed independently.
+- Caching: with a short `defaultCacheDuration`, verify a second pull within the cache window does not re-invoke the provider and a pull after expiry does.
+
+A one-time manual validation against Amazon ECR with the upstream `ecr-credential-provider` binary is performed before release to confirm the customer's exact path and to source the configuration guide. Automated CI coverage uses the mock provider and local registry only.
+
+## Graduation Criteria
+
+### Dev Preview -> Tech Preview
+N/A
+
+### Tech Preview -> GA
+
+- Ability to utilize the enhancement end to end
+- End user documentation completed and published, including a configuration guide for Amazon ECR
+- Available by default
+- End-to-end tests
+- Unit tests covering config extraction and validation
+
+### Removing a deprecated feature
+N/A
+
+## Upgrade / Downgrade Strategy
+
+When upgrading from a version without support for these keys, the keys remain unset unless the user adds them, and existing behavior is preserved. If a user pre-stages the keys in the configuration file before upgrading, the older version ignores them and the newer version activates them on its first start. No migration is required; the feature holds no persisted state.
+
+When downgrading to a version without support for these keys, the older version passes them through to the `KubeletConfiguration` file, where kubelet's lenient decoder logs a warning and ignores them. MicroShift starts normally with the credential provider feature inactive. Private registry image pulls will fail on the downgraded version until the previous workaround is restored or the device is upgraded again. The configuration file on disk is not modified. This behavior depends on kubelet retaining lenient decoding for `v1beta1`, which holds for all currently supported downgrade targets.
+
+## Version Skew Strategy
+N/A
+
+## Operational Aspects of API Extensions
+
+The credential provider is invoked by kubelet only for images matching a configured `matchImages` pattern; pulls from other registries are unaffected. Credentials are held in kubelet's memory only, never written to disk, and are discarded when MicroShift restarts; the first matching pull after a restart re-invokes the provider.
+
+The provider binary must be able to authenticate to the cloud provider itself (for Amazon ECR: an EC2 instance role, IAM Roles Anywhere, or static credentials in `/root/.aws/credentials`). Failures in the provider surface as image pull failures (`ImagePullBackOff`) with the provider's error in the kubelet journal.
+
+Changes to the two configuration keys require a MicroShift restart. Changes to the provider configuration file or binaries require a MicroShift restart for kubelet to reload them.
+
+## Support Procedures
+
+- Confirm the keys were applied: `journalctl -u microshift` at startup contains `Kubelet image credential provider enabled` with the configured `configPath` and `binDir`. Kubelet does not log `FLAG:` lines in MicroShift and logs nothing at default verbosity when providers are registered, so this MicroShift log line is the authoritative signal.
+- Confirm the effective configuration: `microshift show-config --mode effective` displays both keys under `kubelet:`.
+- Startup validation failures are logged with the field name and path, e.g. `error validating kubelet.imageCredentialProviderConfigPath ("/etc/microshift/credential-providers.yaml"): file or directory does not exist`.
+- Image pull failures with the feature active: inspect `journalctl -u microshift` for provider execution errors, verify the provider binary runs successfully when invoked manually with a `CredentialProviderRequest` on stdin, and verify the device's cloud identity has registry pull permissions.
+- A lenient-decode warning in the kubelet logs referencing either key indicates a MicroShift version that does not support the feature, or a misspelled key.
+
+## Alternatives (Not Implemented)
+
+**Generic kubelet flag passthrough.** A `kubelet.args` or similar mechanism for arbitrary flags was rejected. It exposes the full kubelet flag surface, most of which MicroShift manages deliberately, and increases the risk of misconfiguration. The OCPSTRAT explicitly rules this out of scope; it should be tracked as a separate RFE if needed.
+
+**Typed `kubelet:` section.** Replacing the schemaless map with a typed struct was rejected because it would break the existing passthrough of arbitrary `KubeletConfiguration` fields, which users depend on.
+
+**Separate top-level configuration section.** Placing the keys outside `kubelet:` (e.g. `imageCredentialProvider:`) would avoid special-casing keys inside the passthrough and would be picked up by schema generation. It was rejected because the OCPSTRAT acceptance criteria and the originating RFE specify placement under `kubelet:`, where users familiar with the upstream flags will look for them.
+
+**Removing the reserved keys from the `Config.Kubelet` map.** An earlier draft extracted the two keys by deleting them from (a copy of) the map during configuration processing. This was rejected because `microshift show-config --mode effective` marshals the `Config` struct, so the keys would disappear from its output. Filtering at the point where the map is marshaled into `KubeletConfiguration` keeps the effective configuration faithful to user input.
+
+**Packaging credential provider binaries.** Shipping `ecr-credential-provider` or equivalents as MicroShift RPMs was rejected. The binaries are cloud-specific, upstream-maintained, and have their own release and CVE cadence. Bundling them would make their lifecycle a MicroShift concern.

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -28,8 +28,9 @@ see-also:
 
 ## Summary
 
-MicroShift runs kubelet as an embedded, in-process component. Kubelet's
-[image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)
+MicroShift runs kubelet as an embedded, in-process component. Kubelet's [image
+credential
+provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)
 feature (GA since Kubernetes 1.26) allows kubelet to obtain container registry
 credentials dynamically at image pull time by executing an external provider
 binary. The feature is enabled through two kubelet command-line flags,
@@ -59,8 +60,8 @@ CRI-O's static auth file. This workaround has known drawbacks:
   pulls fail until the next refresh.
 - **Operational overhead:** an additional systemd unit and script must be
   maintained on every device.
-- **Not portable:** each registry type (ECR, GCR, ACR) requires its own
-  bespoke script.
+- **Not portable:** each registry type (ECR, GCR, ACR) requires its own bespoke
+  script.
 
 The kubelet image credential provider is the upstream-standard,
 cloud-vendor-recommended solution to this problem. A customer (see the linked
@@ -74,8 +75,8 @@ devices.
    can authenticate to private registries at pull time without direct access to
    kubelet command-line flags.
 2. As a MicroShift administrator with devices pulling from Amazon ECR, I want
-   kubelet to obtain short-lived registry credentials automatically so that I
-   no longer maintain a per-device token rotation script.
+   kubelet to obtain short-lived registry credentials automatically so that I no
+   longer maintain a per-device token rotation script.
 3. As a MicroShift administrator, I want MicroShift to fail to start with a
    clear error if the credential provider configuration points to paths that do
    not exist or are unsafe, so that misconfigurations are caught at startup
@@ -89,23 +90,26 @@ devices.
 2. Apply these settings to the embedded kubelet as startup flags when present.
 3. Preserve current behavior when the keys are not set, ensuring full backward
    compatibility.
-4. Validate the provided paths at startup and fail with a clear error message
-   if they are invalid or unsafe.
+4. Validate the provided paths at startup and fail with a clear error message if
+   they are invalid or unsafe.
 
 ### Non-Goals
 
 1. A generic mechanism for passing arbitrary kubelet command-line flags through
-   the MicroShift configuration file. This enhancement special-cases exactly
-   two keys.
+   the MicroShift configuration file. This enhancement special-cases exactly two
+   keys.
 2. Packaging or distributing credential provider binaries (e.g.
-   `ecr-credential-provider`). These are standalone upstream binaries that
-   users install separately, and which binary is needed depends on the registry
-   in use.
-3. Validating the contents of the credential provider configuration file, or
-   the presence, executability, or permissions of individual binaries inside
-   the bin directory. Kubelet validates the configuration file and the presence
-   of each configured binary when it registers providers.
+   `ecr-credential-provider`). These are standalone upstream binaries that users
+   install separately, and which binary is needed depends on the registry in
+   use.
+3. Validating the contents of the credential provider configuration file, or the
+   presence and executability of the binaries it names. Kubelet validates the
+   configuration file and the presence of each configured binary when it
+   registers providers. MicroShift validates ownership and permissions of both
+   paths and their contents, but not their semantics.
 4. Runtime reconfiguration of the two keys without restarting MicroShift.
+5. Protection against a user who already holds root privileges. The validation
+   described here defends against unprivileged local users only.
 
 ## Proposal
 
@@ -118,8 +122,8 @@ kubelet:
   imageCredentialProviderBinDir: /usr/libexec/microshift/credential-providers
 ```
 
-This follows the same pattern as user-provided certificates, the hosts file,
-and kustomize manifests: MicroShift consumes user-supplied content at configured
+This follows the same pattern as user-provided certificates, the hosts file, and
+kustomize manifests: MicroShift consumes user-supplied content at configured
 paths and does not provide the content itself. The provider binary and its
 configuration file are supplied by the user because they depend on which
 registry is in use.
@@ -130,13 +134,13 @@ The two new keys are kubelet **flags**, not `KubeletConfiguration` fields, so
 they cannot follow that path: if left in the map, kubelet's strict decoder
 rejects them, falls back to a lenient decoder, logs a warning, and silently
 ignores them. MicroShift will therefore read these two keys from the map during
-configuration processing into typed internal fields, validate them, and set
-them on the `KubeletFlags` struct used to start the embedded kubelet. When the
-remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the
-two reserved keys are filtered out. The `Config.Kubelet` map itself is not
-modified, so `microshift show-config` continues to display the keys exactly
-where the user set them. All other keys in the `kubelet:` section continue to
-be passed through to `KubeletConfiguration` unchanged.
+configuration processing into typed internal fields, validate them, and set them
+on the `KubeletFlags` struct used to start the embedded kubelet. When the
+remaining `kubelet:` contents are marshaled into `KubeletConfiguration`, the two
+reserved keys are filtered out. The `Config.Kubelet` map itself is not modified,
+so `microshift show-config` continues to display the keys exactly where the user
+set them. All other keys in the `kubelet:` section continue to be passed through
+to `KubeletConfiguration` unchanged.
 
 ### Workflow Description
 
@@ -146,13 +150,15 @@ be passed through to `KubeletConfiguration` unchanged.
    `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir` from
    the map into typed internal fields. The map is not modified. An empty string
    or explicit `null` is treated as unset.
-3. During validation, MicroShift checks that either both keys are set or
-   neither is, that both paths are absolute, that
-   `imageCredentialProviderConfigPath` exists as a regular file or directory,
-   and that `imageCredentialProviderBinDir` exists, is a directory, is owned by
-   root, and is not writable by group or others.
-4. If validation fails, MicroShift exits with a descriptive error message
-   naming the field and the path.
+3. During validation, MicroShift checks that either both keys are set or neither
+   is, that both paths are absolute, that `imageCredentialProviderConfigPath`
+   resolves to a regular file or directory and `imageCredentialProviderBinDir`
+   resolves to a directory, and that both paths satisfy the trusted-path rule
+   described under Config validation: after resolving symlinks, every path
+   component, the final object, and every file inside a directory must be owned
+   by root and not writable by group or others.
+4. If validation fails, MicroShift exits with a descriptive error message naming
+   the field and the path.
 5. If validation succeeds, the kubelet component sets
    `KubeletFlags.ImageCredentialProviderConfigPath` and
    `KubeletFlags.ImageCredentialProviderBinDir` before starting the embedded
@@ -164,10 +170,10 @@ be passed through to `KubeletConfiguration` unchanged.
    kubelet startup errors, reported in the MicroShift journal.
 8. At image pull time, kubelet consults the credential provider configuration;
    for images matching a configured provider, kubelet executes the provider
-   binary, caches the returned credentials in memory for the returned or
-   default cache duration, and passes them to CRI-O with the pull request.
-   CRI-O uses credentials supplied by kubelet in preference to its own auth
-   files; images that match no provider use CRI-O's auth files as today.
+   binary, caches the returned credentials in memory for the returned or default
+   cache duration, and passes them to CRI-O with the pull request. CRI-O uses
+   credentials supplied by kubelet in preference to its own auth files; images
+   that match no provider use CRI-O's auth files as today.
 9. If the keys are not set, kubelet starts without credential provider
    configuration, identical to current behavior.
 
@@ -185,10 +191,11 @@ kubelet:
   `CredentialProviderConfig` file (JSON or YAML), or a directory of such files
   which kubelet merges in lexicographical order.
 - `imageCredentialProviderBinDir`: absolute path to the directory containing
-  credential provider plugin binaries. Must be owned by root and not writable
-  by group or others.
+  credential provider plugin binaries.
 
-Both keys must be set together; setting only one is a validation error. An
+Both keys must be set together; setting only one is a validation error. Both
+paths, every component leading to them, and every file inside a directory must
+be owned by root and not writable by group or others (see Config validation). An
 empty string or explicit `null` is equivalent to omitting the key. Because user
 configuration files and drop-ins under `/etc/microshift/config.d/` are combined
 with a JSON merge patch, which merges maps key by key, the two keys may be set
@@ -200,8 +207,8 @@ The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no
 change to the generated configuration schema or a schema version bump is
 required. As a consequence, the configuration generator cannot emit the keys as
 schema entries; they are documented through the doc comment on the `Kubelet`
-field, which the generator propagates into the sample configuration file and
-the configuration reference (see Sample configuration and documentation below).
+field, which the generator propagates into the sample configuration file and the
+configuration reference (see Sample configuration and documentation below).
 
 `microshift show-config --mode effective` displays the keys under `kubelet:` as
 set by the user, since the underlying map is not modified.
@@ -241,9 +248,9 @@ N/A
 
 Add two internal, non-serialized fields to the `Config` struct in
 `pkg/config/config.go`, following the existing convention for internal fields
-(e.g. `userSettings`). The `Kubelet` field's doc comment is extended to
-describe the two keys, because the configuration generator propagates it into
-the sample configuration and reference documentation:
+(e.g. `userSettings`). The `Kubelet` field's doc comment is extended to describe
+the two keys, because the configuration generator propagates it into the sample
+configuration and reference documentation:
 
 ```go
     // Settings specified in this section are transferred as-is into the
@@ -253,9 +260,10 @@ the sample configuration and reference documentation:
     //     CredentialProviderConfig file, or a directory of such files. Enables
     //     the kubelet image credential provider.
     //   imageCredentialProviderBinDir: absolute path to the directory
-    //     containing credential provider plugin binaries. Must be owned by
-    //     root and not writable by group or others. Must be set together with
-    //     imageCredentialProviderConfigPath.
+    //     containing credential provider plugin binaries. Must be set together
+    //     with imageCredentialProviderConfigPath.
+    // Both paths, their parent directories, and the files they contain must be
+    // owned by root and not writable by group or others.
     // +kubebuilder:validation:Schemaless
     Kubelet map[string]any `json:"kubelet"`
 
@@ -265,8 +273,8 @@ the sample configuration and reference documentation:
     KubeletImageCredentialProviderBinDir     string `json:"-"`
 ```
 
-Populating internal fields from the schemaless `Kubelet` map is a new pattern
-in the MicroShift configuration code. The map has always been passed through
+Populating internal fields from the schemaless `Kubelet` map is a new pattern in
+the MicroShift configuration code. The map has always been passed through
 untouched, and this enhancement preserves that: the map is read, not modified.
 
 #### Config extraction
@@ -282,52 +290,79 @@ kubelet:
 func (c *Config) KubeletPassthrough() map[string]any
 ```
 
-`generateConfig()` in `pkg/node/kubelet.go` marshals
-`cfg.KubeletPassthrough()` instead of `cfg.Kubelet`, so the reserved keys
-never reach the `KubeletConfiguration` file. The list of reserved keys lives
-only in the `config` package.
+`generateConfig()` in `pkg/node/kubelet.go` marshals `cfg.KubeletPassthrough()`
+instead of `cfg.Kubelet`, so the reserved keys never reach the
+`KubeletConfiguration` file. The list of reserved keys lives only in the
+`config` package.
 
 #### Config validation
 
-`validate()` in `pkg/config/config.go` is extended with the following rules,
-in order:
+`validate()` in `pkg/config/config.go` is extended with the following rules, in
+order:
 
 - Neither key set: valid, feature inactive.
 - Exactly one key set: error. Kubelet requires both to activate the feature;
   failing early in MicroShift produces a clearer message than kubelet's own
   error.
-- Either path not absolute: error. A relative path would be resolved against
-  the MicroShift process working directory, which is not a stable location.
-- `imageCredentialProviderConfigPath` must exist and be a regular file or a
+- Either path not absolute: error. A relative path would be resolved against the
+  MicroShift process working directory, which is not a stable location.
+- `imageCredentialProviderConfigPath` must resolve to a regular file or a
   directory. Other file types (devices, sockets, FIFOs) are rejected. A
   directory is accepted to match upstream kubelet semantics.
-- `imageCredentialProviderBinDir` must exist and be a directory.
-- `imageCredentialProviderBinDir` must be owned by root (uid 0) and must not
-  have group or other write permission. Credential provider binaries execute
-  with kubelet's privileges, so a directory that other users can write to is a
-  local privilege escalation vector. The check is applied to the directory
-  because directory permissions govern who can add or replace binaries; kubelet
-  resolves each binary at invocation time, so per-binary checks at startup
-  would not provide durable protection.
+- `imageCredentialProviderBinDir` must resolve to a directory.
+- Both paths must satisfy the trusted-path rule below.
 
-Error messages name the field and the path, e.g.
-`error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"): must be owned by root and not writable by group or others`.
+**Trusted-path rule.** Both the configuration file and the binaries are inputs
+to a process that kubelet executes with root privileges: the bin directory
+supplies the executable, and the configuration file supplies its name,
+arguments, and environment. An unprivileged local user who can modify either can
+therefore obtain root execution during a matching image pull. MicroShift applies
+one rule to both paths, implemented once as a helper in the `config` package:
+
+1. Resolve symlinks to obtain the canonical path (`filepath.EvalSymlinks`).
+   Symlinks are not rejected, because image-based systems rely on them for
+   standard locations (for example `/usr/local` and `/home` on ostree and
+   bootc); the checks are applied to what the path actually refers to.
+2. Every component of the canonical path, from `/` down to and including the
+   final object, must be owned by root (uid 0) and must not have group or other
+   write permission. Checking ancestors prevents an unprivileged user who owns a
+   parent directory from replacing the validated file or directory after
+   startup.
+3. If the final object is a directory, every entry in it must satisfy the same
+   ownership and permission requirement, with symlinked entries checked at their
+   resolved target. For the bin directory this covers every provider binary; for
+   a configuration directory this covers every file kubelet will load.
+
+Together these checks mean an unprivileged user can neither add, replace, nor
+modify anything on either path. Only root can change the ownership or
+permissions of root-owned objects, so the properties verified at startup hold
+until a privileged actor changes them, which is outside the threat model.
+Standard layouts (`/etc/microshift/...`, `/usr/libexec/...`, and their ostree
+and bootc equivalents) satisfy the rule as installed; paths under user home
+directories or `/tmp` do not.
+
+Error messages name the field, the configured path, and the offending component,
+e.g. `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"):
+"/opt/providers/ecr-credential-provider" must be owned by root and not writable
+by group or others`.
 
 MicroShift deliberately does **not** validate the contents of the credential
-provider configuration file, nor the presence or executability of individual
-binaries. Kubelet validates the configuration file and checks that each
-configured provider binary exists (`exec.LookPath`) when it registers
-providers; failures surface as kubelet startup errors in the journal.
-Duplicating that validation would require keeping MicroShift in sync with
-upstream kubelet behavior.
+provider configuration file, nor the presence or executability of the binaries
+it names. Kubelet validates the configuration file and checks that each
+configured provider binary exists (`exec.LookPath`) when it registers providers;
+failures surface as kubelet startup errors in the journal. Duplicating that
+validation would require keeping MicroShift in sync with upstream kubelet
+behavior. Checking ownership and permissions of every entry in the bin
+directory, rather than only the configured providers, avoids parsing the
+configuration file at all.
 
 #### Kubelet flag injection
 
 `configure()` in `pkg/node/kubelet.go` sets the two fields on `KubeletFlags`.
 The `KubeletFlags` struct from the vendored
 `k8s.io/kubernetes/cmd/kubelet/app/options` package already exposes them, and
-the existing in-process startup path passes them through to
-`NewMainKubelet()`; no new plumbing is required:
+the existing in-process startup path passes them through to `NewMainKubelet()`;
+no new plumbing is required:
 
 ```go
     if cfg.KubeletImageCredentialProviderConfigPath != "" {
@@ -341,22 +376,22 @@ the existing in-process startup path passes them through to
     }
 ```
 
-The log line records that MicroShift applied the configuration to kubelet. It
-is emitted before kubelet registers providers, so it does not by itself
-indicate that the providers are usable; a missing or non-executable provider
-binary is reported by kubelet as a startup error after this line. Because
-MicroShift calls `kubelet.Run()` directly rather than through kubelet's cobra
-command, kubelet's usual `FLAG: --image-credential-provider-config=...` startup
-lines are never emitted, and kubelet's own credential provider code logs
-nothing at default verbosity on successful registration. The MicroShift log
-line is therefore the authoritative signal that the keys were applied.
+The log line records that MicroShift applied the configuration to kubelet. It is
+emitted before kubelet registers providers, so it does not by itself indicate
+that the providers are usable; a missing or non-executable provider binary is
+reported by kubelet as a startup error after this line. Because MicroShift calls
+`kubelet.Run()` directly rather than through kubelet's cobra command, kubelet's
+usual `FLAG: --image-credential-provider-config=...` startup lines are never
+emitted, and kubelet's own credential provider code logs nothing at default
+verbosity on successful registration. The MicroShift log line is therefore the
+authoritative signal that the keys were applied.
 
 #### Sample configuration and documentation
 
-`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are
-generated by `scripts/generate-config.sh` and kept in sync by
-`scripts/verify/verify-config.sh`; they must not be edited by hand. Because
-the `kubelet:` section is schemaless, the generator cannot emit the two keys as
+`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are generated
+by `scripts/generate-config.sh` and kept in sync by
+`scripts/verify/verify-config.sh`; they must not be edited by hand. Because the
+`kubelet:` section is schemaless, the generator cannot emit the two keys as
 schema entries. They are documented by extending the doc comment on the
 `Kubelet` field in `pkg/config/config.go` (shown above), which the generator
 propagates into both files. After changing the comment, run
@@ -364,27 +399,30 @@ propagates into both files. After changing the comment, run
 
 #### Image-based deployments (bootc and rpm-ostree)
 
-The feature behaves identically across RPM, rpm-ostree, and bootc
-installations; the configuration and kubelet startup code paths do not branch
-on install type. What differs is how the user-supplied files reach the device.
-On image-based systems `/usr` is read-only at runtime, so the credential
-provider binary must be included in the OS image, while `/etc` content (the
-MicroShift configuration or a `/etc/microshift/config.d/` drop-in, and the
-provider configuration file) may be included in the image or written after
-deployment.
+The feature behaves identically across RPM, rpm-ostree, and bootc installations;
+the configuration and kubelet startup code paths do not branch on install type.
+What differs is how the user-supplied files reach the device. On image-based
+systems `/usr` is read-only at runtime, so the credential provider binary must
+be included in the OS image, while `/etc` content (the MicroShift configuration
+or a `/etc/microshift/config.d/` drop-in, and the provider configuration file)
+may be included in the image or written after deployment.
 
-- On bootc, the user adds the binary in their Containerfile, e.g.
-  `COPY --chmod=755 ecr-credential-provider /usr/libexec/microshift/credential-providers/`.
-  Because `/usr` is replaced on every image update while `/etc` persists, every
-  subsequent image must also contain the binary; otherwise startup validation
-  fails on the new image and greenboot rolls the device back to the previous
-  one.
-- On rpm-ostree systems built with Image Builder (RHEL 9 only; rpm-ostree is
-  not available on RHEL 10), blueprint file customizations cannot place content
-  under `/usr` and cannot carry binary content, so the binary must be delivered
-  as an RPM added to the blueprint. Packaging the provider binary is out of
-  scope for MicroShift (see Non-Goals); users of rpm-ostree deployments must
-  build or obtain such an RPM themselves.
+- On bootc (image mode, the RHEL 10 edge deployment model, built with
+  bootc-image-builder or a Containerfile), the user adds the binary in their
+  Containerfile, e.g. `COPY --chmod=755 ecr-credential-provider
+  /usr/libexec/microshift/credential-providers/`. Because `/usr` is replaced on
+  every image update while `/etc` persists, every subsequent image must also
+  contain the binary; otherwise startup validation fails on the new image and
+  greenboot rolls the device back to the previous one.
+- On rpm-ostree (the RHEL 9 edge deployment model, built with Image Builder
+  blueprints), blueprint file customizations cannot place content under `/usr`
+  and cannot carry binary content, so the binary must be delivered as an RPM
+  added to the blueprint. Packaging the provider binary is out of scope for
+  MicroShift (see Non-Goals); users of rpm-ostree deployments must build or
+  obtain such an RPM themselves.
+
+Files placed by either method are root-owned with standard permissions and
+satisfy the trusted-path rule as installed.
 
 MicroShift component images that are embedded in an OS image are never pulled
 from a registry and do not involve the credential provider. The feature applies
@@ -397,29 +435,31 @@ The following items must be covered by the end-user documentation and are
 tracked in the documentation epic OSDOCS-20657 (MicroShift-side input in
 OCPEDGE-2976):
 
-1. The two configuration keys, their semantics (both-or-neither, absolute
-   paths, file-or-directory for the config path), and the
-   `microshift show-config` behavior.
+1. The two configuration keys, their semantics (both-or-neither, absolute paths,
+   file-or-directory for the config path), and the `microshift show-config`
+   behavior.
 2. A configuration guide for Amazon ECR: obtaining the upstream
-   `ecr-credential-provider` binary, placement, the
-   `CredentialProviderConfig` format with a `matchImages` example, the
-   device's AWS identity requirement, and verification steps. A note that the
-   same mechanism applies to GCR and ACR with their respective provider
-   binaries.
-3. The trust boundary: provider binaries run with kubelet's privileges; the bin
-   directory must be root-owned and not writable by group or others, and
-   MicroShift refuses to start otherwise.
-4. Image-based deployments: the binary must be present in every OS image
-   build; on rpm-ostree it must be delivered as an RPM; validation failures on
-   a new image cause greenboot rollback.
+   `ecr-credential-provider` binary, placement, the `CredentialProviderConfig`
+   format with a `matchImages` example, the device's AWS identity requirement,
+   and verification steps. A note that the same mechanism applies to GCR and ACR
+   with their respective provider binaries.
+3. The trust boundary: provider binaries run with kubelet's privileges and the
+   configuration file controls their arguments and environment; both paths,
+   their parent directories, and their contents must be root-owned and not
+   writable by group or others, and MicroShift refuses to start otherwise.
+   Recommended locations that satisfy this as installed.
+4. Image-based deployments: the binary must be present in every OS image build;
+   on rpm-ostree it must be delivered as an RPM; validation failures on a new
+   image cause greenboot rollback.
 5. `defaultCacheDuration` guidance: keep it comfortably shorter than the
    registry token lifetime (Amazon ECR: 12 hours).
 6. Restart requirements: changes to the two keys or to the provider
    configuration file require a MicroShift restart; replacing an existing
    provider binary takes effect on the next uncached invocation.
-7. Rollback behavior: on a deployment without this feature, the keys are
-   ignored with a kubelet warning and private registry pulls fail until the
-   previous workaround is restored or the device is upgraded again.
+7. Upgrade and rollback: add the keys after upgrading to a version with the
+   feature. On a deployment without the feature, the keys are ignored with a
+   kubelet warning and private registry pulls fail until the previous workaround
+   is restored or the device is upgraded again.
 
 ### Risks and Mitigations
 
@@ -432,27 +472,36 @@ ignores it. The feature appears enabled but is inert.
 improvement could warn on near-miss keys. This risk is not specific to this
 enhancement; it applies to any misspelled key in the passthrough.
 
-**Risk:** Kubelet's lenient decoding of unknown `KubeletConfiguration` fields
-is marked upstream as temporary, to be removed when `v1beta1` support is
-dropped. When that happens, any unknown key left in the passthrough becomes a
-hard kubelet startup failure.
+**Risk:** Kubelet's lenient decoding of unknown `KubeletConfiguration` fields is
+marked upstream as temporary, to be removed when `v1beta1` support is dropped.
+When that happens, any unknown key left in the passthrough becomes a hard
+kubelet startup failure.
 **Mitigation:** This enhancement filters its two keys out of the passthrough
 before the map is marshaled, so it never depends on lenient decoding. The
 general passthrough exposure predates this enhancement.
 
-**Risk:** Credential provider binaries execute with kubelet's (root)
-privileges. A bin directory writable by unprivileged users would allow a local
-user to replace a provider binary and gain root execution during a matching
-image pull.
-**Mitigation:** MicroShift refuses to start if the bin directory is not owned
-by root or is writable by group or others (see Config validation).
-Documentation states the trust boundary. Individual binaries are not checked
-because kubelet resolves them at invocation time; the directory check is what
-durably controls who can place binaries.
+**Risk:** Credential provider binaries execute with kubelet's (root) privileges,
+and the provider configuration file controls their name, arguments, and
+environment. An unprivileged local user who can add, replace, or modify a
+binary, modify the configuration file, or replace a parent directory of either
+path could obtain root execution during a matching image pull.
+**Mitigation:** MicroShift refuses to start unless both paths satisfy the
+trusted-path rule: after symlink resolution, every path component, the final
+object, and every contained file must be root-owned and not writable by group or
+others (see Config validation). This closes all three vectors for unprivileged
+users. Documentation states the trust boundary and recommends locations that
+satisfy it as installed.
 
-**Risk:** On image-based (ostree/bootc) systems, a validation failure at
-startup causes greenboot health checks to fail, triggering an automatic
-rollback to the previous deployment.
+**Risk:** The trusted-path checks run at startup. Ownership or permissions could
+be changed afterwards.
+**Mitigation:** Only root can change the ownership or permissions of root-owned
+objects, and root is outside the threat model (see Non-Goals). The checks
+therefore remain valid until a privileged actor changes the filesystem, and they
+run again at every restart.
+
+**Risk:** On image-based (ostree/bootc) systems, a validation failure at startup
+causes greenboot health checks to fail, triggering an automatic rollback to the
+previous deployment.
 **Mitigation:** This is the intended composition of fail-fast validation with
 greenboot: the device returns to a known-good state rather than remaining
 unhealthy. Documentation notes that the provider config file and bin directory
@@ -462,15 +511,15 @@ must exist in the image before the configuration keys are enabled.
 provider binary while the configuration keys persist in `/etc`. The new image
 fails startup validation and is rolled back by greenboot, which may not be
 immediately attributed to the missing binary.
-**Mitigation:** Documentation for image-based deployments states that the
-binary must be present in every image build. The validation error names the bin
+**Mitigation:** Documentation for image-based deployments states that the binary
+must be present in every image build. The validation error names the bin
 directory path, and the failure is visible in the journal of the failed boot.
 
 **Risk:** Users may set `defaultCacheDuration` in the provider configuration
 longer than the registry token lifetime, causing kubelet to serve expired
 credentials.
-**Mitigation:** Documentation for Amazon ECR (12-hour tokens) recommends a
-cache duration comfortably shorter than the token lifetime.
+**Mitigation:** Documentation for Amazon ECR (12-hour tokens) recommends a cache
+duration comfortably shorter than the token lifetime.
 
 ### Drawbacks
 
@@ -481,18 +530,19 @@ them. This is accepted because the OCPSTRAT acceptance criteria specify
 placement under `kubelet:`, and the alternative of a generic flag passthrough
 was explicitly ruled out of scope.
 
-Enforcing ownership and permissions on the bin directory goes beyond what
-upstream kubelet enforces. It may reject a small number of unusual but
-deliberate layouts. This is accepted because no legitimate layout for
-root-executed plugins should be writable by other users.
+The trusted-path rule goes beyond what upstream kubelet enforces and rejects
+some unusual but deliberate layouts, such as a bin directory under a non-root
+user's home directory. This is accepted because no legitimate layout for
+root-executed plugins should be modifiable by other users, and standard system
+locations pass as installed.
 
 ## Test Plan
 
 ### Unit Tests
 
 - Extraction: both keys present, both absent, only one present.
-- Extraction: non-string values rejected with an error; explicit `null`
-  treated as unset.
+- Extraction: non-string values rejected with an error; explicit `null` treated
+  as unset.
 - Extraction: `c.Kubelet` is not modified; `KubeletPassthrough()` returns the
   map without the two reserved keys and with all other keys intact.
 - Extraction: empty string values are treated as unset.
@@ -503,13 +553,27 @@ root-executed plugins should be writable by other users.
   FIFO) fails.
 - Validation: `imageCredentialProviderBinDir` missing fails; path is a file
   fails; existing directory passes.
-- Validation: `imageCredentialProviderBinDir` not owned by root fails;
-  group-writable fails; world-writable fails; root-owned `0755` passes.
+- Validation, trusted path (each case for both keys): final object not owned by
+  root fails; group-writable fails; world-writable fails; root-owned `0755`
+  directory or `0644` file passes.
+- Validation, trusted path, ancestors: a group- or world-writable ancestor
+  directory fails; a non-root-owned ancestor fails; the error names the
+  offending component.
+- Validation, trusted path, contents: a writable or non-root-owned file inside
+  the bin directory fails; a writable or non-root-owned file inside a
+  configuration directory fails; a directory whose entries all pass succeeds.
+- Validation, trusted path, symlinks: a symlink whose resolved target satisfies
+  the rule passes (ostree-style layout); a symlink to a writable or
+  non-root-owned target fails; a symlinked entry inside the bin directory is
+  checked at its target.
 - Validation: neither key set passes (backward compatibility).
 - `generateConfig()`: the two keys never appear in the generated
   `KubeletConfiguration` YAML; other user-provided keys still do.
 - `configure()`: `KubeletFlags` carries both values when set, and empty values
   when unset.
+
+Unit tests that require non-root ownership use fake ownership through an
+injected `stat` function, since tests do not run as root and cannot `chown`.
 
 ### Integration Tests (Robot Framework)
 
@@ -519,61 +583,72 @@ root-executed plugins should be writable by other users.
   drop-in, restart, verify MicroShift starts and the journal contains the
   "Kubelet image credential provider configured" log line with the configured
   paths.
-- `show-config`: verify `microshift show-config --mode effective` displays
-  both keys under `kubelet:`.
+- `show-config`: verify `microshift show-config --mode effective` displays both
+  keys under `kubelet:`.
 - Split configuration: one key in `config.yaml` and the other in a
-  `/etc/microshift/config.d/` drop-in, verify the merged configuration is
-  valid and MicroShift starts.
-- Empty strings: both keys set to `""`, verify behavior is identical to
-  omitting them.
+  `/etc/microshift/config.d/` drop-in, verify the merged configuration is valid
+  and MicroShift starts.
+- Empty strings: both keys set to `""`, verify behavior is identical to omitting
+  them.
 - Relative path: verify MicroShift fails to start with an error naming the
   field.
-- Directory config path: `imageCredentialProviderConfigPath` set to a
-  directory, verify MicroShift starts.
-- Missing config path: verify MicroShift fails to start with an error naming
-  the field and path in the journal.
+- Directory config path: `imageCredentialProviderConfigPath` set to a directory,
+  verify MicroShift starts.
+- Missing config path: verify MicroShift fails to start with an error naming the
+  field and path in the journal.
 - Missing bin directory: verify MicroShift fails to start with an error naming
   the field and path in the journal.
-- Unsafe bin directory: bin directory world-writable, verify MicroShift fails
-  to start with an error naming the field and path; restore `0755`, verify
+- Unsafe bin directory: bin directory world-writable, verify MicroShift fails to
+  start with an error naming the field and path; restore `0755`, verify
   MicroShift starts.
+- Unsafe provider binary: bin directory `0755` but a binary inside it
+  world-writable, verify MicroShift fails to start with an error naming the
+  binary; restore `0755`, verify MicroShift starts.
+- Unsafe configuration file: configuration file group-writable, verify
+  MicroShift fails to start with an error naming the file; restore `0644`,
+  verify MicroShift starts.
+- Unsafe ancestor: bin directory placed under a world-writable parent, verify
+  MicroShift fails to start with an error naming the parent.
 - Only one key set: verify MicroShift fails to start with the both-or-neither
   error.
 - Missing provider binary: valid keys, provider configuration naming a binary
-  that is not present in the bin directory, verify the "configured" log line
-  is present and kubelet reports a startup error for the missing plugin binary
-  in the journal.
+  that is not present in the bin directory, verify the "configured" log line is
+  present and kubelet reports a startup error for the missing plugin binary in
+  the journal.
 - Recovery: restore valid configuration, restart, verify MicroShift starts.
-- Rollback: on an image-based system, configuration with the new keys present
-  in `/etc`, roll back to a deployment without the feature, verify MicroShift
+- Upgrade with pre-staged keys: on the previous minor version (Y-1) with the
+  keys present in the configuration, verify MicroShift starts with a kubelet
+  lenient-decode warning; upgrade to the version with the feature, verify the
+  feature is active without further configuration changes.
+- Rollback: on an image-based system, configuration with the new keys present in
+  `/etc`, roll back to a deployment without the feature, verify MicroShift
   starts with a kubelet lenient-decode warning and the feature inert; roll
   forward, verify the feature is active.
-- End-to-end pull: deploy a mock credential provider (an executable
-  implementing the `credentialprovider.kubelet.k8s.io/v1` exec contract
-  returning static credentials) and a local password-protected registry,
-  deploy a pod referencing a private image with no CRI-O auth pre-populated,
-  verify the pod reaches Running.
+- End-to-end pull: deploy a mock credential provider (an executable implementing
+  the `credentialprovider.kubelet.k8s.io/v1` exec contract returning static
+  credentials) and a local password-protected registry, deploy a pod referencing
+  a private image with no CRI-O auth pre-populated, verify the pod reaches
+  Running.
 - End-to-end negative: mock provider returns incorrect credentials, verify the
   pod reaches ImagePullBackOff.
-- Coexistence with CRI-O auth: with the credential provider configured and
-  CRI-O auth also pre-populated for the same registry, verify the pull
-  succeeds.
+- Coexistence with CRI-O auth: with the credential provider configured and CRI-O
+  auth also pre-populated for the same registry, verify the pull succeeds.
 - Mixed registries: pods referencing an image from a credential-provider
   registry and an image from a registry using CRI-O static auth, verify both
   pulls succeed independently.
-- Caching: with a short `defaultCacheDuration`, verify a second pull within
-  the cache window does not re-invoke the provider and a pull after expiry
-  does.
-- Binary replacement without restart: replace the mock provider binary in
-  place, verify the next uncached invocation runs the new binary without
+- Caching: with a short `defaultCacheDuration`, verify a second pull within the
+  cache window does not re-invoke the provider and a pull after expiry does.
+- Binary replacement without restart: as root, replace the mock provider binary
+  in place, verify the next uncached invocation runs the new binary without
   restarting MicroShift.
 - bootc: a bootc test image layer that copies the mock provider into
-  `/usr/libexec/microshift/credential-providers/` and the configuration
-  drop-in and provider configuration into `/etc/microshift/` at image build
-  time, following the existing `test/image-blueprints-bootc` layering; boot
-  the image and run the end-to-end pull scenarios above. This exercises the
-  read-only `/usr` placement that distinguishes image-based deployments from
-  RPM installs.
+  `/usr/libexec/microshift/credential-providers/` and the configuration drop-in
+  and provider configuration into `/etc/microshift/` at image build time,
+  following the existing `test/image-blueprints-bootc` layering; boot the image
+  and run the end-to-end pull scenarios above. This exercises the read-only
+  `/usr` placement that distinguishes image-based deployments from RPM installs,
+  and verifies that image-installed files satisfy the trusted-path rule without
+  manual permission changes.
 
 A one-time manual validation against Amazon ECR with the upstream
 `ecr-credential-provider` binary is performed before release to confirm the
@@ -600,10 +675,20 @@ N/A
 ## Upgrade / Downgrade Strategy
 
 When upgrading from a version without support for these keys, the keys remain
-unset unless the user adds them, and existing behavior is preserved. If a user
-pre-stages the keys in the configuration file before upgrading, the older
-version ignores them and the newer version activates them on its first start.
-No migration is required; the feature holds no persisted state.
+unset unless the user adds them, and existing behavior is preserved. The
+documented procedure is to add the keys after upgrading to a version that
+supports them. No migration is required; the feature holds no persisted state.
+
+If a user pre-stages the keys before upgrading, the older version passes them
+through to the `KubeletConfiguration` file, where kubelet's strict decoder
+rejects them and the lenient `v1beta1` fallback logs a warning and ignores them;
+the newer version then activates the keys on its first start. This holds for
+every MicroShift version that predates this feature, because all of them vendor
+a kubelet that includes the lenient fallback and those released binaries do not
+change. The upstream plan to remove the fallback affects only future kubelet
+versions, which will only ship in MicroShift versions that also include this
+feature and never pass the keys through. The upgrade test covers the Y-1 to
+feature-version transition with pre-staged keys.
 
 MicroShift does not support downgrades. The supported scenario that boots an
 older MicroShift with a newer configuration is rollback to the previous
@@ -612,13 +697,13 @@ automatically through greenboot. Because `/etc` persists across deployments
 while `/usr` does not, the rolled-back deployment sees the configuration keys
 but not necessarily the provider binary. In that scenario the older MicroShift
 passes the keys through to the `KubeletConfiguration` file, where kubelet's
-lenient decoder logs a warning and ignores them. MicroShift starts normally
-with the credential provider feature inactive, so the rollback itself succeeds.
+lenient decoder logs a warning and ignores them. MicroShift starts normally with
+the credential provider feature inactive, so the rollback itself succeeds.
 Private registry image pulls fail on the rolled-back deployment until the
 previous workaround is restored or the device is rolled forward again. The
-configuration file on disk is not modified. This behavior relies on kubelet's
-lenient decoding of `v1beta1` `KubeletConfiguration`, which is present in the
-previous deployment that a rollback targets.
+configuration file on disk is not modified. As above, this relies on the lenient
+fallback, which is present in every pre-feature version that a rollback can
+target.
 
 ## Version Skew Strategy
 N/A
@@ -632,43 +717,44 @@ discarded when MicroShift restarts; the first matching pull after a restart
 re-invokes the provider.
 
 The provider binary must be able to authenticate to the cloud provider itself
-(for Amazon ECR: an EC2 instance role, IAM Roles Anywhere, or static
-credentials in `/root/.aws/credentials`). Failures in the provider surface as
-image pull failures (`ImagePullBackOff`) with the provider's error in the
-kubelet journal.
+(for Amazon ECR: an EC2 instance role, IAM Roles Anywhere, or static credentials
+in `/root/.aws/credentials`). Failures in the provider surface as image pull
+failures (`ImagePullBackOff`) with the provider's error in the kubelet journal.
 
 Changes to the two configuration keys or to the provider configuration file
 require a MicroShift restart: kubelet reads the provider configuration once
 during initialization. Replacing an existing provider binary in place does not
 require a restart, because kubelet resolves the binary path at each invocation;
 the replacement takes effect on the next invocation that is not served from the
-credential cache. Adding a new provider entry to the configuration file
-requires a restart.
+credential cache. Adding a new provider entry to the configuration file requires
+a restart. Only root can perform any of these changes on a correctly configured
+system.
 
 See Image-based deployments for the placement requirements on bootc and
 rpm-ostree.
 
 ## Support Procedures
 
-- Confirm the keys were applied: `journalctl -u microshift` at startup
-  contains `Kubelet image credential provider configured` with the configured
+- Confirm the keys were applied: `journalctl -u microshift` at startup contains
+  `Kubelet image credential provider configured` with the configured
   `configPath` and `binDir`. Kubelet does not log `FLAG:` lines in MicroShift
-  and logs nothing at default verbosity on successful provider registration,
-  so this MicroShift log line is the authoritative signal that the keys
-  reached kubelet. It does not confirm that the provider binaries are usable.
+  and logs nothing at default verbosity on successful provider registration, so
+  this MicroShift log line is the authoritative signal that the keys reached
+  kubelet. It does not confirm that the provider binaries are usable.
 - Confirm the providers registered: the absence of a kubelet startup error
   following the "configured" line. A missing or non-executable provider binary
   is reported by kubelet as a startup error naming the plugin binary path.
-- Confirm the effective configuration:
-  `microshift show-config --mode effective` displays both keys under
-  `kubelet:`.
-- Startup validation failures are logged with the field name and path, e.g.
+- Confirm the effective configuration: `microshift show-config --mode effective`
+  displays both keys under `kubelet:`.
+- Startup validation failures are logged with the field name, the configured
+  path, and where applicable the offending component, e.g.
   `error validating kubelet.imageCredentialProviderConfigPath ("/etc/microshift/credential-providers.yaml"): file or directory does not exist`
   or
-  `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"): must be owned by root and not writable by group or others`.
+  `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"): "/opt/providers/ecr-credential-provider" must be owned by root and not writable by group or others`.
+  Fix with `chown root:root` and `chmod go-w` on the named component.
 - Image pull failures with the feature active: inspect
-  `journalctl -u microshift` for provider execution errors, verify the
-  provider binary runs successfully when invoked manually with a
+  `journalctl -u microshift` for provider execution errors, verify the provider
+  binary runs successfully when invoked manually with a
   `CredentialProviderRequest` on stdin, and verify the device's cloud identity
   has registry pull permissions.
 - A lenient-decode warning in the kubelet logs referencing either key indicates
@@ -693,25 +779,37 @@ was rejected because it would break the existing passthrough of arbitrary
 `kubelet:` (e.g. `imageCredentialProvider:`) would avoid special-casing keys
 inside the passthrough and would be picked up by schema generation. It was
 rejected because the OCPSTRAT acceptance criteria and the originating RFE
-specify placement under `kubelet:`, where users familiar with the upstream
-flags will look for them.
+specify placement under `kubelet:`, where users familiar with the upstream flags
+will look for them.
 
 **Removing the reserved keys from the `Config.Kubelet` map.** An earlier draft
 extracted the two keys by deleting them from (a copy of) the map during
 configuration processing. This was rejected because
 `microshift show-config --mode effective` marshals the `Config` struct, so the
 keys would disappear from its output. Filtering at the point where the map is
-marshaled into `KubeletConfiguration` keeps the effective configuration
-faithful to user input.
+marshaled into `KubeletConfiguration` keeps the effective configuration faithful
+to user input.
 
-**Warning instead of failing on unsafe bin directory permissions.** An earlier
+**Warning instead of failing on unsafe ownership or permissions.** An earlier
 draft only warned. A warning does not prevent a local user from replacing a
 provider binary that kubelet executes as root, so the check is a startup
 failure.
 
+**Checking only the final directory.** An earlier draft checked ownership and
+permissions of the bin directory only. This was rejected because it does not
+prevent in-place modification of an existing writable binary, replacement of the
+directory through a writable ancestor, or modification of the configuration
+file, which controls the provider's arguments and environment. The trusted-path
+rule covers all three.
+
+**Rejecting symlinks outright.** Refusing any symlink in either path would be
+simpler than resolving and checking targets, but standard image-based layouts
+depend on symlinks for locations such as `/usr/local` and `/home`. Resolving
+symlinks and checking every component of the canonical path provides the same
+protection without rejecting those layouts.
+
 **Packaging credential provider binaries.** Shipping `ecr-credential-provider`
-or equivalents as MicroShift RPMs was rejected. The binaries are
-cloud-specific, upstream-maintained, and have their own release and CVE
-cadence; there is one per registry type, so shipping any subset would favor
-particular clouds. Bundling them would make their lifecycle a MicroShift
-concern.
+or equivalents as MicroShift RPMs was rejected. The binaries are cloud-specific,
+upstream-maintained, and have their own release and CVE cadence; there is one
+per registry type, so shipping any subset would favor particular clouds.
+Bundling them would make their lifecycle a MicroShift concern.

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -209,8 +209,9 @@ The `kubelet:` section is annotated `+kubebuilder:validation:Schemaless`, so no
 change to the generated configuration schema or a schema version bump is
 required. As a consequence, the configuration generator cannot emit the keys as
 schema entries; they are documented through the doc comment on the `Kubelet`
-field, which the generator propagates into the sample configuration file and the
-configuration reference (see Sample configuration and documentation below).
+field, which the generator propagates into the sample configuration file
+(`packaging/microshift/config.yaml`) and the OpenAPI description (see Sample
+configuration and documentation below).
 
 `microshift show-config --mode effective` displays the keys under `kubelet:` as
 set by the user, since the underlying map is not modified. Kubelet receives the
@@ -253,7 +254,7 @@ Add two internal, non-serialized fields to the `Config` struct in
 `pkg/config/config.go`, following the existing convention for internal fields
 (e.g. `userSettings`). The `Kubelet` field's doc comment is extended to describe
 the two keys, because the configuration generator propagates it into the sample
-configuration and reference documentation:
+configuration file and the OpenAPI description:
 
 ```go
     // Settings specified in this section are transferred as-is into the
@@ -389,9 +390,9 @@ no new plumbing is required:
 ```
 
 The typed fields hold the canonical paths produced by validation, so kubelet
-receives symlink-resolved paths. When a configured path differs from its
-canonical form, the log line additionally records the configured value. The log
-line records that MicroShift applied the configuration to kubelet. It is emitted
+receives symlink-resolved paths; the log line records those canonical paths. The
+values the user configured remain available from `microshift show-config`. The
+log line records that MicroShift applied the configuration to kubelet. It is emitted
 before kubelet registers providers, so it does not by itself indicate that the
 providers are usable; a missing or non-executable provider binary is reported by
 kubelet as a startup error after this line. Because MicroShift calls
@@ -403,13 +404,17 @@ authoritative signal that the keys were applied.
 
 #### Sample configuration and documentation
 
-`packaging/microshift/config.yaml` and `docs/user/howto_config.md` are generated
+`packaging/microshift/config.yaml`, `docs/user/howto_config.md`, and the OpenAPI
+description in `cmd/generate-config/config/config-openapi-spec.json` are generated
 by `scripts/generate-config.sh` and kept in sync by
 `scripts/verify/verify-config.sh`; they must not be edited by hand. Because the
 `kubelet:` section is schemaless, the generator cannot emit the two keys as
 schema entries. They are documented by extending the doc comment on the
-`Kubelet` field in `pkg/config/config.go` (shown above), which the generator
-propagates into both files. After changing the comment, run
+`Kubelet` field in `pkg/config/config.go` (shown above). That comment is rendered
+into the sample configuration file (`config.yaml`) and the OpenAPI description;
+`howto_config.md` renders the sample configuration without comments, so the keys
+are not separately described there. End-user documentation is tracked in OSDOCS
+(see Documentation requirements). After changing the comment, run
 `make generate-config` and commit the regenerated files.
 
 #### Image-based deployments (bootc and rpm-ostree)
@@ -464,7 +469,14 @@ OSDOCS-20657 (MicroShift-side input in OCPEDGE-2976):
 3. Image-based deployments: the credential provider binary must be present in
    every OS image build (on rpm-ostree, delivered as the user's own RPM);
    a missing binary on a new image fails validation and triggers greenboot
-   rollback — check the failed boot's journal.
+   rollback — check the failed boot's journal. The bin directory must sit at a
+   location that carries the `bin_t` SELinux label (`/usr/libexec` or
+   `/usr/local/bin`); the confined kubelet (`kubelet_t`) may only execute
+   `bin_t` files. A bin directory under `/etc/microshift` (`kubernetes_file_t`)
+   or `/opt` (`usr_t`) passes MicroShift's path validation but is denied
+   execution under SELinux enforcing — the provider never runs and the only
+   trace is an AVC denial (`ausearch -m AVC -ts recent`). MicroShift does not
+   validate SELinux labels, so RPM packaging must place the binary accordingly.
 4. `defaultCacheDuration`: keep it comfortably shorter than the registry
    token lifetime (Amazon ECR: 12 hours).
 
@@ -753,8 +765,8 @@ rpm-ostree.
 ## Support Procedures
 
 - Confirm the keys were applied: `journalctl -u microshift` at startup contains
-  `Kubelet image credential provider configured` with the configured
-  `configPath` and `binDir`. Kubelet does not log `FLAG:` lines in MicroShift
+  `Kubelet image credential provider configured` with the canonical
+  (symlink-resolved) `configPath` and `binDir`. Kubelet does not log `FLAG:` lines in MicroShift
   and logs nothing at default verbosity on successful provider registration, so
   this MicroShift log line is the authoritative signal that the keys reached
   kubelet. It does not confirm that the provider binaries are usable.
@@ -773,6 +785,14 @@ rpm-ostree.
   microshift` for provider execution errors, verify the provider binary runs
   successfully when invoked manually with a `CredentialProviderRequest` on
   stdin, and verify the device's cloud identity has registry pull permissions.
+- Image pull failures with no provider execution error in the journal: check for
+  an SELinux denial with `ausearch -m AVC -ts recent`. MicroShift runs confined
+  as `kubelet_t` and may only execute files labeled `bin_t`. A bin directory
+  under `/etc/microshift` (`kubernetes_file_t`) or `/opt` (`usr_t`) passes
+  MicroShift's path validation but is denied execution under SELinux enforcing;
+  the provider never runs and the only trace is the AVC. Move the bin directory
+  under `/usr/libexec` or `/usr/local/bin`, or restore the label with
+  `restorecon -Rv`, so the binaries carry `bin_t`.
 - A lenient-decode warning in the kubelet logs referencing either key indicates
   a MicroShift version that does not support the feature, or a misspelled key.
 - On bootc or rpm-ostree systems, a greenboot rollback after an image update

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -387,7 +387,11 @@ and before storing the canonical paths:
 
 - If `imageCredentialProviderConfigPath` is a directory, it contains at least
   one file with a `.json`, `.yaml`, or `.yml` extension (kubelet requires this
-  and merges them in lexicographical order).
+  and merges them in lexicographical order). A dangling symlink or non-regular
+  file with a matching extension is an error, as kubelet would fail on it:
+  kubelet does not resolve symlinks and reads every matching entry with
+  `os.ReadFile`, so a broken link errors at registration and a FIFO blocks
+  startup forever.
 - Each configuration file decodes as a `CredentialProviderConfig` using the same
   strict decoder kubelet uses, built from the same vendored kubelet packages
   (`k8s.io/kubernetes/pkg/kubelet/apis/config` and its `v1`, `v1beta1`, and
@@ -675,8 +679,9 @@ locations pass as installed.
   wrong apiVersion, malformed YAML) fails naming the file; a file declaring no
   providers fails; a provider whose name has no executable in the bin directory
   fails naming the provider and the joined path; a non-executable file of that
-  name fails; a valid file and a valid directory pass; structural checks run
-  after the trusted-path rule.
+  name fails; a dangling `.yaml` symlink alongside a valid file fails naming the
+  link; a FIFO named `x.yaml` fails as "not a regular file"; a valid file and a
+  valid directory pass; structural checks run after the trusted-path rule.
 - `generateConfig()`: the two keys never appear in the generated
   `KubeletConfiguration` YAML; other user-provided keys still do.
 - `configure()`: `KubeletFlags` carries both canonical values when set, and

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -391,8 +391,7 @@ no new plumbing is required:
 
 The typed fields hold the canonical paths produced by validation, so kubelet
 receives symlink-resolved paths; the log line records those canonical paths. The
-values the user configured remain available from `microshift show-config`. The
-log line records that MicroShift applied the configuration to kubelet. It is emitted
+values the user configured remain available from `microshift show-config`. It is emitted
 before kubelet registers providers, so it does not by itself indicate that the
 providers are usable; a missing or non-executable provider binary is reported by
 kubelet as a startup error after this line. Because MicroShift calls

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -340,13 +340,12 @@ one rule to both paths, implemented once as a helper in the `config` package:
    final object, must be owned by root (uid 0) and must not have group or other
    write permission. Checking ancestors prevents an unprivileged user who owns a
    parent directory from replacing the validated file or directory after
-   startup. No component may carry an extended POSIX ACL
-   (`system.posix_acl_access`): an ACL can grant write access that the mode bits
-   do not show (`setfacl -m u:x:rwx dir` leaves the mode at `0755`). Root-owned
-   system directories do not carry extended ACLs, so this does not affect
-   standard layouts.
+   startup. POSIX ACLs cannot grant write access that this check misses: when an
+   extended ACL is present, Linux reports the ACL mask in the group permission
+   bits, so any ACL entry with effective write access makes the group write bit
+   visible and the object is rejected. No separate ACL check is needed.
 3. If the final object is a directory, every entry in it must satisfy the same
-   ownership, permission, and no-ACL requirement. A symlinked entry is resolved
+   ownership and permission requirement. A symlinked entry is resolved
    and the full rule, including ancestors, is applied to its target, so an entry
    cannot point into a location an unprivileged user controls.
 4. The canonical path, not the configured path, is what MicroShift passes to
@@ -397,9 +396,7 @@ and before storing the canonical paths:
   (`k8s.io/kubernetes/pkg/kubelet/apis/config` and its `v1`, `v1beta1`, and
   `v1alpha1` sub-packages). Unknown fields are rejected and all three API
   versions kubelet accepts are accepted, so the check cannot diverge from the
-  kubelet in the same build. An unreadable file (`EACCES`, typical of
-  `show-config` run as non-root against a `0600` file) is reported as needing
-  root, not as invalid.
+  kubelet in the same build.
 - Every `providers[].name` resolves to an executable in the bin directory using
   `exec.LookPath(filepath.Join(binDir, name))`, the same call kubelet makes at
   registration.
@@ -535,15 +532,11 @@ OSDOCS-20657 (MicroShift-side input in OCPEDGE-2976):
    `NO_PROXY` for the provider through the `env` list in its entry in the
    `CredentialProviderConfig`, and include the cloud metadata service
    (`169.254.169.254`, the IMDS endpoint) in `NO_PROXY` so identity lookups are
-   not routed through the proxy. When a provider must read static cloud
-   credentials from a file (for example AWS shared credentials), do not place
-   the file under `/root/.aws`: that path carries the `admin_home_t` SELinux
-   label, which the confined kubelet (`kubelet_t`) cannot read, so the provider
-   sees no credentials and the only trace is an AVC denial. Place the file under
-   `/etc/microshift/` instead and point the provider at it with an explicit
-   `env` entry (for AWS, `AWS_SHARED_CREDENTIALS_FILE`). Verify by confirming a
-   successful pull in `journalctl -u microshift` and the absence of denials in
-   `ausearch -m AVC -ts recent`.
+   not routed through the proxy. Static AWS credentials in
+   `/root/.aws/credentials` are readable by the confined kubelet on RHEL 9
+   (verified); an instance role or IAM Roles Anywhere is still preferred because
+   no long-lived secret is stored on the device. If pulls fail with no provider
+   error in the journal, check `ausearch -m AVC -ts recent`.
 
 ### Risks and Mitigations
 
@@ -669,10 +662,6 @@ locations pass as installed.
   path; a symlink to a writable or non-root-owned target fails; a symlinked
   entry inside the bin directory is checked at its target including the target's
   ancestors.
-- Validation, trusted path, extended ACL: an extended ACL on the final object,
-  an ancestor, or a directory entry fails naming the component; a chain with no
-  extended ACL passes. The ACL probe is exercised through an overridable hook so
-  the suite runs without `setfacl` or root.
 - Validation: neither key set passes (backward compatibility).
 - Validation, structural: configuration directory with no `.json/.yaml/.yml`
   fails; a file that does not decode as `CredentialProviderConfig` (wrong kind,
@@ -883,12 +872,8 @@ rpm-ostree.
   start-rate limit (`Start request repeated too quickly`).
 - Confirm the effective configuration: `microshift show-config --mode effective`
   displays both keys under `kubelet:`.
-- `microshift show-config` runs the same validation, including the structural
-  provider-config decode. Run as a non-root user against a provider config file
-  that is not world-readable (for example `0600`), it reports
-  `error validating kubelet.imageCredentialProviderConfigPath (...): cannot read "..." : permission denied (run as root)`.
-  This does not mean the configuration is invalid; it means the reader lacks
-  permission. Re-run `microshift show-config` as root (or with `sudo`).
+- `microshift show-config` requires root; it runs the same validation as
+  startup, including the provider configuration decode.
 - Startup validation failures are logged with the field name, the configured
   path, and where applicable the offending component, e.g.
   `error validating kubelet.imageCredentialProviderConfigPath ("/etc/microshift/credential-providers.yaml"): file or directory does not exist`
@@ -913,7 +898,7 @@ rpm-ostree.
   with a validation error naming `imageCredentialProviderBinDir` indicates the
   new image was built without the provider binary. greenboot loads the same
   MicroShift configuration and therefore runs the same validation, so any of the
-  validation errors above (missing path, trusted-path violation, extended ACL,
+  validation errors above (missing path, trusted-path violation,
   undecodable provider config, unresolvable provider name) will fail the health
   check and trigger the normal rollback; the rollback outcome is unchanged, and
   the specific error is in `journalctl -u microshift -b` for the failed boot.

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -16,7 +16,7 @@ approvers:
 api-approvers:
   - None
 creation-date: 2026-09-02
-last-updated: 2026-09-03
+last-updated: 2026-09-08
 tracking-link:
   - https://redhat.atlassian.net/browse/OCPSTRAT-3456
 see-also:
@@ -102,11 +102,12 @@ devices.
    `ecr-credential-provider`). These are standalone upstream binaries that users
    install separately, and which binary is needed depends on the registry in
    use.
-3. Validating the contents of the credential provider configuration file, or the
-   presence and executability of the binaries it names. Kubelet validates the
-   configuration file and the presence of each configured binary when it
-   registers providers. MicroShift validates ownership and permissions of both
-   paths and their contents, but not their semantics.
+3. Semantic validation of the credential provider configuration (for example
+   `matchImages` patterns or cache durations). Kubelet validates these when it
+   registers providers. MicroShift validates only the structural conditions that
+   would otherwise terminate the process (see *Provider configuration structural
+   checks* under Config validation), plus ownership and permissions of both paths
+   and their contents.
 4. Runtime reconfiguration of the two keys without restarting MicroShift.
 5. Protection against a user who already holds root privileges. The validation
    described here defends against unprivileged local users only.
@@ -156,8 +157,12 @@ to `KubeletConfiguration` unchanged.
    resolves to a directory, and that both paths satisfy the trusted-path rule
    described under Config validation: after resolving symlinks, every path
    component, the final object, and every file inside a directory must be owned
-   by root and not writable by group or others. The canonical (symlink-resolved)
-   paths are stored in the typed fields.
+   by root and not writable by group or others. MicroShift then performs the
+   structural checks on the provider configuration: a configuration directory
+   contains at least one configuration file, each file decodes as a
+   `CredentialProviderConfig`, and every named provider resolves to an executable
+   in the bin directory. The canonical (symlink-resolved) paths are stored in the
+   typed fields.
 4. If validation fails, MicroShift exits with a descriptive error message naming
    the field and the path.
 5. If validation succeeds, the kubelet component sets
@@ -167,9 +172,13 @@ to `KubeletConfiguration` unchanged.
    both the configured and the canonical values.
 6. The keys in the `kubelet:` section other than the two reserved keys are
    marshaled into the `KubeletConfiguration` file as today.
-7. Kubelet reads the provider configuration file and verifies that each
-   configured provider binary exists in the bin directory. Failures here are
-   kubelet startup errors, reported in the MicroShift journal.
+7. Kubelet reads the provider configuration file and performs its own full
+   validation when it registers providers. Because MicroShift already verified
+   the structural conditions, the only failures that can remain are semantic ones
+   (for example an invalid `matchImages` pattern). On such a failure upstream
+   kubelet logs `Failed to register CRI auth plugins` and calls `os.Exit(1)`; in
+   MicroShift this terminates the whole process after the other components have
+   started (see Risks and Mitigations).
 8. At image pull time, kubelet consults the credential provider configuration;
    for images matching a configured provider, kubelet executes the provider
    binary, caches the returned credentials in memory for the returned or default
@@ -359,15 +368,43 @@ e.g. `error validating kubelet.imageCredentialProviderBinDir ("/opt/providers"):
 "/opt/providers/ecr-credential-provider" must be owned by root and not writable
 by group or others`.
 
-MicroShift deliberately does **not** validate the contents of the credential
-provider configuration file, nor the presence or executability of the binaries
-it names. Kubelet validates the configuration file and checks that each
-configured provider binary exists (`exec.LookPath`) when it registers providers;
-failures surface as kubelet startup errors in the journal. Duplicating that
-validation would require keeping MicroShift in sync with upstream kubelet
-behavior. Checking ownership and permissions of every entry in the bin
-directory, rather than only the configured providers, avoids parsing the
-configuration file at all.
+#### Provider configuration structural checks
+
+Upstream kubelet handles a failure to register credential providers by logging
+`Failed to register CRI auth plugins` and calling `os.Exit(1)`
+(`pkg/kubelet/kuberuntime/kuberuntime_manager.go`). In a standalone kubelet that
+ends one process; in MicroShift, where kubelet is a goroutine, it terminates the
+entire MicroShift process after etcd, the API server, and the other components
+have already started, and systemd restarts it into the same failure. The
+upstream error for a missing binary also does not name the binary (`plugin binary
+executable  did not exist`, with an empty path). To turn these into ordinary
+fail-fast configuration errors, MicroShift verifies, after the trusted-path rule
+and before storing the canonical paths:
+
+- If `imageCredentialProviderConfigPath` is a directory, it contains at least
+  one file with a `.json`, `.yaml`, or `.yml` extension (kubelet requires this
+  and merges them in lexicographical order).
+- Each configuration file decodes as a `CredentialProviderConfig` using the
+  vendored `k8s.io/kubelet/config/v1` types, with `apiVersion` and `kind`
+  checked. Decoding with the vendored types means the check cannot drift from
+  the kubelet in the same build.
+- Every `providers[].name` resolves to an executable in the bin directory using
+  `exec.LookPath(filepath.Join(binDir, name))`, the same call kubelet makes at
+  registration.
+
+Error messages name the field, the file, and the provider, e.g. `error
+validating kubelet.imageCredentialProviderConfigPath
+("/etc/microshift/credential-providers.yaml"): provider "ecr-credential-provider"
+has no executable at
+"/usr/libexec/microshift/credential-providers/ecr-credential-provider"`.
+
+MicroShift does **not** replicate kubelet's semantic validation of the
+configuration (`validateCredentialProviderConfig` is unexported; it covers
+`matchImages` syntax, cache durations, and similar). Those failures still reach
+the upstream `os.Exit` path and are documented as such. Checking ownership and
+permissions of every entry in the bin directory, rather than only the configured
+providers, remains the rule for the trusted-path check; it is stricter and
+independent of the configuration contents.
 
 #### Kubelet flag injection
 
@@ -520,6 +557,17 @@ objects, and root is outside the threat model (see Non-Goals). Kubelet receives
 the canonical path, so re-pointing a symlink in the configured path after
 startup has no effect. The checks run again at every restart.
 
+**Risk:** Upstream kubelet terminates the process with `os.Exit(1)` when
+credential provider registration fails. In MicroShift this kills the whole
+process after other components are running, and systemd restarts it into the
+same failure until the start-rate limit is reached. The upstream message for a
+missing binary carries an empty path.
+**Mitigation:** MicroShift pre-validates the structural conditions that cause
+registration to fail (empty configuration directory, undecodable configuration,
+unresolvable provider name) with clear messages, so they fail at configuration
+load. Semantic failures kubelet detects itself still exit the process; the
+`Failed to register CRI auth plugins` line in the journal identifies them.
+
 **Risk:** On image-based (ostree/bootc) systems, a validation failure at startup
 causes greenboot health checks to fail, triggering an automatic rollback to the
 previous deployment.
@@ -552,6 +600,11 @@ treated differently from all others, and the generated schema cannot express
 them. This is accepted because the OCPSTRAT acceptance criteria specify
 placement under `kubelet:`, and the alternative of a generic flag passthrough
 was explicitly ruled out of scope.
+
+Decoding the provider configuration in MicroShift duplicates a small part of
+what kubelet does at registration. This is accepted because the alternative is a
+process exit with an unhelpful message; using the vendored API types keeps the
+duplication to structure only, with no independent schema.
 
 The trusted-path rule goes beyond what upstream kubelet enforces and rejects
 some unusual but deliberate layouts, such as a bin directory under a non-root
@@ -591,6 +644,13 @@ locations pass as installed.
   entry inside the bin directory is checked at its target including the target's
   ancestors.
 - Validation: neither key set passes (backward compatibility).
+- Validation, structural: configuration directory with no `.json/.yaml/.yml`
+  fails; a file that does not decode as `CredentialProviderConfig` (wrong kind,
+  wrong apiVersion, malformed YAML) fails naming the file; a file declaring no
+  providers fails; a provider whose name has no executable in the bin directory
+  fails naming the provider and the joined path; a non-executable file of that
+  name fails; a valid file and a valid directory pass; structural checks run
+  after the trusted-path rule.
 - `generateConfig()`: the two keys never appear in the generated
   `KubeletConfiguration` YAML; other user-provided keys still do.
 - `configure()`: `KubeletFlags` carries both canonical values when set, and
@@ -642,9 +702,15 @@ injected `stat` function, since tests do not run as root and cannot `chown`.
 - Only one key set: verify MicroShift fails to start with the both-or-neither
   error.
 - Missing provider binary: valid keys, provider configuration naming a binary
-  that is not present in the bin directory, verify the "configured" log line is
-  present and kubelet reports a startup error for the missing plugin binary in
-  the journal.
+  that is not present in the bin directory, verify MicroShift fails to start
+  with an error naming the provider and the resolved path, and that the
+  "configured" log line is absent (validation fails before kubelet is
+  configured). Restore, verify recovery.
+- Empty configuration directory: `imageCredentialProviderConfigPath` set to a
+  directory with no configuration files, verify MicroShift fails to start with
+  an error naming the directory.
+- Malformed configuration file: verify MicroShift fails to start with an error
+  naming the file.
 - Recovery: restore valid configuration, restart, verify MicroShift starts.
 - Upgrade with pre-staged keys: on the previous minor version (Y-1) with the
   keys present in the configuration, verify MicroShift starts with a kubelet
@@ -774,9 +840,16 @@ rpm-ostree.
   and logs nothing at default verbosity on successful provider registration, so
   this MicroShift log line is the authoritative signal that the keys reached
   kubelet. It does not confirm that the provider binaries are usable.
-- Confirm the providers registered: the absence of a kubelet startup error
-  following the "configured" line. A missing or non-executable provider binary
-  is reported by kubelet as a startup error naming the plugin binary path.
+- Confirm the providers registered: the absence of `Failed to register CRI auth
+  plugins` following the "configured" line. Structural problems (missing binary,
+  undecodable file, empty directory) are caught earlier by MicroShift validation
+  and never reach kubelet. If the line does appear, the configuration is
+  structurally valid but semantically rejected by kubelet (for example an invalid
+  `matchImages` pattern); the process exits and systemd restarts it, so check
+  `journalctl -u microshift -b` for the line and fix the configuration. After
+  fixing any startup failure, run `systemctl reset-failed microshift` before
+  `systemctl start microshift`; repeated fast failures trip systemd's
+  start-rate limit (`Start request repeated too quickly`).
 - Confirm the effective configuration: `microshift show-config --mode effective`
   displays both keys under `kubelet:`.
 - Startup validation failures are logged with the field name, the configured

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -476,8 +476,11 @@ OSDOCS-20657 (MicroShift-side input in OCPEDGE-2976):
    execution under SELinux enforcing — the provider never runs and the only
    trace is an AVC denial (`ausearch -m AVC -ts recent`). MicroShift does not
    validate SELinux labels, so RPM packaging must place the binary accordingly.
-4. `defaultCacheDuration`: keep it comfortably shorter than the registry
-   token lifetime (Amazon ECR: 12 hours).
+4. `defaultCacheDuration` guidance for providers that do not return their own
+   cache duration: keep it comfortably shorter than the registry token lifetime.
+   The ECR provider returns its own `cacheDuration` (6 hours) and kubelet honors
+   it over `defaultCacheDuration`, so for ECR the field has no effect (6-hour
+   cache against a 12-hour token).
 
 ### Risks and Mitigations
 
@@ -533,11 +536,13 @@ immediately attributed to the missing binary.
 must be present in every image build. The validation error names the bin
 directory path, and the failure is visible in the journal of the failed boot.
 
-**Risk:** Users may set `defaultCacheDuration` in the provider configuration
-longer than the registry token lifetime, causing kubelet to serve expired
-credentials.
-**Mitigation:** Documentation for Amazon ECR (12-hour tokens) recommends a cache
-duration comfortably shorter than the token lifetime.
+**Risk:** For providers that do not return their own cache duration, users may
+set `defaultCacheDuration` in the provider configuration longer than the registry
+token lifetime, causing kubelet to serve expired credentials.
+**Mitigation:** Documentation recommends a cache duration comfortably shorter than
+the token lifetime. Note that the ECR provider returns its own `cacheDuration`
+(6 hours), which kubelet honors over `defaultCacheDuration`, so for ECR the field
+has no effect (6-hour cache against a 12-hour token).
 
 ### Drawbacks
 

--- a/enhancements/microshift/microshift-kubelet-image-credential-provider.md
+++ b/enhancements/microshift/microshift-kubelet-image-credential-provider.md
@@ -340,11 +340,15 @@ one rule to both paths, implemented once as a helper in the `config` package:
    final object, must be owned by root (uid 0) and must not have group or other
    write permission. Checking ancestors prevents an unprivileged user who owns a
    parent directory from replacing the validated file or directory after
-   startup.
+   startup. No component may carry an extended POSIX ACL
+   (`system.posix_acl_access`): an ACL can grant write access that the mode bits
+   do not show (`setfacl -m u:x:rwx dir` leaves the mode at `0755`). Root-owned
+   system directories do not carry extended ACLs, so this does not affect
+   standard layouts.
 3. If the final object is a directory, every entry in it must satisfy the same
-   ownership and permission requirement. A symlinked entry is resolved and the
-   full rule, including ancestors, is applied to its target, so an entry cannot
-   point into a location an unprivileged user controls.
+   ownership, permission, and no-ACL requirement. A symlinked entry is resolved
+   and the full rule, including ancestors, is applied to its target, so an entry
+   cannot point into a location an unprivileged user controls.
 4. The canonical path, not the configured path, is what MicroShift passes to
    kubelet. Validating the canonical path while handing kubelet the configured
    path would leave a gap: a symlink under a user-writable directory could be
@@ -384,10 +388,14 @@ and before storing the canonical paths:
 - If `imageCredentialProviderConfigPath` is a directory, it contains at least
   one file with a `.json`, `.yaml`, or `.yml` extension (kubelet requires this
   and merges them in lexicographical order).
-- Each configuration file decodes as a `CredentialProviderConfig` using the
-  vendored `k8s.io/kubelet/config/v1` types, with `apiVersion` and `kind`
-  checked. Decoding with the vendored types means the check cannot drift from
-  the kubelet in the same build.
+- Each configuration file decodes as a `CredentialProviderConfig` using the same
+  strict decoder kubelet uses, built from the same vendored kubelet packages
+  (`k8s.io/kubernetes/pkg/kubelet/apis/config` and its `v1`, `v1beta1`, and
+  `v1alpha1` sub-packages). Unknown fields are rejected and all three API
+  versions kubelet accepts are accepted, so the check cannot diverge from the
+  kubelet in the same build. An unreadable file (`EACCES`, typical of
+  `show-config` run as non-root against a `0600` file) is reported as needing
+  root, not as invalid.
 - Every `providers[].name` resolves to an executable in the bin directory using
   `exec.LookPath(filepath.Join(binDir, name))`, the same call kubelet makes at
   registration.
@@ -518,6 +526,20 @@ OSDOCS-20657 (MicroShift-side input in OCPEDGE-2976):
    The ECR provider returns its own `cacheDuration` (6 hours) and kubelet honors
    it over `defaultCacheDuration`, so for ECR the field has no effect (6-hour
    cache against a 12-hour token).
+5. Provider environment and static credentials: the provider binary inherits
+   MicroShift's process environment. Behind a proxy, set `HTTPS_PROXY` and
+   `NO_PROXY` for the provider through the `env` list in its entry in the
+   `CredentialProviderConfig`, and include the cloud metadata service
+   (`169.254.169.254`, the IMDS endpoint) in `NO_PROXY` so identity lookups are
+   not routed through the proxy. When a provider must read static cloud
+   credentials from a file (for example AWS shared credentials), do not place
+   the file under `/root/.aws`: that path carries the `admin_home_t` SELinux
+   label, which the confined kubelet (`kubelet_t`) cannot read, so the provider
+   sees no credentials and the only trace is an AVC denial. Place the file under
+   `/etc/microshift/` instead and point the provider at it with an explicit
+   `env` entry (for AWS, `AWS_SHARED_CREDENTIALS_FILE`). Verify by confirming a
+   successful pull in `journalctl -u microshift` and the absence of denials in
+   `ausearch -m AVC -ts recent`.
 
 ### Risks and Mitigations
 
@@ -643,6 +665,10 @@ locations pass as installed.
   path; a symlink to a writable or non-root-owned target fails; a symlinked
   entry inside the bin directory is checked at its target including the target's
   ancestors.
+- Validation, trusted path, extended ACL: an extended ACL on the final object,
+  an ancestor, or a directory entry fails naming the component; a chain with no
+  extended ACL passes. The ACL probe is exercised through an overridable hook so
+  the suite runs without `setfacl` or root.
 - Validation: neither key set passes (backward compatibility).
 - Validation, structural: configuration directory with no `.json/.yaml/.yml`
   fails; a file that does not decode as `CredentialProviderConfig` (wrong kind,
@@ -852,6 +878,12 @@ rpm-ostree.
   start-rate limit (`Start request repeated too quickly`).
 - Confirm the effective configuration: `microshift show-config --mode effective`
   displays both keys under `kubelet:`.
+- `microshift show-config` runs the same validation, including the structural
+  provider-config decode. Run as a non-root user against a provider config file
+  that is not world-readable (for example `0600`), it reports
+  `error validating kubelet.imageCredentialProviderConfigPath (...): cannot read "..." : permission denied (run as root)`.
+  This does not mean the configuration is invalid; it means the reader lacks
+  permission. Re-run `microshift show-config` as root (or with `sudo`).
 - Startup validation failures are logged with the field name, the configured
   path, and where applicable the offending component, e.g.
   `error validating kubelet.imageCredentialProviderConfigPath ("/etc/microshift/credential-providers.yaml"): file or directory does not exist`
@@ -874,7 +906,12 @@ rpm-ostree.
   a MicroShift version that does not support the feature, or a misspelled key.
 - On bootc or rpm-ostree systems, a greenboot rollback after an image update
   with a validation error naming `imageCredentialProviderBinDir` indicates the
-  new image was built without the provider binary.
+  new image was built without the provider binary. greenboot loads the same
+  MicroShift configuration and therefore runs the same validation, so any of the
+  validation errors above (missing path, trusted-path violation, extended ACL,
+  undecodable provider config, unresolvable provider name) will fail the health
+  check and trigger the normal rollback; the rollback outcome is unchanged, and
+  the specific error is in `journalctl -u microshift -b` for the failed boot.
 
 ## Alternatives (Not Implemented)
 


### PR DESCRIPTION
## Summary

Enhancement proposal for [OCPSTRAT-3456](https://redhat.atlassian.net/browse/OCPSTRAT-3456): allow MicroShift users to configure the kubelet image credential provider via `config.yaml`.

- Two new optional keys under `kubelet:`: `imageCredentialProviderConfigPath` and `imageCredentialProviderBinDir`
- MicroShift extracts, validates, and injects them as `KubeletFlags` on the embedded kubelet
- Enables edge devices to pull from token-based registries (ECR/GCR/ACR) without CRI-O auth pre-population
- Epic: [OCPEDGE-2972](https://redhat.atlassian.net/browse/OCPEDGE-2972)

/cc @pacevedom @eslutsky @copejon @ggiguash @pmtk @kasturinarra @qJkee @dfroehli @jerpeter1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that trusted-path validation resolves symlinks before paths are passed to kubelet, preventing post-startup symlink replacement from redirecting provider execution.
  - Documented that user-configured paths remain visible in `show-config`.
  - Expanded symlink validation tests and guidance.
  - Narrowed compatibility claims for pre-staged credentials to verified Kubernetes branches and tested upgrade/rollback transitions.
  - Added guidance to create credentials after upgrading when the source version is unverified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->